### PR TITLE
Feat/ranking and tier system

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,30 +1,63 @@
 # BestDuo_BE
 
-## Daily Session Performance Checklist
+## Overview (English)
+BestDuo_BE is the backend that powers **bestduo**, a League of Legends analytics tool that focuses on bottom-lane duo synergy. The service collects Emerald+ solo-queue summoners, keeps their match history up to date, and aggregates win rate, pick rate, ranking, and counter data for every ADC/support pairing per patch. All data is sourced directly from Riot's league-v4 and match-v5 APIs and is used strictly for educational statistics—there are no automation hooks or gameplay advantages.
 
-Follow this playbook when `RunDailySession` behaves differently between the local DB and the Railway DB.
+### Key Capabilities
+- **Seed → Refresh → Consume pipeline** guarded by Riot request budgets to continuously bring fresh solo-queue data.
+- **Match payload storage** so the raw Riot match-v5 JSON is saved before domain-specific parsing.
+- **Bottom duo extraction & aggregation** to compute synergy scores, tier-based rankings, and matchup counters from historical matches.
+- **Public REST APIs** such as `/bottom-duo/stats`, `/bottom-duo/detail`, and `/bottom-duo/counters` that the frontend consumes.
+- **Admin tooling** (`/admin/session`, `/collect`, etc.) to manually trigger sessions, enqueue matches, or inspect the collection queue.
 
-1. **함수별 시간 비교**
-   - Run the session (e.g. via `SessionRunner`) once against the local DB and once against Railway.
-   - Every run now emits a single `RunDailySession timings ...` log with `seedMs`, `refreshMs`, `consumeMs` and the overall `totalMs`.
-   - Compare those numbers across the two environments to name the "범인 함수" (SeedBootstrapRun, RefreshBatchRun, or MatchDetailQueueWorker).
+### High-Level Flow
+1. `SeedBootstrapRun` pulls league entries by tier/division and registers new summoner seeds.
+2. `MatchIdsFinder` fetches recent match IDs which are pushed into the `match_queue`.
+3. `CollectMatchDetailAndSaveRaw` loads match-v5 payloads, stores them, extracts bottom duos, and schedules new participants for expansion.
+4. Aggregators compute tier-scoped stats and write them into materialized tables that the presentation layer reads.
+5. `ViewBottomDuo*` use cases resolve patch versions, look up champion metadata, and expose the aggregated insights through controllers.
 
-2. **범인 함수 안의 SQL 개수**
-   - The same log line now exposes `seedSqlTotal`, `refreshSqlTotal`, and `consumeSqlTotal` (plus the SELECT/INSERT/UPDATE/DELETE breakdown).
-   - If the culprit phase already issues only a few SQL statements, focus on query/DB/infra; if it fires hundreds, review the code path for unnecessary loops.
+### API Surface (Selected)
+- `GET /bottom-duo/stats`: global stats (win/pick/ban rate, ranking, tier delta) with filtering by tier, patch, or specific champions.
+- `GET /bottom-duo/detail`: matchup breakdown for a specific duo versus opposing duos.
+- `GET /bottom-duo/counters`: lowest-win-rate counters for a selected duo.
+- `POST /collect/match/{matchId}`: manual ingestion of a Riot match with a chosen tier label.
+- `POST /admin/session/run`: kick off a budgeted session that runs the seed, refresh, and consume phases sequentially.
 
-3. **느린 SQL의 DB 내부 실행시간 확인**
-   - Turn on query logging by setting `logging.level.com.bestduo_BE.SQL=DEBUG` (application YAML or env var) and rerun the session.
-   - Every executed SQL now prints as `SQL timeMs=123 success=true batch=false query=... params=[...]`, so you can immediately see which statements cost 100ms+.
-   - Copy the slow SQL from the log (it includes bind parameters and execution time) and run `EXPLAIN ANALYZE` directly on Railway.
-   - Decide whether the DB engine is actually slow or if most of the time is spent in network hops / repeated round-trips.
+### Tech & Monitoring
+- Spring Boot + Gradle project structure with layered `application`, `domain`, `infra`, and `presentation` packages.
+- Persistence via JPA repositories for matches, queues, and aggregated stats.
+- Rate limiting handled by `DualWindowRateLimiter` + `RiotRateLimitInterceptor` to respect API quotas.
+- Prometheus/Grafana dashboards (see `monitoring/`) to observe JVM metrics, SQL counts, and session timings.
 
-4. **Railway 메트릭 점검**
-   - While step 3 runs, open the Railway metrics dashboard: CPU, memory, network, and disk IO should all stay within limits.
-   - If any resource plateaus, record the timestamp together with the corresponding log line to justify a spec upgrade.
+---
 
-5. **위치 문제 분리**
-   - After finishing steps 1–4, optionally rerun the same command from a different region (or tunnel through a VM in Railway's region).
-   - If timings stay bad everywhere, it is DB/query bound. If the slowdown only happens far from the DB region, prioritize relocating the worker or the DB.
+## 시스템 개요 (Korean)
+BestDuo_BE는 리그 오브 레전드 바텀 듀오 시너지를 분석하는 **bestduo** 서비스의 백엔드입니다. 에메랄드 이상의 솔로 랭크 플레이어를 지속적으로 수집하고, 최신 매치 기록을 동기화한 뒤 패치 단위로 ADC/서포터 조합의 승률·픽률·랭킹·카운터 데이터를 집계합니다. 모든 데이터는 Riot league-v4와 match-v5 API에서 직접 가져오며, 순수 통계 제공 목적만을 위해 사용됩니다.
 
-The combination of phase-level timings, SQL counts, and detailed SQL logs should drastically shorten the feedback loop when comparing Local vs Railway behaviour.
+### 주요 기능
+- Riot 요청 예산을 지키는 **Seed → Refresh → Consume 파이프라인**으로 최신 솔로 랭크 데이터를 꾸준히 확보.
+- **Match payload 저장**: match-v5 JSON을 가공 전에 먼저 저장해 재처리에 활용.
+- **바텀 듀오 추출/집계**: 히스토리 데이터를 바탕으로 시너지 점수, 티어 기반 랭킹, 매치업 카운터를 계산.
+- 프론트엔드에서 호출하는 **공개 REST API**(`/bottom-duo/stats`, `/bottom-duo/detail`, `/bottom-duo/counters` 등).
+- 세션 실행, 매치 적재, 큐 상태 확인을 위한 **관리 도구**(`/admin/session`, `/collect` 등).
+
+### 처리 흐름
+1. `SeedBootstrapRun`이 티어/디비전별 리그 엔트리를 가져와 신규 시드를 등록합니다.
+2. `MatchIdsFinder`가 최근 match ID를 조회해 `match_queue`에 적재합니다.
+3. `CollectMatchDetailAndSaveRaw`가 match-v5 payload를 불러와 저장하고, 바텀 듀오를 추출하며 참가자를 확장 큐에 넣습니다.
+4. 집계기에서 티어별 통계를 계산해 프레젠테이션 계층이 조회하는 테이블에 반영합니다.
+5. `ViewBottomDuo*` 유스케이스가 패치 버전/챔피언 메타를 resolve하고, 컨트롤러를 통해 인사이트를 제공합니다.
+
+### 제공 API 예시
+- `GET /bottom-duo/stats`: 티어, 패치, 챔피언 필터에 따른 승률/픽률/랭킹 조회.
+- `GET /bottom-duo/detail`: 특정 듀오 vs 상대 듀오 매치업 상세 데이터.
+- `GET /bottom-duo/counters`: 선택 듀오 기준 최저 승률 카운터 목록.
+- `POST /collect/match/{matchId}`: 지정 티어 라벨로 Riot 매치를 수동 적재.
+- `POST /admin/session/run`: 예산을 나눠 시드/리프레시/소비 단계를 순차 실행.
+
+### 기술 스택 및 모니터링
+- Spring Boot + Gradle 기반 계층형 구조(`application`, `domain`, `infra`, `presentation`).
+- 매치, 큐, 집계 테이블을 다루는 JPA 저장소.
+- `DualWindowRateLimiter`와 `RiotRateLimitInterceptor`로 Riot API 레이트 리밋 준수.
+- `monitoring/` 이하 Prometheus/Grafana 구성으로 JVM, SQL, 세션 타이밍을 관측.

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -1,0 +1,50 @@
+# 모니터링 (Prometheus + Grafana)
+
+로컬에서 JVM 메모리 등 메트릭을 실시간으로 확인할 수 있습니다.
+
+## 사용 방법
+
+### 1. Spring Boot 앱 실행
+
+```bash
+./gradlew bootRun
+```
+
+앱이 `localhost:8080`에서 떠 있어야 합니다.
+
+### 2. Prometheus + Grafana 실행
+
+(설정은 compose 파일에 인라인되어 있어 File Sharing 제한과 무관하게 동작합니다.)
+
+```bash
+cd monitoring
+docker compose up -d
+```
+
+### 3. 접속
+
+- **Grafana**: http://localhost:3000
+  - ID: `admin`
+  - PW: `admin` (최초 로그인 시 변경 권장)
+
+- **Prometheus**: http://localhost:9090 (직접 쿼리용)
+
+### 4. 대시보드 확인
+
+Grafana 로그인 후 왼쪽 메뉴 **Dashboards** → **Bestduo JVM Memory** 선택.
+
+- Heap / Non-Heap 메모리 사용량 시계열
+- 전체 JVM 메모리 사용량
+- 5초마다 자동 갱신
+
+## 종료
+
+```bash
+cd monitoring
+docker compose down
+```
+
+## 참고
+
+- `host.docker.internal`은 Mac/Windows Docker에서 동작합니다.
+- Linux에서는 `host.docker.internal`이 없을 수 있어, `prometheus.yml`의 target을 `host.docker.internal` → `172.17.0.1` 또는 호스트 IP로 변경해야 할 수 있습니다.

--- a/monitoring/docker-compose.yml
+++ b/monitoring/docker-compose.yml
@@ -1,0 +1,87 @@
+# 호스트 볼륨 마운트 없이 configs 인라인 사용 (File Sharing 제한 환경 대응)
+
+services:
+  prometheus:
+    image: prom/prometheus:latest
+    container_name: bestduo-prometheus
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    ports:
+      - "9090:9090"
+    configs:
+      - source: prometheus_config
+        target: /etc/prometheus/prometheus.yml
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+      - --storage.tsdb.retention.time=7d
+      - --web.enable-lifecycle
+    restart: unless-stopped
+
+  grafana:
+    image: grafana/grafana:latest
+    container_name: bestduo-grafana
+    ports:
+      - "3000:3000"
+    environment:
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+      - GF_USERS_ALLOW_SIGN_UP=false
+      - GF_SERVER_HTTP_PORT=3000
+    configs:
+      - source: grafana_datasource
+        target: /etc/grafana/provisioning/datasources/datasource.yml
+      - source: grafana_dashboard_provider
+        target: /etc/grafana/provisioning/dashboards/dashboard.yml
+      - source: grafana_jvm_dashboard
+        target: /etc/grafana/provisioning/dashboards/json/jvm-memory.json
+    volumes:
+      - grafana-data:/var/lib/grafana
+    depends_on:
+      - prometheus
+    restart: unless-stopped
+
+configs:
+  prometheus_config:
+    content: |
+      global:
+        scrape_interval: 15s
+        evaluation_interval: 15s
+      scrape_configs:
+        - job_name: 'bestduo-be'
+          metrics_path: '/actuator/prometheus'
+          static_configs:
+            - targets: ['host.docker.internal:8080']
+          scrape_interval: 5s
+
+  grafana_datasource:
+    content: |
+      apiVersion: 1
+      datasources:
+        - name: Prometheus
+          type: prometheus
+          uid: prometheus
+          access: proxy
+          url: http://prometheus:9090
+          isDefault: true
+          editable: false
+
+  grafana_dashboard_provider:
+    content: |
+      apiVersion: 1
+      providers:
+        - name: 'JVM Dashboards'
+          orgId: 1
+          folder: ''
+          type: file
+          disableDeletion: false
+          updateIntervalSeconds: 30
+          allowUiUpdates: true
+          options:
+            path: /etc/grafana/provisioning/dashboards/json
+
+  grafana_jvm_dashboard:
+    content: |
+      {"annotations":{"list":[]},"editable":true,"fiscalYearStartMonth":0,"graphTooltip":1,"id":null,"links":[],"liveNow":false,"panels":[{"datasource":{"type":"prometheus","uid":"prometheus"},"fieldConfig":{"defaults":{"color":{"mode":"palette-classic"},"custom":{"drawStyle":"line","lineWidth":1},"unit":"bytes"}},"gridPos":{"h":8,"w":12,"x":0,"y":0},"id":1,"options":{"legend":{"showLegend":true}},"targets":[{"expr":"jvm_memory_used_bytes{area=\"heap\"}","legendFormat":"Heap","refId":"A"}],"title":"Heap Memory Used","type":"timeseries"},{"datasource":{"type":"prometheus","uid":"prometheus"},"fieldConfig":{"defaults":{"color":{"mode":"palette-classic"},"custom":{"drawStyle":"line","lineWidth":1},"unit":"bytes"}},"gridPos":{"h":8,"w":12,"x":12,"y":0},"id":2,"options":{"legend":{"showLegend":true}},"targets":[{"expr":"jvm_memory_used_bytes{area=\"nonheap\"}","legendFormat":"Non-Heap","refId":"A"}],"title":"Non-Heap Memory Used","type":"timeseries"},{"datasource":{"type":"prometheus","uid":"prometheus"},"fieldConfig":{"defaults":{"color":{"mode":"palette-classic"},"custom":{"drawStyle":"line","lineWidth":1},"unit":"bytes"}},"gridPos":{"h":8,"w":24,"x":0,"y":8},"id":3,"options":{"legend":{"showLegend":true}},"targets":[{"expr":"sum(jvm_memory_used_bytes)","legendFormat":"Total Used","refId":"A"}],"title":"Total JVM Memory Used","type":"timeseries"},{"datasource":{"type":"prometheus","uid":"prometheus"},"fieldConfig":{"defaults":{"color":{"mode":"thresholds"},"mappings":[],"thresholds":{"mode":"absolute","steps":[{"color":"green","value":null}]},"unit":"bytes"}},"gridPos":{"h":6,"w":8,"x":0,"y":16},"id":4,"options":{"colorMode":"value","graphMode":"area","justifyMode":"auto","orientation":"auto","reduceOptions":{"calcs":["lastNotNull"],"fields":"","values":false},"textMode":"auto"},"targets":[{"expr":"sum(jvm_memory_used_bytes)","legendFormat":"Current","refId":"A"}],"title":"Current Memory (bytes)","type":"stat"}],"refresh":"5s","schemaVersion":39,"style":"dark","tags":["jvm","bestduo"],"templating":{"list":[]},"time":{"from":"now-15m","to":"now"},"timepicker":{},"timezone":"browser","title":"Bestduo JVM Memory","uid":"bestduo-jvm-memory","version":1}
+
+volumes:
+  grafana-data:

--- a/monitoring/grafana/provisioning/dashboards/dashboard.yml
+++ b/monitoring/grafana/provisioning/dashboards/dashboard.yml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+providers:
+  - name: 'JVM Dashboards'
+    orgId: 1
+    folder: ''
+    type: file
+    disableDeletion: false
+    updateIntervalSeconds: 30
+    allowUiUpdates: true
+    options:
+      path: /etc/grafana/provisioning/dashboards/json

--- a/monitoring/grafana/provisioning/dashboards/json/jvm-memory.json
+++ b/monitoring/grafana/provisioning/dashboards/json/jvm-memory.json
@@ -1,0 +1,120 @@
+{
+  "annotations": {
+    "list": []
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 1,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "drawStyle": "line", "lineWidth": 1 },
+          "unit": "bytes"
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "id": 1,
+      "options": { "legend": { "showLegend": true } },
+      "targets": [
+        {
+          "expr": "jvm_memory_used_bytes{area=\"heap\"}",
+          "legendFormat": "Heap",
+          "refId": "A"
+        }
+      ],
+      "title": "Heap Memory Used",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "drawStyle": "line", "lineWidth": 1 },
+          "unit": "bytes"
+        }
+      },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "id": 2,
+      "options": { "legend": { "showLegend": true } },
+      "targets": [
+        {
+          "expr": "jvm_memory_used_bytes{area=\"nonheap\"}",
+          "legendFormat": "Non-Heap",
+          "refId": "A"
+        }
+      ],
+      "title": "Non-Heap Memory Used",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "palette-classic" },
+          "custom": { "drawStyle": "line", "lineWidth": 1 },
+          "unit": "bytes"
+        }
+      },
+      "gridPos": { "h": 8, "w": 24, "x": 0, "y": 8 },
+      "id": 3,
+      "options": { "legend": { "showLegend": true } },
+      "targets": [
+        {
+          "expr": "sum(jvm_memory_used_bytes)",
+          "legendFormat": "Total Used",
+          "refId": "A"
+        }
+      ],
+      "title": "Total JVM Memory Used",
+      "type": "timeseries"
+    },
+    {
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "fieldConfig": {
+        "defaults": {
+          "color": { "mode": "thresholds" },
+          "mappings": [],
+          "thresholds": { "mode": "absolute", "steps": [{ "color": "green", "value": null }] },
+          "unit": "bytes"
+        }
+      },
+      "gridPos": { "h": 6, "w": 8, "x": 0, "y": 16 },
+      "id": 4,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "area",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": { "calcs": ["lastNotNull"], "fields": "", "values": false },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "expr": "sum(jvm_memory_used_bytes)",
+          "legendFormat": "Current",
+          "refId": "A"
+        }
+      ],
+      "title": "Current Memory (bytes)",
+      "type": "stat"
+    }
+  ],
+  "refresh": "5s",
+  "schemaVersion": 39,
+  "style": "dark",
+  "tags": ["jvm", "bestduo"],
+  "templating": { "list": [] },
+  "time": { "from": "now-15m", "to": "now" },
+  "timepicker": {},
+  "timezone": "browser",
+  "title": "Bestduo JVM Memory",
+  "uid": "bestduo-jvm-memory",
+  "version": 1
+}

--- a/monitoring/grafana/provisioning/datasources/datasource.yml
+++ b/monitoring/grafana/provisioning/datasources/datasource.yml
@@ -1,0 +1,10 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    type: prometheus
+    uid: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false

--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -1,0 +1,11 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+scrape_configs:
+  - job_name: 'bestduo-be'
+    metrics_path: '/actuator/prometheus'
+    static_configs:
+      # host.docker.internal: Mac/Windows Docker에서 호스트 머신 접근
+      - targets: ['host.docker.internal:8080']
+    scrape_interval: 5s

--- a/monitoring/run.sh
+++ b/monitoring/run.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+# Documents 폴더 마운트 문제 회피: /tmp로 복사 후 실행 (Docker는 /tmp 항상 접근 가능)
+
+set -e
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TMP_DIR="/tmp/bestduo-monitoring"
+
+mkdir -p "$TMP_DIR"/prometheus "$TMP_DIR"/grafana/provisioning/datasources "$TMP_DIR"/grafana/provisioning/dashboards/json
+
+cp "$SCRIPT_DIR"/prometheus/prometheus.yml "$TMP_DIR/prometheus/"
+cp "$SCRIPT_DIR"/grafana/provisioning/datasources/datasource.yml "$TMP_DIR/grafana/provisioning/datasources/"
+cp "$SCRIPT_DIR"/grafana/provisioning/dashboards/dashboard.yml "$TMP_DIR/grafana/provisioning/dashboards/"
+cp "$SCRIPT_DIR"/grafana/provisioning/dashboards/json/jvm-memory.json "$TMP_DIR/grafana/provisioning/dashboards/json/"
+
+# volume 경로를 TMP_DIR로 변경한 compose 파일 생성
+sed "s|\./prometheus|$TMP_DIR/prometheus|g; s|\./grafana|$TMP_DIR/grafana|g" \
+  "$SCRIPT_DIR/docker-compose.yml" > "$TMP_DIR/docker-compose.yml"
+
+cd "$TMP_DIR"
+docker compose up -d "$@"
+
+echo ""
+echo "Prometheus: http://localhost:9090"
+echo "Grafana:    http://localhost:3000 (admin/admin)"
+echo ""
+echo "종료: cd $TMP_DIR && docker compose down"

--- a/src/main/java/com/bestduo_BE/application/AggregateBottomDuoStat.java
+++ b/src/main/java/com/bestduo_BE/application/AggregateBottomDuoStat.java
@@ -9,12 +9,13 @@ import org.springframework.stereotype.Service;
 public class AggregateBottomDuoStat {
 
   private final BottomDuoStatAggregator aggregator;
+  private final ComputeBottomDuoRanking ranking;
 
   public Result execute() {
     int affected = aggregator.aggregateAll();
-    return new Result(affected);
+    ComputeBottomDuoRanking.Result rankingResult = ranking.execute();
+    return new Result(affected, rankingResult.updatedRows());
   }
 
-  public record Result(int affectedRows) {}
+  public record Result(int affectedRows, int rankingsUpdated) {}
 }
-

--- a/src/main/java/com/bestduo_BE/application/ComputeBottomDuoRanking.java
+++ b/src/main/java/com/bestduo_BE/application/ComputeBottomDuoRanking.java
@@ -1,0 +1,123 @@
+package com.bestduo_BE.application;
+
+import com.bestduo_BE.infra.persistence.entity.BottomDuoStatAgg;
+import com.bestduo_BE.infra.persistence.repository.BottomDuoStatAggJpaRepository;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class ComputeBottomDuoRanking {
+
+  private static final int MIN_GAMES = 4;
+  private static final int INSUFFICIENT_TIER = 5;
+
+  private final BottomDuoStatAggJpaRepository repository;
+
+  @Transactional
+  public Result execute() {
+    String currentPatch = repository.findLatestPatchVersion();
+    if (currentPatch == null) {
+      return new Result(null, 0);
+    }
+
+    List<BottomDuoStatAgg> currentStats = repository.findByPatchVersion(currentPatch);
+    if (currentStats.isEmpty()) {
+      return new Result(currentPatch, 0);
+    }
+
+    Map<String, Integer> totalGamesByTier = currentStats.stream()
+        .collect(Collectors.groupingBy(BottomDuoStatAgg::getTier, Collectors.summingInt(BottomDuoStatAgg::getGames)));
+
+    Map<String, Integer> previousRankings = loadPreviousRankings(currentPatch);
+    OffsetDateTime now = OffsetDateTime.now();
+
+    Map<String, List<BottomDuoStatAgg>> byTier = currentStats.stream()
+        .collect(Collectors.groupingBy(BottomDuoStatAgg::getTier));
+
+    int updatedRows = 0;
+
+    for (Map.Entry<String, List<BottomDuoStatAgg>> entry : byTier.entrySet()) {
+      String tier = entry.getKey();
+      int tierTotalGames = totalGamesByTier.getOrDefault(tier, 0);
+      List<Candidate> eligible = new ArrayList<>();
+
+      for (BottomDuoStatAgg agg : entry.getValue()) {
+        double pickRate = tierTotalGames == 0 ? 0 : (double) agg.getGames() / tierTotalGames;
+        boolean enoughSamples = agg.getGames() >= MIN_GAMES;
+        if (!enoughSamples) {
+          agg.markInsufficientData(pickRate, INSUFFICIENT_TIER, now);
+          updatedRows++;
+          continue;
+        }
+        double rankScore = computeRankScore(agg, pickRate);
+        eligible.add(new Candidate(agg, pickRate, rankScore));
+      }
+
+      eligible.sort(Comparator
+          .comparing(Candidate::rankScore).reversed()
+          .thenComparing(c -> c.agg().getGames(), Comparator.reverseOrder())
+      );
+
+      int ranking = 1;
+      for (Candidate candidate : eligible) {
+        BottomDuoStatAgg agg = candidate.agg();
+        Integer previousRanking = previousRankings.get(agg.duoKey());
+        Integer rankDelta = previousRanking == null ? null : previousRanking - ranking;
+        int duoTier = toDuoTier(candidate.rankScore());
+        agg.applyRankingMetrics(
+            candidate.pickRate(),
+            candidate.rankScore(),
+            ranking,
+            duoTier,
+            previousRanking,
+            rankDelta,
+            now
+        );
+        ranking++;
+        updatedRows++;
+      }
+    }
+
+    repository.saveAll(currentStats);
+    return new Result(currentPatch, updatedRows);
+  }
+
+  private Map<String, Integer> loadPreviousRankings(String currentPatch) {
+    String previousPatch = repository.findPreviousPatchVersion(currentPatch);
+    if (previousPatch == null) {
+      return Map.of();
+    }
+    return repository.findByPatchVersion(previousPatch).stream()
+        .filter(e -> e.getRanking() != null)
+        .collect(Collectors.toMap(BottomDuoStatAgg::duoKey, BottomDuoStatAgg::getRanking, (left, right) -> left, HashMap::new));
+  }
+
+  private double computeRankScore(BottomDuoStatAgg agg, double pickRate) {
+    double winScore = agg.getAdjustedWinRate();
+    double pickScore = pickRate;
+    double gameScore = Math.min(1.0, (double) agg.getGames() / MIN_GAMES);
+    return 0.60 * winScore + 0.25 * pickScore + 0.15 * gameScore;
+  }
+
+  private int toDuoTier(double score) {
+    if (score >= 0.75) return 0;
+    if (score >= 0.65) return 1;
+    if (score >= 0.55) return 2;
+    if (score >= 0.45) return 3;
+    if (score >= 0.35) return 4;
+    return 5;
+  }
+
+  public record Result(String patchVersion, int updatedRows) {}
+
+  private record Candidate(BottomDuoStatAgg agg, double pickRate, double rankScore) {}
+}

--- a/src/main/java/com/bestduo_BE/application/SeedBootstrapRun.java
+++ b/src/main/java/com/bestduo_BE/application/SeedBootstrapRun.java
@@ -43,6 +43,9 @@ public class SeedBootstrapRun {
     int puuidRegistered = 0;
     int matchIdsFetched = 0;
     int matchIdsEnqueued = 0;
+    int processedEntries = 0;
+    boolean limitEnabled = cmd.maxEntries() > 0;
+    int maxEntries = cmd.maxEntries();
 
     for (int page = cmd.startPage(); page <= cmd.endPage(); page++) {
       List<LeagueEntry> entries = leagueEntriesSeedLoader.loadEntries(
@@ -50,14 +53,27 @@ public class SeedBootstrapRun {
 
       if (entries == null || entries.isEmpty()) break;
 
-      pagesProcessed++;
-      entriesFetched += entries.size();
+      List<LeagueEntry> entriesToProcess = entries;
+      if (limitEnabled) {
+        int remainingSlots = maxEntries - processedEntries;
+        if (remainingSlots <= 0) break;
+        if (entries.size() > remainingSlots) {
+          entriesToProcess = entries.subList(0, remainingSlots);
+        }
+      }
 
-      for (LeagueEntry e : entries) {
+      if (entriesToProcess.isEmpty()) break;
+
+      pagesProcessed++;
+      entriesFetched += entriesToProcess.size();
+
+      for (LeagueEntry e : entriesToProcess) {
         if (e == null) continue;
 
         String puuid = e.puuid();
         if (puuid == null || puuid.isBlank()) continue;
+
+        processedEntries++;
 
         // 1) summoner 등록(멱등) - 처음 본 puuid만 진행
         boolean firstTime = summonerSeedRegistry.registerIfAbsent(puuid);
@@ -91,6 +107,14 @@ public class SeedBootstrapRun {
           summonerSeedRegistry.markSeedError(puuid);
           // Phase2A는 계속 진행 (다음 puuid로)
         }
+
+        if (limitEnabled && processedEntries >= maxEntries) {
+          break;
+        }
+      }
+
+      if (limitEnabled && processedEntries >= maxEntries) {
+        break;
       }
     }
 

--- a/src/main/java/com/bestduo_BE/application/SessionRunner.java
+++ b/src/main/java/com/bestduo_BE/application/SessionRunner.java
@@ -138,7 +138,8 @@ public class SessionRunner {
           resolvedTier,
           seedProps.getStartPage(),
           seedProps.getEndPage(),
-          seedProps.getMatchesPerPuuid()
+          seedProps.getMatchesPerPuuid(),
+          seedProps.getMaxEntries()
       );
     }
 

--- a/src/main/java/com/bestduo_BE/application/ViewBottomDuoCounters.java
+++ b/src/main/java/com/bestduo_BE/application/ViewBottomDuoCounters.java
@@ -20,13 +20,19 @@ public class ViewBottomDuoCounters {
 
   public BottomDuoCounterResponse execute(
       Tier tier,
+      String patchVersionOrNull,
       String myAdcChampionId,
       String mySupChampionId,
       Integer counterSizeOrNull
   ) {
     int counterSize = (counterSizeOrNull == null) ? DEFAULT_COUNTER_SIZE : Math.max(1, Math.min(50, counterSizeOrNull));
 
-    int totalGames = matchupFinder.findMyDuoTotalGames(tier, myAdcChampionId, mySupChampionId);
+    String patchVersion = blankToNull(patchVersionOrNull);
+    String resolvedPatchVersion = matchupFinder.resolvePatchVersion(patchVersion);
+
+    int totalGames = resolvedPatchVersion == null
+        ? 0
+        : matchupFinder.findMyDuoTotalGames(tier, resolvedPatchVersion, myAdcChampionId, mySupChampionId);
 
     var myAdc = championMetaFinder.findById(myAdcChampionId);
     var mySup = championMetaFinder.findById(mySupChampionId);
@@ -41,12 +47,13 @@ public class ViewBottomDuoCounters {
     );
 
     List<Item> counters =
-        matchupFinder.findCountersByLowestWinRate(tier, myAdcChampionId, mySupChampionId, counterSize)
+        (resolvedPatchVersion == null ? List.<BottomDuoMatchupFinder.MatchupRow>of()
+            : matchupFinder.findCountersByLowestWinRate(tier, resolvedPatchVersion, myAdcChampionId, mySupChampionId, counterSize))
             .stream()
             .map(row -> toItem(row, totalGames))
             .toList();
 
-    return new BottomDuoCounterResponse(tier.name(), totalGames, myMeta, counterSize, counters);
+    return new BottomDuoCounterResponse(tier.name(), resolvedPatchVersion, totalGames, myMeta, counterSize, counters);
   }
 
   private BottomDuoCounterResponse.Item toItem(BottomDuoMatchupFinder.MatchupRow row, int totalGames) {
@@ -66,5 +73,13 @@ public class ViewBottomDuoCounters {
         pickRate,
         row.games()
     );
+  }
+
+  private String blankToNull(String value) {
+    if (value == null) {
+      return null;
+    }
+    String trimmed = value.trim();
+    return trimmed.isEmpty() ? null : trimmed;
   }
 }

--- a/src/main/java/com/bestduo_BE/application/ViewBottomDuoCounters.java
+++ b/src/main/java/com/bestduo_BE/application/ViewBottomDuoCounters.java
@@ -32,8 +32,12 @@ public class ViewBottomDuoCounters {
     var mySup = championMetaFinder.findById(mySupChampionId);
 
     var myMeta = new BottomDuoCounterResponse.DuoMeta(
-        myAdc.name(), myAdc.imageUrl(),
-        mySup.name(), mySup.imageUrl()
+        myAdcChampionId,
+        myAdc.name(),
+        myAdc.imageUrl(),
+        mySupChampionId,
+        mySup.name(),
+        mySup.imageUrl()
     );
 
     List<Item> counters =
@@ -52,8 +56,10 @@ public class ViewBottomDuoCounters {
     double pickRate = totalGames == 0 ? 0 : (double) row.games() / totalGames;
 
     return new BottomDuoCounterResponse.Item(
+        row.oppAdcChampionId(),
         oppAdc.name(),
         oppAdc.imageUrl(),
+        row.oppSupChampionId(),
         oppSup.name(),
         oppSup.imageUrl(),
         row.winRate(),

--- a/src/main/java/com/bestduo_BE/application/ViewBottomDuoDetailStatistics.java
+++ b/src/main/java/com/bestduo_BE/application/ViewBottomDuoDetailStatistics.java
@@ -19,13 +19,19 @@ public class ViewBottomDuoDetailStatistics {
 
   public BottomDuoDetailStatisticsResponse execute(
       Tier tier,
+      String patchVersionOrNull,
       String myAdcChampionId,
       String mySupChampionId,
       String oppAdcChampionIdOrNull,
       String oppSupChampionIdOrNull,
       BottomDuoMatchupFinder.SortKey sortKey
   ) {
-    int totalGames = matchupFinder.findMyDuoTotalGames(tier, myAdcChampionId, mySupChampionId);
+    String patchVersion = blankToNull(patchVersionOrNull);
+    String resolvedPatchVersion = matchupFinder.resolvePatchVersion(patchVersion);
+
+    int totalGames = resolvedPatchVersion == null
+        ? 0
+        : matchupFinder.findMyDuoTotalGames(tier, resolvedPatchVersion, myAdcChampionId, mySupChampionId);
 
     var myAdc = championMetaClient.findById(myAdcChampionId);
     var mySup = championMetaClient.findById(mySupChampionId);
@@ -40,8 +46,10 @@ public class ViewBottomDuoDetailStatistics {
     );
 
     List<BottomDuoDetailStatisticsResponse.Item> items =
-        matchupFinder.findMatchups(
+        (resolvedPatchVersion == null ? List.<BottomDuoMatchupFinder.MatchupRow>of()
+            : matchupFinder.findMatchups(
                 tier,
+                resolvedPatchVersion,
                 myAdcChampionId,
                 mySupChampionId,
                 blankToNull(oppAdcChampionIdOrNull),
@@ -49,11 +57,11 @@ public class ViewBottomDuoDetailStatistics {
                 sortKey,
                 totalGames,
                 MAX_ROWS
-            ).stream()
+            )).stream()
             .map(row -> toItem(row, totalGames))
             .toList();
 
-    return new BottomDuoDetailStatisticsResponse(tier.name(), totalGames, myMeta, items);
+    return new BottomDuoDetailStatisticsResponse(tier.name(), resolvedPatchVersion, totalGames, myMeta, items);
   }
 
   private BottomDuoDetailStatisticsResponse.Item toItem(BottomDuoMatchupFinder.MatchupRow row, int totalGames) {

--- a/src/main/java/com/bestduo_BE/application/ViewBottomDuoDetailStatistics.java
+++ b/src/main/java/com/bestduo_BE/application/ViewBottomDuoDetailStatistics.java
@@ -31,8 +31,12 @@ public class ViewBottomDuoDetailStatistics {
     var mySup = championMetaClient.findById(mySupChampionId);
 
     var myMeta = new BottomDuoDetailStatisticsResponse.DuoMeta(
-        myAdc.name(), myAdc.imageUrl(),
-        mySup.name(), mySup.imageUrl()
+        myAdcChampionId,
+        myAdc.name(),
+        myAdc.imageUrl(),
+        mySupChampionId,
+        mySup.name(),
+        mySup.imageUrl()
     );
 
     List<BottomDuoDetailStatisticsResponse.Item> items =
@@ -59,8 +63,10 @@ public class ViewBottomDuoDetailStatistics {
     double pickRate = totalGames == 0 ? 0 : (double) row.games() / totalGames;
 
     return new BottomDuoDetailStatisticsResponse.Item(
+        row.oppAdcChampionId(),
         oppAdc.name(),
         oppAdc.imageUrl(),
+        row.oppSupChampionId(),
         oppSup.name(),
         oppSup.imageUrl(),
         row.winRate(),

--- a/src/main/java/com/bestduo_BE/application/ViewBottomDuoStatistics.java
+++ b/src/main/java/com/bestduo_BE/application/ViewBottomDuoStatistics.java
@@ -47,8 +47,10 @@ public class ViewBottomDuoStatistics {
     double pickRate = totalGames == 0 ? 0 : (double) row.games() / totalGames;
 
     return new BottomDuoStatisticsResponse.Item(
+        row.adcChampionId(),
         adc.name(),
         adc.imageUrl(),
+        row.supChampionId(),
         sup.name(),
         sup.imageUrl(),
         row.winRate(),

--- a/src/main/java/com/bestduo_BE/application/ViewBottomDuoStatistics.java
+++ b/src/main/java/com/bestduo_BE/application/ViewBottomDuoStatistics.java
@@ -28,12 +28,13 @@ public class ViewBottomDuoStatistics {
     String adcChampionId = blankToNull(adcChampionIdOrNull);
     String supChampionId = blankToNull(supChampionIdOrNull);
 
-    int totalGames = statFinder.findTierTotalGames(tier, patchVersion);
+    String resolvedPatchVersion = statFinder.resolvePatchVersion(patchVersion);
+    int totalGames = statFinder.findTierTotalGames(tier, resolvedPatchVersion);
 
     List<BottomDuoStatisticsResponse.Item> items =
         statFinder.findStats(
                 tier,
-                patchVersion,
+                resolvedPatchVersion,
                 adcChampionId,
                 supChampionId,
                 sortKey,
@@ -43,7 +44,7 @@ public class ViewBottomDuoStatistics {
             .map(row -> toItem(row, totalGames))
             .toList();
 
-    return new BottomDuoStatisticsResponse(tier.name(), totalGames, items);
+    return new BottomDuoStatisticsResponse(tier.name(), resolvedPatchVersion, totalGames, items);
   }
 
   private BottomDuoStatisticsResponse.Item toItem(BottomDuoStatFinder.StatRow row, int totalGames) {

--- a/src/main/java/com/bestduo_BE/application/ViewBottomDuoStatistics.java
+++ b/src/main/java/com/bestduo_BE/application/ViewBottomDuoStatistics.java
@@ -19,17 +19,23 @@ public class ViewBottomDuoStatistics {
 
   public BottomDuoStatisticsResponse execute(
       Tier tier,
+      String patchVersionOrNull,
       String adcChampionIdOrNull,
       String supChampionIdOrNull,
       BottomDuoStatFinder.SortKey sortKey
   ) {
-    int totalGames = statFinder.findTierTotalGames(tier);
+    String patchVersion = blankToNull(patchVersionOrNull);
+    String adcChampionId = blankToNull(adcChampionIdOrNull);
+    String supChampionId = blankToNull(supChampionIdOrNull);
+
+    int totalGames = statFinder.findTierTotalGames(tier, patchVersion);
 
     List<BottomDuoStatisticsResponse.Item> items =
         statFinder.findStats(
                 tier,
-                blankToNull(adcChampionIdOrNull),
-                blankToNull(supChampionIdOrNull),
+                patchVersion,
+                adcChampionId,
+                supChampionId,
                 sortKey,
                 totalGames,
                 MAX_ROWS
@@ -55,7 +61,10 @@ public class ViewBottomDuoStatistics {
         sup.imageUrl(),
         row.winRate(),
         pickRate,
-        row.games()
+        row.games(),
+        row.duoTier(),
+        row.ranking(),
+        row.rankDelta()
     );
   }
 

--- a/src/main/java/com/bestduo_BE/application/port/BottomDuoMatchupFinder.java
+++ b/src/main/java/com/bestduo_BE/application/port/BottomDuoMatchupFinder.java
@@ -24,10 +24,11 @@ public interface BottomDuoMatchupFinder {
     }
   }
 
-  int findMyDuoTotalGames(Tier tier, String myAdcChampionId, String mySupChampionId);
+  int findMyDuoTotalGames(Tier tier, String patchVersionOrNull, String myAdcChampionId, String mySupChampionId);
 
   List<MatchupRow> findMatchups(
       Tier tier,
+      String patchVersionOrNull,
       String myAdcChampionId,
       String mySupChampionId,
       String oppAdcChampionIdOrNull,
@@ -40,8 +41,11 @@ public interface BottomDuoMatchupFinder {
   // ✅ 추가: 카운터(최저 승률 N개)
   List<MatchupRow> findCountersByLowestWinRate(
       Tier tier,
+      String patchVersionOrNull,
       String myAdcChampionId,
       String mySupChampionId,
       int maxRows
   );
+
+  String resolvePatchVersion(String patchVersionOrNull);
 }

--- a/src/main/java/com/bestduo_BE/application/port/BottomDuoStatFinder.java
+++ b/src/main/java/com/bestduo_BE/application/port/BottomDuoStatFinder.java
@@ -7,7 +7,9 @@ public interface BottomDuoStatFinder {
 
   enum SortKey {
     PICKRATE_ASC, PICKRATE_DESC,
-    WINRATE_ASC,  WINRATE_DESC
+    WINRATE_ASC,  WINRATE_DESC,
+    DUO_TIER_ASC, DUO_TIER_DESC,
+    RANKING_ASC, RANKING_DESC
   }
 
   record StatRow(
@@ -15,16 +17,20 @@ public interface BottomDuoStatFinder {
       String supChampionId,
       Tier tier,
       int wins,
-      int games
+      int games,
+      Integer duoTier,
+      Integer ranking,
+      Integer rankDelta
   ) {
     public double winRate() {
       return games == 0 ? 0 : (double) wins / games;
     }
   }
 
-  int findTierTotalGames(Tier tier);
+  int findTierTotalGames(Tier tier, String patchVersionOrNull);
 
   List<StatRow> findStats(Tier tier,
+      String patchVersionOrNull,
       String adcChampionIdOrNull,
       String supChampionIdOrNull,
       SortKey sortKey,

--- a/src/main/java/com/bestduo_BE/application/port/BottomDuoStatFinder.java
+++ b/src/main/java/com/bestduo_BE/application/port/BottomDuoStatFinder.java
@@ -36,4 +36,6 @@ public interface BottomDuoStatFinder {
       SortKey sortKey,
       int tierTotalGamesForPickRate,
       int maxRows);
+
+  String resolvePatchVersion(String patchVersionOrNull);
 }

--- a/src/main/java/com/bestduo_BE/config/DailySessionProperties.java
+++ b/src/main/java/com/bestduo_BE/config/DailySessionProperties.java
@@ -32,5 +32,6 @@ public class DailySessionProperties {
     private int startPage = 1;
     private int endPage = 1;
     private int matchesPerPuuid = 20;
+    private int maxEntries = 0;
   }
 }

--- a/src/main/java/com/bestduo_BE/domain/model/SeedBootstrapCommand.java
+++ b/src/main/java/com/bestduo_BE/domain/model/SeedBootstrapCommand.java
@@ -7,7 +7,8 @@ public record SeedBootstrapCommand(
     Tier seedTier, // bottom_duo_raw.collection_tier로 들어갈 값
     int startPage,
     int endPage,
-    int matchesPerPuuid
+    int matchesPerPuuid,
+    int maxEntries
 ) {
 
 }

--- a/src/main/java/com/bestduo_BE/infra/persistence/BottomDuoMatchupFinderImpl.java
+++ b/src/main/java/com/bestduo_BE/infra/persistence/BottomDuoMatchupFinderImpl.java
@@ -14,13 +14,18 @@ public class BottomDuoMatchupFinderImpl implements BottomDuoMatchupFinder {
   private final BottomDuoMatchupAggJpaRepository repository;
 
   @Override
-  public int findMyDuoTotalGames(Tier tier, String myAdcChampionId, String mySupChampionId) {
-    return repository.sumGamesOfMyDuo(tier.name(), myAdcChampionId, mySupChampionId);
+  public int findMyDuoTotalGames(Tier tier, String patchVersionOrNull, String myAdcChampionId, String mySupChampionId) {
+    String patchVersion = resolvePatchVersion(patchVersionOrNull);
+    if (patchVersion == null) {
+      return 0;
+    }
+    return repository.sumGamesOfMyDuo(patchVersion, tier.name(), myAdcChampionId, mySupChampionId);
   }
 
   @Override
   public List<MatchupRow> findMatchups(
       Tier tier,
+      String patchVersionOrNull,
       String myAdcChampionId,
       String mySupChampionId,
       String oppAdcChampionIdOrNull,
@@ -34,11 +39,16 @@ public class BottomDuoMatchupFinderImpl implements BottomDuoMatchupFinder {
     String oppAdc = blankToNull(oppAdcChampionIdOrNull);
     String oppSup = blankToNull(oppSupChampionIdOrNull);
 
+    String patchVersion = resolvePatchVersion(patchVersionOrNull);
+    if (patchVersion == null) {
+      return List.of();
+    }
+
     var entities = switch (sortKey) {
-      case WINRATE_DESC -> repository.findTopWinRateDesc(tier.name(), myAdcChampionId, mySupChampionId, oppAdc, oppSup, limit);
-      case WINRATE_ASC  -> repository.findTopWinRateAsc(tier.name(), myAdcChampionId, mySupChampionId, oppAdc, oppSup, limit);
-      case PICKRATE_DESC -> repository.findTopPickRateDesc(tier.name(), myAdcChampionId, mySupChampionId, oppAdc, oppSup, myTotalGamesForPickRate, limit);
-      case PICKRATE_ASC  -> repository.findTopPickRateAsc(tier.name(), myAdcChampionId, mySupChampionId, oppAdc, oppSup, myTotalGamesForPickRate, limit);
+      case WINRATE_DESC -> repository.findTopWinRateDesc(patchVersion, tier.name(), myAdcChampionId, mySupChampionId, oppAdc, oppSup, limit);
+      case WINRATE_ASC  -> repository.findTopWinRateAsc(patchVersion, tier.name(), myAdcChampionId, mySupChampionId, oppAdc, oppSup, limit);
+      case PICKRATE_DESC -> repository.findTopPickRateDesc(patchVersion, tier.name(), myAdcChampionId, mySupChampionId, oppAdc, oppSup, myTotalGamesForPickRate, limit);
+      case PICKRATE_ASC  -> repository.findTopPickRateAsc(patchVersion, tier.name(), myAdcChampionId, mySupChampionId, oppAdc, oppSup, myTotalGamesForPickRate, limit);
     };
 
     return entities.stream()
@@ -57,13 +67,20 @@ public class BottomDuoMatchupFinderImpl implements BottomDuoMatchupFinder {
   @Override
   public List<MatchupRow> findCountersByLowestWinRate(
       Tier tier,
+      String patchVersionOrNull,
       String myAdcChampionId,
       String mySupChampionId,
       int maxRows
   ) {
     int limit = Math.max(1, maxRows);
 
+    String patchVersion = resolvePatchVersion(patchVersionOrNull);
+    if (patchVersion == null) {
+      return List.of();
+    }
+
     var entities = repository.findCountersByLowestWinRate(
+        patchVersion,
         tier.name(),
         myAdcChampionId,
         mySupChampionId,
@@ -87,5 +104,14 @@ public class BottomDuoMatchupFinderImpl implements BottomDuoMatchupFinder {
     if (v == null) return null;
     String t = v.trim();
     return t.isEmpty() ? null : t;
+  }
+
+  @Override
+  public String resolvePatchVersion(String patchVersionOrNull) {
+    String patchVersion = blankToNull(patchVersionOrNull);
+    if (patchVersion != null) {
+      return patchVersion;
+    }
+    return repository.findLatestPatchVersion();
   }
 }

--- a/src/main/java/com/bestduo_BE/infra/persistence/BottomDuoStatFinderImpl.java
+++ b/src/main/java/com/bestduo_BE/infra/persistence/BottomDuoStatFinderImpl.java
@@ -13,12 +13,17 @@ public class BottomDuoStatFinderImpl implements BottomDuoStatFinder {
   private final BottomDuoStatAggJpaRepository repository;
 
   @Override
-  public int findTierTotalGames(Tier tier) {
-    return repository.sumGamesByTier(tier.name());
+  public int findTierTotalGames(Tier tier, String patchVersionOrNull) {
+    String patchVersion = resolvePatchVersion(patchVersionOrNull);
+    if (patchVersion == null) {
+      return 0;
+    }
+    return repository.sumGamesByTier(patchVersion, tier.name());
   }
 
   @Override
   public List<StatRow> findStats(Tier tier,
+      String patchVersionOrNull,
       String adcChampionIdOrNull,
       String supChampionIdOrNull,
       SortKey sortKey,
@@ -30,11 +35,20 @@ public class BottomDuoStatFinderImpl implements BottomDuoStatFinder {
     String adc = blankToNull(adcChampionIdOrNull);
     String sup = blankToNull(supChampionIdOrNull);
 
+    String patchVersion = resolvePatchVersion(patchVersionOrNull);
+    if (patchVersion == null) {
+      return List.of();
+    }
+
     var entities = switch (sortKey) {
-      case WINRATE_DESC -> repository.findTopWinRateDesc(tier.name(), adc, sup, limit);
-      case WINRATE_ASC  -> repository.findTopWinRateAsc(tier.name(), adc, sup, limit);
-      case PICKRATE_DESC -> repository.findTopPickRateDesc(tier.name(), adc, sup, tierTotalGamesForPickRate, limit);
-      case PICKRATE_ASC  -> repository.findTopPickRateAsc(tier.name(), adc, sup, tierTotalGamesForPickRate, limit);
+      case WINRATE_DESC -> repository.findTopWinRateDesc(patchVersion, tier.name(), adc, sup, limit);
+      case WINRATE_ASC  -> repository.findTopWinRateAsc(patchVersion, tier.name(), adc, sup, limit);
+      case PICKRATE_DESC -> repository.findTopPickRateDesc(patchVersion, tier.name(), adc, sup, tierTotalGamesForPickRate, limit);
+      case PICKRATE_ASC  -> repository.findTopPickRateAsc(patchVersion, tier.name(), adc, sup, tierTotalGamesForPickRate, limit);
+      case DUO_TIER_ASC -> repository.findTopDuoTierAsc(patchVersion, tier.name(), adc, sup, limit);
+      case DUO_TIER_DESC -> repository.findTopDuoTierDesc(patchVersion, tier.name(), adc, sup, limit);
+      case RANKING_ASC -> repository.findTopRankingAsc(patchVersion, tier.name(), adc, sup, limit);
+      case RANKING_DESC -> repository.findTopRankingDesc(patchVersion, tier.name(), adc, sup, limit);
     };
 
     return entities.stream()
@@ -43,7 +57,10 @@ public class BottomDuoStatFinderImpl implements BottomDuoStatFinder {
             e.getSupChampionId(),
             Tier.valueOf(e.getTier()),
             e.getWins(),
-            e.getGames()
+            e.getGames(),
+            e.getDuoTier(),
+            e.getRanking(),
+            e.getRankDelta()
         ))
         .toList();
   }
@@ -52,6 +69,14 @@ public class BottomDuoStatFinderImpl implements BottomDuoStatFinder {
     if (v == null) return null;
     String t = v.trim();
     return t.isEmpty() ? null : t;
+  }
+
+  private String resolvePatchVersion(String patchVersionOrNull) {
+    String patchVersion = blankToNull(patchVersionOrNull);
+    if (patchVersion != null) {
+      return patchVersion;
+    }
+    return repository.findLatestPatchVersion();
   }
 
 }

--- a/src/main/java/com/bestduo_BE/infra/persistence/BottomDuoStatFinderImpl.java
+++ b/src/main/java/com/bestduo_BE/infra/persistence/BottomDuoStatFinderImpl.java
@@ -71,7 +71,12 @@ public class BottomDuoStatFinderImpl implements BottomDuoStatFinder {
     return t.isEmpty() ? null : t;
   }
 
-  private String resolvePatchVersion(String patchVersionOrNull) {
+  @Override
+  public String resolvePatchVersion(String patchVersionOrNull) {
+    return doResolvePatchVersion(patchVersionOrNull);
+  }
+
+  private String doResolvePatchVersion(String patchVersionOrNull) {
     String patchVersion = blankToNull(patchVersionOrNull);
     if (patchVersion != null) {
       return patchVersion;

--- a/src/main/java/com/bestduo_BE/infra/persistence/entity/BottomDuoMatchupAgg.java
+++ b/src/main/java/com/bestduo_BE/infra/persistence/entity/BottomDuoMatchupAgg.java
@@ -21,6 +21,11 @@ import lombok.NoArgsConstructor;
 @IdClass(BottomDuoMatchupAggId.class)
 public class BottomDuoMatchupAgg {
 
+
+  @Id
+  @Column(name = "patch_version", nullable = false, length = 20)
+  private String patchVersion;
+
   @Id
   @Column(name = "my_adc_champion_id", nullable = false)
   private String myAdcChampionId;

--- a/src/main/java/com/bestduo_BE/infra/persistence/entity/BottomDuoMatchupAggId.java
+++ b/src/main/java/com/bestduo_BE/infra/persistence/entity/BottomDuoMatchupAggId.java
@@ -11,10 +11,10 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @EqualsAndHashCode
 public class BottomDuoMatchupAggId implements Serializable {
+  private String patchVersion;
   private String myAdcChampionId;
   private String mySupChampionId;
   private String oppAdcChampionId;
   private String oppSupChampionId;
   private String tier;
 }
-

--- a/src/main/java/com/bestduo_BE/infra/persistence/entity/BottomDuoStatAgg.java
+++ b/src/main/java/com/bestduo_BE/infra/persistence/entity/BottomDuoStatAgg.java
@@ -2,10 +2,13 @@ package com.bestduo_BE.infra.persistence.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
 import jakarta.persistence.IdClass;
 import jakarta.persistence.Table;
 import java.time.OffsetDateTime;
+import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -22,15 +25,19 @@ import lombok.NoArgsConstructor;
 public class BottomDuoStatAgg {
 
   @Id
-  @Column(name = "adc_champion_id", nullable = false)
+  @Column(name = "patch_version", nullable = false, length = 20)
+  private String patchVersion;
+
+  @Id
+  @Column(name = "adc_champion_id", nullable = false, length = 50)
   private String adcChampionId;
 
   @Id
-  @Column(name = "sup_champion_id", nullable = false)
+  @Column(name = "sup_champion_id", nullable = false, length = 50)
   private String supChampionId;
 
   @Id
-  @Column(name = "tier", nullable = false)
+  @Column(name = "tier", nullable = false, length = 30)
   private String tier;
 
   @Column(name = "wins", nullable = false)
@@ -39,10 +46,81 @@ public class BottomDuoStatAgg {
   @Column(name = "games", nullable = false)
   private int games;
 
+  @Column(name = "win_rate", nullable = false)
+  private double winRate;
+
+  @Column(name = "pick_rate", nullable = false)
+  private double pickRate;
+
+  @Column(name = "adjusted_win_rate", nullable = false)
+  private double adjustedWinRate;
+
+  @Column(name = "rank_score", nullable = false)
+  private double rankScore;
+
+  @Column(name = "ranking")
+  private Integer ranking;
+
+  @Column(name = "duo_tier")
+  private Integer duoTier;
+
+  @Column(name = "previous_ranking")
+  private Integer previousRanking;
+
+  @Column(name = "rank_delta")
+  private Integer rankDelta;
+
+  @Enumerated(EnumType.STRING)
+  @Column(name = "ranking_status", nullable = false, length = 20)
+  private RankingStatus rankingStatus;
+
   @Column(name = "created_at", nullable = false)
   private OffsetDateTime createdAt;
 
   @Column(name = "updated_at", nullable = false)
   private OffsetDateTime updatedAt;
-}
 
+  public String duoKey() {
+    return adcChampionId + ":" + supChampionId + ":" + tier;
+  }
+
+  public void applyRankingMetrics(
+      double pickRate,
+      double rankScore,
+      Integer ranking,
+      Integer duoTier,
+      Integer previousRanking,
+      Integer rankDelta,
+      OffsetDateTime newUpdatedAt
+  ) {
+    this.pickRate = pickRate;
+    this.rankScore = rankScore;
+    this.ranking = ranking;
+    this.duoTier = duoTier;
+    this.previousRanking = previousRanking;
+    this.rankDelta = rankDelta;
+    this.rankingStatus = RankingStatus.RANKED;
+    this.updatedAt = Objects.requireNonNullElseGet(newUpdatedAt, OffsetDateTime::now);
+  }
+
+  public void markInsufficientData(
+      double pickRate,
+      int insufficientTier,
+      OffsetDateTime newUpdatedAt
+  ) {
+    this.pickRate = pickRate;
+    this.rankScore = 0;
+    this.ranking = null;
+    this.duoTier = insufficientTier;
+    this.previousRanking = null;
+    this.rankDelta = null;
+    this.rankingStatus = RankingStatus.INSUFFICIENT;
+    this.updatedAt = Objects.requireNonNullElseGet(newUpdatedAt, OffsetDateTime::now);
+  }
+
+  public enum RankingStatus {
+    PENDING,
+    RANKED,
+    INSUFFICIENT
+  }
+}

--- a/src/main/java/com/bestduo_BE/infra/persistence/entity/BottomDuoStatAggId.java
+++ b/src/main/java/com/bestduo_BE/infra/persistence/entity/BottomDuoStatAggId.java
@@ -11,6 +11,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @EqualsAndHashCode
 public class BottomDuoStatAggId implements Serializable {
+  private String patchVersion;
   private String adcChampionId;
   private String supChampionId;
   private String tier;

--- a/src/main/java/com/bestduo_BE/infra/persistence/repository/BottomDuoMatchupAggJpaRepository.java
+++ b/src/main/java/com/bestduo_BE/infra/persistence/repository/BottomDuoMatchupAggJpaRepository.java
@@ -18,11 +18,13 @@ public interface BottomDuoMatchupAggJpaRepository extends JpaRepository<BottomDu
   @Transactional
   @Query(value = """
       insert into bottom_duo_matchup_agg(
+        patch_version,
         my_adc_champion_id, my_sup_champion_id,
         opp_adc_champion_id, opp_sup_champion_id,
         tier, wins, games, created_at, updated_at
       )
       select
+        coalesce(a.patch, 'UNKNOWN') as patch_version,
         a.adc_champion_id as my_adc,
         a.sup_champion_id as my_sup,
         b.adc_champion_id as opp_adc,
@@ -37,8 +39,8 @@ public interface BottomDuoMatchupAggJpaRepository extends JpaRepository<BottomDu
         on a.match_id = b.match_id
        and a.collection_tier = b.collection_tier
        and a.team_id <> b.team_id
-      group by a.adc_champion_id, a.sup_champion_id, b.adc_champion_id, b.sup_champion_id, a.collection_tier
-      on conflict (my_adc_champion_id, my_sup_champion_id, opp_adc_champion_id, opp_sup_champion_id, tier)
+      group by coalesce(a.patch, 'UNKNOWN'), a.adc_champion_id, a.sup_champion_id, b.adc_champion_id, b.sup_champion_id, a.collection_tier
+      on conflict (patch_version, my_adc_champion_id, my_sup_champion_id, opp_adc_champion_id, opp_sup_champion_id, tier)
       do update set
         wins = excluded.wins,
         games = excluded.games,
@@ -50,18 +52,29 @@ public interface BottomDuoMatchupAggJpaRepository extends JpaRepository<BottomDu
       select coalesce(sum(games), 0)
       from bottom_duo_matchup_agg
       where tier = :tier
+        and patch_version = :patchVersion
         and my_adc_champion_id = :myAdc
         and my_sup_champion_id = :mySup
       """, nativeQuery = true)
-  int sumGamesOfMyDuo(@Param("tier") String tier,
+  int sumGamesOfMyDuo(@Param("patchVersion") String patchVersion,
+      @Param("tier") String tier,
       @Param("myAdc") String myAdc,
       @Param("mySup") String mySup);
+
+  @Query(value = """
+      select patch_version
+      from bottom_duo_matchup_agg
+      order by updated_at desc
+      limit 1
+      """, nativeQuery = true)
+  String findLatestPatchVersion();
 
   // WINRATE DESC
   @Query(value = """
       select *
       from bottom_duo_matchup_agg
       where tier = :tier
+        and patch_version = :patchVersion
         and my_adc_champion_id = :myAdc
         and my_sup_champion_id = :mySup
         and (:oppAdc is null or opp_adc_champion_id = :oppAdc)
@@ -72,6 +85,7 @@ public interface BottomDuoMatchupAggJpaRepository extends JpaRepository<BottomDu
       limit :limit
       """, nativeQuery = true)
   List<BottomDuoMatchupAgg> findTopWinRateDesc(
+      @Param("patchVersion") String patchVersion,
       @Param("tier") String tier,
       @Param("myAdc") String myAdc,
       @Param("mySup") String mySup,
@@ -85,6 +99,7 @@ public interface BottomDuoMatchupAggJpaRepository extends JpaRepository<BottomDu
       select *
       from bottom_duo_matchup_agg
       where tier = :tier
+        and patch_version = :patchVersion
         and my_adc_champion_id = :myAdc
         and my_sup_champion_id = :mySup
         and (:oppAdc is null or opp_adc_champion_id = :oppAdc)
@@ -95,6 +110,7 @@ public interface BottomDuoMatchupAggJpaRepository extends JpaRepository<BottomDu
       limit :limit
       """, nativeQuery = true)
   List<BottomDuoMatchupAgg> findTopWinRateAsc(
+      @Param("patchVersion") String patchVersion,
       @Param("tier") String tier,
       @Param("myAdc") String myAdc,
       @Param("mySup") String mySup,
@@ -108,6 +124,7 @@ public interface BottomDuoMatchupAggJpaRepository extends JpaRepository<BottomDu
       select *
       from bottom_duo_matchup_agg
       where tier = :tier
+        and patch_version = :patchVersion
         and my_adc_champion_id = :myAdc
         and my_sup_champion_id = :mySup
         and (:oppAdc is null or opp_adc_champion_id = :oppAdc)
@@ -118,6 +135,7 @@ public interface BottomDuoMatchupAggJpaRepository extends JpaRepository<BottomDu
       limit :limit
       """, nativeQuery = true)
   List<BottomDuoMatchupAgg> findTopPickRateDesc(
+      @Param("patchVersion") String patchVersion,
       @Param("tier") String tier,
       @Param("myAdc") String myAdc,
       @Param("mySup") String mySup,
@@ -132,6 +150,7 @@ public interface BottomDuoMatchupAggJpaRepository extends JpaRepository<BottomDu
       select *
       from bottom_duo_matchup_agg
       where tier = :tier
+        and patch_version = :patchVersion
         and my_adc_champion_id = :myAdc
         and my_sup_champion_id = :mySup
         and (:oppAdc is null or opp_adc_champion_id = :oppAdc)
@@ -142,6 +161,7 @@ public interface BottomDuoMatchupAggJpaRepository extends JpaRepository<BottomDu
       limit :limit
       """, nativeQuery = true)
   List<BottomDuoMatchupAgg> findTopPickRateAsc(
+      @Param("patchVersion") String patchVersion,
       @Param("tier") String tier,
       @Param("myAdc") String myAdc,
       @Param("mySup") String mySup,
@@ -156,14 +176,16 @@ public interface BottomDuoMatchupAggJpaRepository extends JpaRepository<BottomDu
       select *
       from bottom_duo_matchup_agg
       where tier = :tier
+        and patch_version = :patchVersion
         and my_adc_champion_id = :myAdc
         and my_sup_champion_id = :mySup
-      order by
+     order by
         (case when games = 0 then 0 else (wins::double precision / games) end) asc,
         games desc
       limit :limit
       """, nativeQuery = true)
   List<BottomDuoMatchupAgg> findCountersByLowestWinRate(
+      @Param("patchVersion") String patchVersion,
       @Param("tier") String tier,
       @Param("myAdc") String myAdc,
       @Param("mySup") String mySup,

--- a/src/main/java/com/bestduo_BE/infra/persistence/repository/BottomDuoStatAggJpaRepository.java
+++ b/src/main/java/com/bestduo_BE/infra/persistence/repository/BottomDuoStatAggJpaRepository.java
@@ -14,21 +14,60 @@ public interface BottomDuoStatAggJpaRepository extends JpaRepository<BottomDuoSt
   @Modifying
   @Transactional
   @Query(value = """
-      insert into bottom_duo_stat_agg(adc_champion_id, sup_champion_id, tier, wins, games, created_at, updated_at)
+      insert into bottom_duo_stat_agg(
+        patch_version,
+        adc_champion_id,
+        sup_champion_id,
+        tier,
+        wins,
+        games,
+        win_rate,
+        pick_rate,
+        adjusted_win_rate,
+        rank_score,
+        ranking,
+        duo_tier,
+        previous_ranking,
+        rank_delta,
+        ranking_status,
+        created_at,
+        updated_at
+      )
       select
+        coalesce(r.patch, 'UNKNOWN') as patch_version,
         r.adc_champion_id,
         r.sup_champion_id,
         r.collection_tier as tier,
         sum(case when r.win = true then 1 else 0 end) as wins,
         count(*) as games,
+        case when count(*) = 0 then 0
+             else sum(case when r.win = true then 1 else 0 end)::double precision / count(*) end as win_rate,
+        0 as pick_rate,
+        case when count(*) = 0 then 0
+             else (sum(case when r.win = true then 1 else 0 end)::double precision + 25.0) / (count(*) + 50) end as adjusted_win_rate,
+        0 as rank_score,
+        null as ranking,
+        null as duo_tier,
+        null as previous_ranking,
+        null as rank_delta,
+        'PENDING' as ranking_status,
         now(),
         now()
       from bottom_duo_raw r
-      group by r.adc_champion_id, r.sup_champion_id, r.collection_tier
-      on conflict (adc_champion_id, sup_champion_id, tier)
+      group by
+        coalesce(r.patch, 'UNKNOWN'),
+        r.adc_champion_id,
+        r.sup_champion_id,
+        r.collection_tier
+      on conflict (patch_version, adc_champion_id, sup_champion_id, tier)
       do update set
         wins = excluded.wins,
         games = excluded.games,
+        win_rate = excluded.win_rate,
+        pick_rate = excluded.pick_rate,
+        adjusted_win_rate = excluded.adjusted_win_rate,
+        rank_score = excluded.rank_score,
+        ranking_status = excluded.ranking_status,
         updated_at = now()
       """, nativeQuery = true)
   int upsertAllFromRaw();
@@ -37,14 +76,39 @@ public interface BottomDuoStatAggJpaRepository extends JpaRepository<BottomDuoSt
       select coalesce(sum(games), 0)
       from bottom_duo_stat_agg
       where tier = :tier
+        and patch_version = :patchVersion
+        and ranking_status = 'RANKED'
       """, nativeQuery = true)
-  int sumGamesByTier(@Param("tier") String tier);
+  int sumGamesByTier(
+      @Param("patchVersion") String patchVersion,
+      @Param("tier") String tier);
+
+  @Query(value = """
+      select patch_version
+      from bottom_duo_stat_agg
+      order by updated_at desc
+      limit 1
+      """, nativeQuery = true)
+  String findLatestPatchVersion();
+
+  @Query(value = """
+      select patch_version
+      from bottom_duo_stat_agg
+      where patch_version < :currentPatch
+      order by patch_version desc
+      limit 1
+      """, nativeQuery = true)
+  String findPreviousPatchVersion(@Param("currentPatch") String currentPatch);
+
+  List<BottomDuoStatAgg> findByPatchVersion(String patchVersion);
 
   // ✅ WINRATE DESC
   @Query(value = """
       select *
       from bottom_duo_stat_agg
       where tier = :tier
+        and patch_version = :patchVersion
+        and ranking_status = 'RANKED'
         and (:adc is null or adc_champion_id = :adc)
         and (:sup is null or sup_champion_id = :sup)
       order by
@@ -53,6 +117,7 @@ public interface BottomDuoStatAggJpaRepository extends JpaRepository<BottomDuoSt
       limit :limit
       """, nativeQuery = true)
   List<BottomDuoStatAgg> findTopWinRateDesc(
+      @Param("patchVersion") String patchVersion,
       @Param("tier") String tier,
       @Param("adc") String adc,
       @Param("sup") String sup,
@@ -64,6 +129,8 @@ public interface BottomDuoStatAggJpaRepository extends JpaRepository<BottomDuoSt
       select *
       from bottom_duo_stat_agg
       where tier = :tier
+        and patch_version = :patchVersion
+        and ranking_status = 'RANKED'
         and (:adc is null or adc_champion_id = :adc)
         and (:sup is null or sup_champion_id = :sup)
       order by
@@ -72,6 +139,7 @@ public interface BottomDuoStatAggJpaRepository extends JpaRepository<BottomDuoSt
       limit :limit
       """, nativeQuery = true)
   List<BottomDuoStatAgg> findTopWinRateAsc(
+      @Param("patchVersion") String patchVersion,
       @Param("tier") String tier,
       @Param("adc") String adc,
       @Param("sup") String sup,
@@ -83,6 +151,8 @@ public interface BottomDuoStatAggJpaRepository extends JpaRepository<BottomDuoSt
       select *
       from bottom_duo_stat_agg
       where tier = :tier
+        and patch_version = :patchVersion
+        and ranking_status = 'RANKED'
         and (:adc is null or adc_champion_id = :adc)
         and (:sup is null or sup_champion_id = :sup)
       order by
@@ -91,6 +161,7 @@ public interface BottomDuoStatAggJpaRepository extends JpaRepository<BottomDuoSt
       limit :limit
       """, nativeQuery = true)
   List<BottomDuoStatAgg> findTopPickRateDesc(
+      @Param("patchVersion") String patchVersion,
       @Param("tier") String tier,
       @Param("adc") String adc,
       @Param("sup") String sup,
@@ -103,6 +174,8 @@ public interface BottomDuoStatAggJpaRepository extends JpaRepository<BottomDuoSt
       select *
       from bottom_duo_stat_agg
       where tier = :tier
+        and patch_version = :patchVersion
+        and ranking_status = 'RANKED'
         and (:adc is null or adc_champion_id = :adc)
         and (:sup is null or sup_champion_id = :sup)
       order by
@@ -111,10 +184,93 @@ public interface BottomDuoStatAggJpaRepository extends JpaRepository<BottomDuoSt
       limit :limit
       """, nativeQuery = true)
   List<BottomDuoStatAgg> findTopPickRateAsc(
+      @Param("patchVersion") String patchVersion,
       @Param("tier") String tier,
       @Param("adc") String adc,
       @Param("sup") String sup,
       @Param("totalGames") int totalGames,
+      @Param("limit") int limit
+  );
+
+  // ✅ DUO TIER ASC/DESC
+  @Query(value = """
+      select *
+      from bottom_duo_stat_agg
+      where tier = :tier
+        and patch_version = :patchVersion
+        and ranking_status = 'RANKED'
+        and (:adc is null or adc_champion_id = :adc)
+        and (:sup is null or sup_champion_id = :sup)
+      order by duo_tier asc nulls last,
+        rank_score desc
+      limit :limit
+      """, nativeQuery = true)
+  List<BottomDuoStatAgg> findTopDuoTierAsc(
+      @Param("patchVersion") String patchVersion,
+      @Param("tier") String tier,
+      @Param("adc") String adc,
+      @Param("sup") String sup,
+      @Param("limit") int limit
+  );
+
+  @Query(value = """
+      select *
+      from bottom_duo_stat_agg
+      where tier = :tier
+        and patch_version = :patchVersion
+        and ranking_status = 'RANKED'
+        and (:adc is null or adc_champion_id = :adc)
+        and (:sup is null or sup_champion_id = :sup)
+      order by duo_tier desc nulls last,
+        rank_score desc
+      limit :limit
+      """, nativeQuery = true)
+  List<BottomDuoStatAgg> findTopDuoTierDesc(
+      @Param("patchVersion") String patchVersion,
+      @Param("tier") String tier,
+      @Param("adc") String adc,
+      @Param("sup") String sup,
+      @Param("limit") int limit
+  );
+
+  // ✅ RANKING ASC/DESC
+  @Query(value = """
+      select *
+      from bottom_duo_stat_agg
+      where tier = :tier
+        and patch_version = :patchVersion
+        and ranking_status = 'RANKED'
+        and (:adc is null or adc_champion_id = :adc)
+        and (:sup is null or sup_champion_id = :sup)
+      order by ranking asc nulls last,
+        rank_score desc
+      limit :limit
+      """, nativeQuery = true)
+  List<BottomDuoStatAgg> findTopRankingAsc(
+      @Param("patchVersion") String patchVersion,
+      @Param("tier") String tier,
+      @Param("adc") String adc,
+      @Param("sup") String sup,
+      @Param("limit") int limit
+  );
+
+  @Query(value = """
+      select *
+      from bottom_duo_stat_agg
+      where tier = :tier
+        and patch_version = :patchVersion
+        and ranking_status = 'RANKED'
+        and (:adc is null or adc_champion_id = :adc)
+        and (:sup is null or sup_champion_id = :sup)
+      order by ranking desc nulls last,
+        rank_score desc
+      limit :limit
+      """, nativeQuery = true)
+  List<BottomDuoStatAgg> findTopRankingDesc(
+      @Param("patchVersion") String patchVersion,
+      @Param("tier") String tier,
+      @Param("adc") String adc,
+      @Param("sup") String sup,
       @Param("limit") int limit
   );
 }

--- a/src/main/java/com/bestduo_BE/infra/riot/LeagueEntriesSeedLoaderImpl.java
+++ b/src/main/java/com/bestduo_BE/infra/riot/LeagueEntriesSeedLoaderImpl.java
@@ -1,10 +1,13 @@
 package com.bestduo_BE.infra.riot;
 
 import com.bestduo_BE.application.port.LeagueEntriesSeedLoader;
+import com.bestduo_BE.domain.model.Tier;
 import com.bestduo_BE.infra.riot.dto.LeagueEntry;
+import com.bestduo_BE.infra.riot.dto.LeagueList;
 import com.bestduo_BE.infra.riot.exception.RiotApiException;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
@@ -17,6 +20,12 @@ public class LeagueEntriesSeedLoaderImpl implements LeagueEntriesSeedLoader {
 
   private final RestTemplate platformRestTemplate;
 
+  private static final Map<Tier, String> TOP_TIER_ENDPOINTS = Map.of(
+      Tier.CHALLENGER, "/lol/league/v4/challengerleagues/by-queue/{queue}",
+      Tier.GRANDMASTER, "/lol/league/v4/grandmasterleagues/by-queue/{queue}",
+      Tier.MASTER, "/lol/league/v4/masterleagues/by-queue/{queue}"
+  );
+
   public LeagueEntriesSeedLoaderImpl(
       @Qualifier("riotPlatformRestTemplate") RestTemplate platformRestTemplate) {
     this.platformRestTemplate = platformRestTemplate;
@@ -25,6 +34,14 @@ public class LeagueEntriesSeedLoaderImpl implements LeagueEntriesSeedLoader {
   @Override
   public List<LeagueEntry> loadEntries(String queue, String tier, String division, int page) {
     try {
+      Tier targetTier = resolveTier(tier);
+      if (isTopTier(targetTier)) {
+        if (page > 1) {
+          return List.of();
+        }
+        return loadTopTierEntries(queue, targetTier);
+      }
+
       LeagueEntry[] entries = platformRestTemplate.getForObject(
           "/lol/league/v4/entries/{queue}/{tier}/{division}?page={page}",
           LeagueEntry[].class,
@@ -43,6 +60,33 @@ public class LeagueEntriesSeedLoaderImpl implements LeagueEntriesSeedLoader {
           page,
           e);
       throw new RiotApiException("Failed to load league entries from Riot API", e);
+    }
+  }
+
+  private boolean isTopTier(Tier tier) {
+    return tier != null && TOP_TIER_ENDPOINTS.containsKey(tier);
+  }
+
+  private List<LeagueEntry> loadTopTierEntries(String queue, Tier tier) {
+    LeagueList leagueList = platformRestTemplate.getForObject(
+        TOP_TIER_ENDPOINTS.get(tier),
+        LeagueList.class,
+        queue
+    );
+    if (leagueList == null || leagueList.entries() == null) {
+      return List.of();
+    }
+    return leagueList.entries();
+  }
+
+  private Tier resolveTier(String tier) {
+    if (tier == null || tier.isBlank()) {
+      return null;
+    }
+    try {
+      return Tier.valueOf(tier.toUpperCase());
+    } catch (IllegalArgumentException ignored) {
+      return null;
     }
   }
 }

--- a/src/main/java/com/bestduo_BE/infra/riot/dto/LeagueList.java
+++ b/src/main/java/com/bestduo_BE/infra/riot/dto/LeagueList.java
@@ -1,0 +1,10 @@
+package com.bestduo_BE.infra.riot.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record LeagueList(
+    @JsonProperty("entries") List<LeagueEntry> entries
+) {}

--- a/src/main/java/com/bestduo_BE/presentation/api/BottomDuoDetailStatisticsController.java
+++ b/src/main/java/com/bestduo_BE/presentation/api/BottomDuoDetailStatisticsController.java
@@ -33,6 +33,7 @@ public class BottomDuoDetailStatisticsController {
   )
   public BottomDuoDetailStatisticsResponse getList(
       @RequestParam Tier tier,
+      @RequestParam(required = false) String patchVersion,
       @RequestParam String adcChampionId,
       @RequestParam String supChampionId,
       @RequestParam(required = false) String oppAdcChampionId,
@@ -41,6 +42,7 @@ public class BottomDuoDetailStatisticsController {
   ) {
     return useCase.execute(
         tier,
+        patchVersion,
         adcChampionId,
         supChampionId,
         oppAdcChampionId,
@@ -57,11 +59,12 @@ public class BottomDuoDetailStatisticsController {
   )
   public BottomDuoCounterResponse counters(
       @RequestParam Tier tier,
+      @RequestParam(required = false) String patchVersion,
       @RequestParam String adcChampionId,
       @RequestParam String supChampionId,
       @RequestParam(required = false) Integer size
   ) {
-    return counterUseCase.execute(tier, adcChampionId, supChampionId, size);
+    return counterUseCase.execute(tier, patchVersion, adcChampionId, supChampionId, size);
   }
 
 }

--- a/src/main/java/com/bestduo_BE/presentation/api/BottomDuoDetailStatisticsController.java
+++ b/src/main/java/com/bestduo_BE/presentation/api/BottomDuoDetailStatisticsController.java
@@ -6,6 +6,8 @@ import com.bestduo_BE.application.port.BottomDuoMatchupFinder;
 import com.bestduo_BE.domain.model.Tier;
 import com.bestduo_BE.presentation.api.dto.BottomDuoCounterResponse;
 import com.bestduo_BE.presentation.api.dto.BottomDuoDetailStatisticsResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -15,12 +17,20 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/bottom-duo")
+@Tag(
+    name = "바텀 듀오 상세 통계",
+    description = "특정 바텀 듀오의 매치업 및 카운터 정보를 상세하게 조회하는 API입니다."
+)
 public class BottomDuoDetailStatisticsController {
 
   private final ViewBottomDuoDetailStatistics useCase;
   private final ViewBottomDuoCounters counterUseCase;
 
   @GetMapping("/matchups")
+  @Operation(
+      summary = "바텀 듀오 매치업 통계 조회",
+      description = "선택한 바텀 듀오가 다른 바텀 듀오를 상대로 했던 승률, KDA, 평균 게임 시간 등 매치업 관련 상세 통계를 조회합니다."
+  )
   public BottomDuoDetailStatisticsResponse getList(
       @RequestParam Tier tier,
       @RequestParam String adcChampionId,
@@ -41,6 +51,10 @@ public class BottomDuoDetailStatisticsController {
 
   // ✅ 카운터: 최저 승률 N개만 반환
   @GetMapping("/counters")
+  @Operation(
+      summary = "바텀 듀오 카운터 조회",
+      description = "선택한 바텀 듀오에게 강한(카운터) 또는 약한 바텀 듀오 목록과 각 매치업의 승률 및 상성 정보를 조회합니다."
+  )
   public BottomDuoCounterResponse counters(
       @RequestParam Tier tier,
       @RequestParam String adcChampionId,

--- a/src/main/java/com/bestduo_BE/presentation/api/BottomDuoStatisticsController.java
+++ b/src/main/java/com/bestduo_BE/presentation/api/BottomDuoStatisticsController.java
@@ -5,6 +5,8 @@ import com.bestduo_BE.application.ViewBottomDuoStatistics;
 import com.bestduo_BE.application.port.BottomDuoStatFinder;
 import com.bestduo_BE.domain.model.Tier;
 import com.bestduo_BE.presentation.api.dto.BottomDuoStatisticsResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -14,10 +16,18 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/bottom-duo")
 @RequiredArgsConstructor
+@Tag(
+    name = "바텀 듀오 통계",
+    description = "바텀 듀오의 전반적인 통계 정보를 조회하는 API입니다."
+)
 public class BottomDuoStatisticsController {
   private final ViewBottomDuoStatistics useCase;
 
   @GetMapping("/stats")
+  @Operation(
+      summary = "바텀 듀오 전체 통계 조회",
+      description = "선택한 조건(티어, 시즌, 패치, 큐 타입 등)에 대해 바텀 듀오의 승률, 픽률, 밴률 등의 종합 통계를 조회합니다."
+  )
   public BottomDuoStatisticsResponse getList(
       @RequestParam Tier tier,
       @RequestParam(required = false) String adcChampionId,

--- a/src/main/java/com/bestduo_BE/presentation/api/BottomDuoStatisticsController.java
+++ b/src/main/java/com/bestduo_BE/presentation/api/BottomDuoStatisticsController.java
@@ -30,10 +30,11 @@ public class BottomDuoStatisticsController {
   )
   public BottomDuoStatisticsResponse getList(
       @RequestParam Tier tier,
+      @RequestParam(required = false) String patchVersion,
       @RequestParam(required = false) String adcChampionId,
       @RequestParam(required = false) String supChampionId,
       @RequestParam(defaultValue = "PICKRATE_DESC") BottomDuoStatFinder.SortKey sort
   ) {
-    return useCase.execute(tier, adcChampionId, supChampionId, sort);
+    return useCase.execute(tier, patchVersion, adcChampionId, supChampionId, sort);
   }
 }

--- a/src/main/java/com/bestduo_BE/presentation/api/SeedBootstrapController.java
+++ b/src/main/java/com/bestduo_BE/presentation/api/SeedBootstrapController.java
@@ -24,12 +24,12 @@ public class SeedBootstrapController {
       @RequestParam(defaultValue = "EMERALD") Tier seedTier,
       @RequestParam(defaultValue = "1") int startPage,
       @RequestParam(defaultValue = "3") int endPage,
-      @RequestParam(defaultValue = "10") int matchesPerPuuid
+      @RequestParam(defaultValue = "10") int matchesPerPuuid,
+      @RequestParam(defaultValue = "0") int maxEntries
   ) {
     SeedBootstrapCommand cmd = new SeedBootstrapCommand(
-        queue, tier, division, seedTier, startPage, endPage, matchesPerPuuid
+        queue, tier, division, seedTier, startPage, endPage, matchesPerPuuid, maxEntries
     );
     return useCase.execute(cmd);
   }
 }
-

--- a/src/main/java/com/bestduo_BE/presentation/api/dto/BottomDuoCounterResponse.java
+++ b/src/main/java/com/bestduo_BE/presentation/api/dto/BottomDuoCounterResponse.java
@@ -10,15 +10,19 @@ public record BottomDuoCounterResponse(
     List<Item> counters
 ) {
   public record DuoMeta(
+      String adcId,
       String adcName,
       String adcImage,
+      String supId,
       String supName,
       String supImage
   ) {}
 
   public record Item(
+      String oppAdcId,
       String oppAdcName,
       String oppAdcImage,
+      String oppSupId,
       String oppSupName,
       String oppSupImage,
       double winRate,

--- a/src/main/java/com/bestduo_BE/presentation/api/dto/BottomDuoCounterResponse.java
+++ b/src/main/java/com/bestduo_BE/presentation/api/dto/BottomDuoCounterResponse.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 public record BottomDuoCounterResponse(
     String tier,
+    String patchVersion,
     int totalGames,
     DuoMeta myDuo,
     int counterSize,

--- a/src/main/java/com/bestduo_BE/presentation/api/dto/BottomDuoDetailStatisticsResponse.java
+++ b/src/main/java/com/bestduo_BE/presentation/api/dto/BottomDuoDetailStatisticsResponse.java
@@ -9,15 +9,19 @@ public record BottomDuoDetailStatisticsResponse(
     List<Item> items
 ) {
   public record DuoMeta(
+      String adcId,
       String adcName,
       String adcImage,
+      String supId,
       String supName,
       String supImage
   ) {}
 
   public record Item(
+      String oppAdcId,
       String oppAdcName,
       String oppAdcImage,
+      String oppSupId,
       String oppSupName,
       String oppSupImage,
       double winRate,

--- a/src/main/java/com/bestduo_BE/presentation/api/dto/BottomDuoDetailStatisticsResponse.java
+++ b/src/main/java/com/bestduo_BE/presentation/api/dto/BottomDuoDetailStatisticsResponse.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 public record BottomDuoDetailStatisticsResponse(
     String tier,
+    String patchVersion,
     int totalGames,
     DuoMeta myDuo,
     List<Item> items

--- a/src/main/java/com/bestduo_BE/presentation/api/dto/BottomDuoStatisticsResponse.java
+++ b/src/main/java/com/bestduo_BE/presentation/api/dto/BottomDuoStatisticsResponse.java
@@ -8,8 +8,10 @@ public record BottomDuoStatisticsResponse(
     List<Item> items
 ) {
   public record Item(
+      String adcId,
       String adcName,
       String adcImage,
+      String supId,
       String supName,
       String supImage,
       double winRate,

--- a/src/main/java/com/bestduo_BE/presentation/api/dto/BottomDuoStatisticsResponse.java
+++ b/src/main/java/com/bestduo_BE/presentation/api/dto/BottomDuoStatisticsResponse.java
@@ -16,6 +16,9 @@ public record BottomDuoStatisticsResponse(
       String supImage,
       double winRate,
       double pickRate,
-      int games
+      int games,
+      Integer duoTier,
+      Integer ranking,
+      Integer rankDelta
   ) {}
 }

--- a/src/main/java/com/bestduo_BE/presentation/api/dto/BottomDuoStatisticsResponse.java
+++ b/src/main/java/com/bestduo_BE/presentation/api/dto/BottomDuoStatisticsResponse.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 public record BottomDuoStatisticsResponse(
     String tier,
+    String patchVersion,
     int totalGames,
     List<Item> items
 ) {

--- a/src/test/java/com/bestduo_BE/application/ComputeBottomDuoRankingTest.java
+++ b/src/test/java/com/bestduo_BE/application/ComputeBottomDuoRankingTest.java
@@ -1,0 +1,164 @@
+package com.bestduo_BE.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.bestduo_BE.infra.persistence.entity.BottomDuoStatAgg;
+import com.bestduo_BE.infra.persistence.repository.BottomDuoStatAggJpaRepository;
+import java.time.OffsetDateTime;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class ComputeBottomDuoRankingTest {
+
+  @Mock
+  private BottomDuoStatAggJpaRepository repository;
+
+  private ComputeBottomDuoRanking useCase;
+
+  @BeforeEach
+  void setUp() {
+    useCase = new ComputeBottomDuoRanking(repository);
+  }
+
+  @Test
+  void returnZeroWhenNoPatchDataExists() {
+    when(repository.findLatestPatchVersion()).thenReturn(null);
+
+    ComputeBottomDuoRanking.Result result = useCase.execute();
+
+    assertThat(result.patchVersion()).isNull();
+    assertThat(result.updatedRows()).isZero();
+    verify(repository, never()).saveAll(anyList());
+  }
+
+  @Test
+  void computeRankingAndApplyPreviousPatchDelta() {
+    OffsetDateTime now = OffsetDateTime.now();
+    BottomDuoStatAgg asheLux = BottomDuoStatAgg.builder()
+        .patchVersion("14.10")
+        .adcChampionId("Ashe")
+        .supChampionId("Lux")
+        .tier("EMERALD")
+        .wins(40)
+        .games(60)
+        .winRate(0.66)
+        .pickRate(0)
+        .adjustedWinRate(0.64)
+        .rankScore(0)
+        .ranking(null)
+        .duoTier(null)
+        .previousRanking(null)
+        .rankDelta(null)
+        .rankingStatus(BottomDuoStatAgg.RankingStatus.PENDING)
+        .createdAt(now)
+        .updatedAt(now)
+        .build();
+    BottomDuoStatAgg jinxThresh = BottomDuoStatAgg.builder()
+        .patchVersion("14.10")
+        .adcChampionId("Jinx")
+        .supChampionId("Thresh")
+        .tier("EMERALD")
+        .wins(35)
+        .games(50)
+        .winRate(0.6)
+        .pickRate(0)
+        .adjustedWinRate(0.6)
+        .rankScore(0)
+        .ranking(null)
+        .duoTier(null)
+        .previousRanking(null)
+        .rankDelta(null)
+        .rankingStatus(BottomDuoStatAgg.RankingStatus.PENDING)
+        .createdAt(now)
+        .updatedAt(now)
+        .build();
+
+    BottomDuoStatAgg prevAsheLux = BottomDuoStatAgg.builder()
+        .patchVersion("14.9")
+        .adcChampionId("Ashe")
+        .supChampionId("Lux")
+        .tier("EMERALD")
+        .wins(10)
+        .games(20)
+        .winRate(0.5)
+        .pickRate(0)
+        .adjustedWinRate(0.5)
+        .rankScore(0)
+        .ranking(4)
+        .duoTier(2)
+        .previousRanking(null)
+        .rankDelta(null)
+        .rankingStatus(BottomDuoStatAgg.RankingStatus.RANKED)
+        .createdAt(now.minusDays(10))
+        .updatedAt(now.minusDays(5))
+        .build();
+
+    when(repository.findLatestPatchVersion()).thenReturn("14.10");
+    when(repository.findByPatchVersion("14.10"))
+        .thenReturn(List.of(asheLux, jinxThresh));
+    when(repository.findPreviousPatchVersion("14.10"))
+        .thenReturn("14.9");
+    when(repository.findByPatchVersion("14.9"))
+        .thenReturn(List.of(prevAsheLux));
+
+    ComputeBottomDuoRanking.Result result = useCase.execute();
+
+    assertThat(result.patchVersion()).isEqualTo("14.10");
+    assertThat(result.updatedRows()).isEqualTo(2);
+
+    verify(repository).saveAll(List.of(asheLux, jinxThresh));
+    assertThat(asheLux.getRanking()).isEqualTo(1);
+    assertThat(asheLux.getPreviousRanking()).isEqualTo(4);
+    assertThat(asheLux.getRankDelta()).isEqualTo(3);
+    assertThat(asheLux.getRankingStatus()).isEqualTo(BottomDuoStatAgg.RankingStatus.RANKED);
+    assertThat(jinxThresh.getRanking()).isEqualTo(2);
+    assertThat(jinxThresh.getPreviousRanking()).isNull();
+    assertThat(jinxThresh.getRankingStatus()).isEqualTo(BottomDuoStatAgg.RankingStatus.RANKED);
+  }
+
+  @Test
+  void markInsufficientDataWhenGamesBelowThreshold() {
+    OffsetDateTime now = OffsetDateTime.now();
+    BottomDuoStatAgg lowSample = BottomDuoStatAgg.builder()
+        .patchVersion("14.10")
+        .adcChampionId("Ezreal")
+        .supChampionId("Yuumi")
+        .tier("EMERALD")
+        .wins(5)
+        .games(3)
+        .winRate(0.5)
+        .pickRate(0)
+        .adjustedWinRate(0.5)
+        .rankScore(0)
+        .ranking(null)
+        .duoTier(null)
+        .previousRanking(null)
+        .rankDelta(null)
+        .rankingStatus(BottomDuoStatAgg.RankingStatus.PENDING)
+        .createdAt(now)
+        .updatedAt(now)
+        .build();
+
+    when(repository.findLatestPatchVersion()).thenReturn("14.10");
+    when(repository.findByPatchVersion("14.10"))
+        .thenReturn(List.of(lowSample));
+    when(repository.findPreviousPatchVersion("14.10")).thenReturn(null);
+
+    ComputeBottomDuoRanking.Result result = useCase.execute();
+
+    assertThat(result.updatedRows()).isEqualTo(1);
+    verify(repository).saveAll(List.of(lowSample));
+    assertThat(lowSample.getRanking()).isNull();
+    assertThat(lowSample.getDuoTier()).isEqualTo(5);
+    assertThat(lowSample.getRankingStatus()).isEqualTo(BottomDuoStatAgg.RankingStatus.INSUFFICIENT);
+  }
+}

--- a/src/test/java/com/bestduo_BE/application/RunDailySessionTest.java
+++ b/src/test/java/com/bestduo_BE/application/RunDailySessionTest.java
@@ -35,7 +35,7 @@ class RunDailySessionTest {
   private QueryCountMonitor queryCountMonitor;
 
   private final SeedBootstrapCommand seedCommand = new SeedBootstrapCommand(
-      "RANKED_SOLO", "GOLD", "I", Tier.GOLD, 1, 1, 20
+      "RANKED_SOLO", "GOLD", "I", Tier.GOLD, 1, 1, 20, 0
   );
 
   @BeforeEach

--- a/src/test/java/com/bestduo_BE/application/SeedBootstrapRunTest.java
+++ b/src/test/java/com/bestduo_BE/application/SeedBootstrapRunTest.java
@@ -39,7 +39,7 @@ class SeedBootstrapRunTest {
   private SeedBootstrapRun useCase;
 
   private final SeedBootstrapCommand command = new SeedBootstrapCommand(
-      "RANKED_SOLO_5x5", "DIAMOND", "I", Tier.MASTER, 1, 1, 2
+      "RANKED_SOLO_5x5", "DIAMOND", "I", Tier.MASTER, 1, 1, 2, 0
   );
 
   @BeforeEach
@@ -101,6 +101,27 @@ class SeedBootstrapRunTest {
     verify(summonerSeedRegistry).markSeedError("p-error");
     assertThat(result.matchIdsFetched()).isZero();
     assertThat(result.matchIdsEnqueued()).isZero();
+  }
+
+  @Test
+  void limitNumberOfEntriesWhenMaxEntriesConfigured() {
+    SeedBootstrapCommand limited = new SeedBootstrapCommand(
+        "RANKED_SOLO_5x5", "MASTER", "I", Tier.MASTER, 1, 1, 2, 1
+    );
+    List<LeagueEntry> entries = List.of(entry("new-1"), entry("new-2"));
+    given(leagueEntriesSeedLoader.loadEntries(
+        limited.queue(), limited.tier(), limited.division(), 1
+    )).willReturn(entries);
+    given(summonerSeedRegistry.registerIfAbsent("new-1")).willReturn(true);
+    given(matchIdsFinder.findRecentMatchIds("new-1", limited.matchesPerPuuid()))
+        .willReturn(List.of("m-1"));
+
+    SeedBootstrapRun.SeedBootstrapResult result = useCase.execute(limited);
+
+    verify(summonerSeedRegistry).registerIfAbsent("new-1");
+    verify(summonerSeedRegistry, never()).registerIfAbsent("new-2");
+    assertThat(result.entriesFetched()).isEqualTo(1);
+    assertThat(result.puuidRegistered()).isEqualTo(1);
   }
 
   private void givenEntries(List<LeagueEntry> entries) {

--- a/src/test/java/com/bestduo_BE/application/ViewBottomDuoCountersTest.java
+++ b/src/test/java/com/bestduo_BE/application/ViewBottomDuoCountersTest.java
@@ -34,11 +34,12 @@ class ViewBottomDuoCountersTest {
 
   @Test
   void executeUsesDefaultCounterSizeAndMapsResponse() {
-    given(matchupFinder.findMyDuoTotalGames(Tier.DIAMOND, "ashe", "lux")).willReturn(80);
+    given(matchupFinder.resolvePatchVersion(null)).willReturn("14.10");
+    given(matchupFinder.findMyDuoTotalGames(Tier.DIAMOND, "14.10", "ashe", "lux")).willReturn(80);
     BottomDuoMatchupFinder.MatchupRow row = new BottomDuoMatchupFinder.MatchupRow(
         "ashe", "lux", "draven", "pyke", Tier.DIAMOND, 30, 40
     );
-    given(matchupFinder.findCountersByLowestWinRate(Tier.DIAMOND, "ashe", "lux", 10))
+    given(matchupFinder.findCountersByLowestWinRate(Tier.DIAMOND, "14.10", "ashe", "lux", 10))
         .willReturn(List.of(row));
 
     stubChampionMeta("ashe", "Ashe", "ashe.png");
@@ -46,9 +47,10 @@ class ViewBottomDuoCountersTest {
     stubChampionMeta("draven", "Draven", "draven.png");
     stubChampionMeta("pyke", "Pyke", "pyke.png");
 
-    BottomDuoCounterResponse response = useCase.execute(Tier.DIAMOND, "ashe", "lux", null);
+    BottomDuoCounterResponse response = useCase.execute(Tier.DIAMOND, null, "ashe", "lux", null);
 
     assertEquals("DIAMOND", response.tier());
+    assertEquals("14.10", response.patchVersion());
     assertEquals(80, response.totalGames());
     assertEquals(10, response.counterSize());
     assertEquals("ashe", response.myDuo().adcId());
@@ -64,35 +66,37 @@ class ViewBottomDuoCountersTest {
     assertEquals(row.winRate(), item.winRate(), 1e-9);
     assertEquals(0.5, item.pickRate(), 1e-9);
     assertEquals(40, item.games());
-    then(matchupFinder).should().findCountersByLowestWinRate(Tier.DIAMOND, "ashe", "lux", 10);
+    then(matchupFinder).should().findCountersByLowestWinRate(Tier.DIAMOND, "14.10", "ashe", "lux", 10);
   }
 
   @Test
   void executeClampsCounterSizeToAtLeastOne() {
-    given(matchupFinder.findMyDuoTotalGames(Tier.GOLD, "ashe", "lux")).willReturn(0);
-    given(matchupFinder.findCountersByLowestWinRate(Tier.GOLD, "ashe", "lux", 1))
+    given(matchupFinder.resolvePatchVersion(null)).willReturn("14.9");
+    given(matchupFinder.findMyDuoTotalGames(Tier.GOLD, "14.9", "ashe", "lux")).willReturn(0);
+    given(matchupFinder.findCountersByLowestWinRate(Tier.GOLD, "14.9", "ashe", "lux", 1))
         .willReturn(List.of());
     stubChampionMeta("ashe", "Ashe", "ashe.png");
     stubChampionMeta("lux", "Lux", "lux.png");
 
-    BottomDuoCounterResponse response = useCase.execute(Tier.GOLD, "ashe", "lux", 0);
+    BottomDuoCounterResponse response = useCase.execute(Tier.GOLD, null, "ashe", "lux", 0);
 
     assertEquals(1, response.counterSize());
-    then(matchupFinder).should().findCountersByLowestWinRate(Tier.GOLD, "ashe", "lux", 1);
+    then(matchupFinder).should().findCountersByLowestWinRate(Tier.GOLD, "14.9", "ashe", "lux", 1);
   }
 
   @Test
   void executeClampsCounterSizeToAtMostFifty() {
-    given(matchupFinder.findMyDuoTotalGames(Tier.PLATINUM, "ashe", "lux")).willReturn(0);
-    given(matchupFinder.findCountersByLowestWinRate(Tier.PLATINUM, "ashe", "lux", 50))
+    given(matchupFinder.resolvePatchVersion(null)).willReturn("14.7");
+    given(matchupFinder.findMyDuoTotalGames(Tier.PLATINUM, "14.7", "ashe", "lux")).willReturn(0);
+    given(matchupFinder.findCountersByLowestWinRate(Tier.PLATINUM, "14.7", "ashe", "lux", 50))
         .willReturn(List.of());
     stubChampionMeta("ashe", "Ashe", "ashe.png");
     stubChampionMeta("lux", "Lux", "lux.png");
 
-    BottomDuoCounterResponse response = useCase.execute(Tier.PLATINUM, "ashe", "lux", 100);
+    BottomDuoCounterResponse response = useCase.execute(Tier.PLATINUM, null, "ashe", "lux", 100);
 
     assertEquals(50, response.counterSize());
-    then(matchupFinder).should().findCountersByLowestWinRate(Tier.PLATINUM, "ashe", "lux", 50);
+    then(matchupFinder).should().findCountersByLowestWinRate(Tier.PLATINUM, "14.7", "ashe", "lux", 50);
   }
 
   private void stubChampionMeta(String id, String name, String imageUrl) {

--- a/src/test/java/com/bestduo_BE/application/ViewBottomDuoCountersTest.java
+++ b/src/test/java/com/bestduo_BE/application/ViewBottomDuoCountersTest.java
@@ -51,11 +51,15 @@ class ViewBottomDuoCountersTest {
     assertEquals("DIAMOND", response.tier());
     assertEquals(80, response.totalGames());
     assertEquals(10, response.counterSize());
+    assertEquals("ashe", response.myDuo().adcId());
     assertEquals("Ashe", response.myDuo().adcName());
+    assertEquals("lux", response.myDuo().supId());
     assertEquals("Lux", response.myDuo().supName());
     assertEquals(1, response.counters().size());
     BottomDuoCounterResponse.Item item = response.counters().get(0);
+    assertEquals("draven", item.oppAdcId());
     assertEquals("Draven", item.oppAdcName());
+    assertEquals("pyke", item.oppSupId());
     assertEquals("Pyke", item.oppSupName());
     assertEquals(row.winRate(), item.winRate(), 1e-9);
     assertEquals(0.5, item.pickRate(), 1e-9);

--- a/src/test/java/com/bestduo_BE/application/ViewBottomDuoDetailStatisticsTest.java
+++ b/src/test/java/com/bestduo_BE/application/ViewBottomDuoDetailStatisticsTest.java
@@ -67,10 +67,14 @@ class ViewBottomDuoDetailStatisticsTest {
 
     assertEquals("EMERALD", response.tier());
     assertEquals(120, response.totalGames());
+    assertEquals("ashe", response.myDuo().adcId());
     assertEquals("Ashe", response.myDuo().adcName());
+    assertEquals("lux", response.myDuo().supId());
     assertEquals(1, response.items().size());
     BottomDuoDetailStatisticsResponse.Item item = response.items().get(0);
+    assertEquals("jinx", item.oppAdcId());
     assertEquals("Jinx", item.oppAdcName());
+    assertEquals("morgana", item.oppSupId());
     assertEquals("Morgana", item.oppSupName());
     assertEquals(row.winRate(), item.winRate(), 1e-9);
     assertEquals(40.0 / 120.0, item.pickRate(), 1e-9);

--- a/src/test/java/com/bestduo_BE/application/ViewBottomDuoDetailStatisticsTest.java
+++ b/src/test/java/com/bestduo_BE/application/ViewBottomDuoDetailStatisticsTest.java
@@ -36,12 +36,14 @@ class ViewBottomDuoDetailStatisticsTest {
 
   @Test
   void executeBuildsResponseWithPickRates() {
-    given(matchupFinder.findMyDuoTotalGames(Tier.EMERALD, "ashe", "lux")).willReturn(120);
+    given(matchupFinder.resolvePatchVersion(null)).willReturn("14.10");
+    given(matchupFinder.findMyDuoTotalGames(Tier.EMERALD, "14.10", "ashe", "lux")).willReturn(120);
     BottomDuoMatchupFinder.MatchupRow row = new BottomDuoMatchupFinder.MatchupRow(
         "ashe", "lux", "jinx", "morgana", Tier.EMERALD, 60, 40
     );
     given(matchupFinder.findMatchups(
         Tier.EMERALD,
+        "14.10",
         "ashe",
         "lux",
         "jinx",
@@ -58,6 +60,7 @@ class ViewBottomDuoDetailStatisticsTest {
 
     BottomDuoDetailStatisticsResponse response = useCase.execute(
         Tier.EMERALD,
+        null,
         "ashe",
         "lux",
         "jinx",
@@ -66,6 +69,7 @@ class ViewBottomDuoDetailStatisticsTest {
     );
 
     assertEquals("EMERALD", response.tier());
+    assertEquals("14.10", response.patchVersion());
     assertEquals(120, response.totalGames());
     assertEquals("ashe", response.myDuo().adcId());
     assertEquals("Ashe", response.myDuo().adcName());
@@ -83,9 +87,11 @@ class ViewBottomDuoDetailStatisticsTest {
 
   @Test
   void executeNormalizesOpponentFiltersAndCapsRows() {
-    given(matchupFinder.findMyDuoTotalGames(Tier.GOLD, "ashe", "lux")).willReturn(0);
+    given(matchupFinder.resolvePatchVersion(null)).willReturn("14.8");
+    given(matchupFinder.findMyDuoTotalGames(Tier.GOLD, "14.8", "ashe", "lux")).willReturn(0);
     given(matchupFinder.findMatchups(
         Tier.GOLD,
+        "14.8",
         "ashe",
         "lux",
         null,
@@ -99,6 +105,7 @@ class ViewBottomDuoDetailStatisticsTest {
 
     useCase.execute(
         Tier.GOLD,
+        null,
         "ashe",
         "lux",
         "  ",
@@ -108,6 +115,7 @@ class ViewBottomDuoDetailStatisticsTest {
 
     then(matchupFinder).should().findMatchups(
         eq(Tier.GOLD),
+        eq("14.8"),
         eq("ashe"),
         eq("lux"),
         isNull(),

--- a/src/test/java/com/bestduo_BE/infra/persistence/BottomDuoMatchupFinderImplTest.java
+++ b/src/test/java/com/bestduo_BE/infra/persistence/BottomDuoMatchupFinderImplTest.java
@@ -34,17 +34,35 @@ class BottomDuoMatchupFinderImplTest {
 
   @Test
   void findMyDuoTotalGamesDelegatesToRepository() {
-    given(repository.sumGamesOfMyDuo("DIAMOND", "ashe", "lux")).willReturn(87);
+    given(repository.sumGamesOfMyDuo("14.9", "DIAMOND", "ashe", "lux")).willReturn(87);
 
-    int totalGames = finder.findMyDuoTotalGames(Tier.DIAMOND, "ashe", "lux");
+    int totalGames = finder.findMyDuoTotalGames(Tier.DIAMOND, "14.9", "ashe", "lux");
 
     assertEquals(87, totalGames);
+  }
+
+  @Test
+  void resolvePatchVersionPrefersProvidedValue() {
+    String patch = finder.resolvePatchVersion(" 14.8 ");
+
+    assertEquals("14.8", patch);
+  }
+
+  @Test
+  void resolvePatchVersionFallsBackToRepository() {
+    given(repository.findLatestPatchVersion()).willReturn("14.10");
+
+    String patch = finder.resolvePatchVersion(null);
+
+    assertEquals("14.10", patch);
+    then(repository).should().findLatestPatchVersion();
   }
 
   @Test
   void findMatchupsWinRateDescMapsEntitiesAndTrimsOpponentFilters() {
     OffsetDateTime now = OffsetDateTime.now();
     BottomDuoMatchupAgg entity = BottomDuoMatchupAgg.builder()
+        .patchVersion("14.10")
         .myAdcChampionId("ashe")
         .mySupChampionId("lux")
         .oppAdcChampionId("jinx")
@@ -55,11 +73,12 @@ class BottomDuoMatchupFinderImplTest {
         .createdAt(now)
         .updatedAt(now)
         .build();
-    given(repository.findTopWinRateDesc(eq("DIAMOND"), eq("ashe"), eq("lux"), isNull(), isNull(), eq(5)))
+    given(repository.findTopWinRateDesc(eq("14.10"), eq("DIAMOND"), eq("ashe"), eq("lux"), isNull(), isNull(), eq(5)))
         .willReturn(List.of(entity));
 
     List<BottomDuoMatchupFinder.MatchupRow> rows = finder.findMatchups(
         Tier.DIAMOND,
+        "14.10",
         "ashe",
         "lux",
         "   ",
@@ -82,11 +101,12 @@ class BottomDuoMatchupFinderImplTest {
 
   @Test
   void findMatchupsWinRateAscCallsRepository() {
-    given(repository.findTopWinRateAsc("DIAMOND", "ashe", "lux", "jinx", "morgana", 3))
+    given(repository.findTopWinRateAsc("14.10", "DIAMOND", "ashe", "lux", "jinx", "morgana", 3))
         .willReturn(List.of());
 
     finder.findMatchups(
         Tier.DIAMOND,
+        "14.10",
         "ashe",
         "lux",
         "jinx",
@@ -96,16 +116,17 @@ class BottomDuoMatchupFinderImplTest {
         3
     );
 
-    then(repository).should().findTopWinRateAsc("DIAMOND", "ashe", "lux", "jinx", "morgana", 3);
+    then(repository).should().findTopWinRateAsc("14.10", "DIAMOND", "ashe", "lux", "jinx", "morgana", 3);
   }
 
   @Test
   void findMatchupsPickRateDescEnforcesMinimumLimit() {
-    given(repository.findTopPickRateDesc("DIAMOND", "ashe", "lux", "jinx", null, 200, 1))
+    given(repository.findTopPickRateDesc("14.10", "DIAMOND", "ashe", "lux", "jinx", null, 200, 1))
         .willReturn(List.of());
 
     finder.findMatchups(
         Tier.DIAMOND,
+        "14.10",
         "ashe",
         "lux",
         "jinx",
@@ -115,16 +136,17 @@ class BottomDuoMatchupFinderImplTest {
         0
     );
 
-    then(repository).should().findTopPickRateDesc("DIAMOND", "ashe", "lux", "jinx", null, 200, 1);
+    then(repository).should().findTopPickRateDesc("14.10", "DIAMOND", "ashe", "lux", "jinx", null, 200, 1);
   }
 
   @Test
   void findMatchupsPickRateAscPassesThroughMyTotalGames() {
-    given(repository.findTopPickRateAsc("DIAMOND", "ashe", "lux", null, null, 321, 4))
+    given(repository.findTopPickRateAsc("14.10", "DIAMOND", "ashe", "lux", null, null, 321, 4))
         .willReturn(List.of());
 
     finder.findMatchups(
         Tier.DIAMOND,
+        "14.10",
         "ashe",
         "lux",
         null,
@@ -134,13 +156,14 @@ class BottomDuoMatchupFinderImplTest {
         4
     );
 
-    then(repository).should().findTopPickRateAsc("DIAMOND", "ashe", "lux", null, null, 321, 4);
+    then(repository).should().findTopPickRateAsc("14.10", "DIAMOND", "ashe", "lux", null, null, 321, 4);
   }
 
   @Test
   void findCountersByLowestWinRateMapsEntitiesAndAppliesLimitFloor() {
     OffsetDateTime now = OffsetDateTime.now();
     BottomDuoMatchupAgg entity = BottomDuoMatchupAgg.builder()
+        .patchVersion("14.10")
         .myAdcChampionId("xayah")
         .mySupChampionId("rakan")
         .oppAdcChampionId("draven")
@@ -151,17 +174,18 @@ class BottomDuoMatchupFinderImplTest {
         .createdAt(now)
         .updatedAt(now)
         .build();
-    given(repository.findCountersByLowestWinRate("GOLD", "xayah", "rakan", 1))
+    given(repository.findCountersByLowestWinRate("14.10", "GOLD", "xayah", "rakan", 1))
         .willReturn(List.of(entity));
 
     List<BottomDuoMatchupFinder.MatchupRow> rows = finder.findCountersByLowestWinRate(
         Tier.GOLD,
+        "14.10",
         "xayah",
         "rakan",
         0
     );
 
-    then(repository).should().findCountersByLowestWinRate("GOLD", "xayah", "rakan", 1);
+    then(repository).should().findCountersByLowestWinRate("14.10", "GOLD", "xayah", "rakan", 1);
     assertEquals(1, rows.size());
     BottomDuoMatchupFinder.MatchupRow row = rows.get(0);
     assertEquals("xayah", row.myAdcChampionId());

--- a/src/test/java/com/bestduo_BE/infra/persistence/BottomDuoStatFinderImplTest.java
+++ b/src/test/java/com/bestduo_BE/infra/persistence/BottomDuoStatFinderImplTest.java
@@ -56,6 +56,24 @@ class BottomDuoStatFinderImplTest {
   }
 
   @Test
+  void resolvePatchVersionPrefersProvidedValue() {
+    String patch = finder.resolvePatchVersion(" 14.9 ");
+
+    assertThat(patch).isEqualTo("14.9");
+    verify(repository, never()).findLatestPatchVersion();
+  }
+
+  @Test
+  void resolvePatchVersionFallsBackToLatest() {
+    when(repository.findLatestPatchVersion()).thenReturn("14.10");
+
+    String patch = finder.resolvePatchVersion(null);
+
+    assertThat(patch).isEqualTo("14.10");
+    verify(repository).findLatestPatchVersion();
+  }
+
+  @Test
   void findStatsMapsEntitiesForWinRateDesc() {
     OffsetDateTime now = OffsetDateTime.now();
     BottomDuoStatAgg entity = BottomDuoStatAgg.builder()

--- a/src/test/java/com/bestduo_BE/infra/persistence/BottomDuoStatFinderImplTest.java
+++ b/src/test/java/com/bestduo_BE/infra/persistence/BottomDuoStatFinderImplTest.java
@@ -2,6 +2,7 @@ package com.bestduo_BE.infra.persistence;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -33,32 +34,57 @@ class BottomDuoStatFinderImplTest {
 
   @Test
   void findTierTotalGamesDelegatesToRepository() {
-    when(repository.sumGamesByTier("GOLD")).thenReturn(128);
+    when(repository.findLatestPatchVersion()).thenReturn("14.10");
+    when(repository.sumGamesByTier("14.10", "GOLD")).thenReturn(128);
 
-    int games = finder.findTierTotalGames(Tier.GOLD);
+    int games = finder.findTierTotalGames(Tier.GOLD, null);
 
     assertThat(games).isEqualTo(128);
-    verify(repository).sumGamesByTier("GOLD");
+    verify(repository).findLatestPatchVersion();
+    verify(repository).sumGamesByTier("14.10", "GOLD");
+  }
+
+  @Test
+  void findTierTotalGamesUsesProvidedPatchVersion() {
+    when(repository.sumGamesByTier("14.9", "GOLD")).thenReturn(222);
+
+    int games = finder.findTierTotalGames(Tier.GOLD, "14.9");
+
+    assertThat(games).isEqualTo(222);
+    verify(repository).sumGamesByTier("14.9", "GOLD");
+    verify(repository, never()).findLatestPatchVersion();
   }
 
   @Test
   void findStatsMapsEntitiesForWinRateDesc() {
     OffsetDateTime now = OffsetDateTime.now();
     BottomDuoStatAgg entity = BottomDuoStatAgg.builder()
+        .patchVersion("14.10")
         .adcChampionId("Ashe")
         .supChampionId("Lux")
         .tier(Tier.EMERALD.name())
         .wins(30)
         .games(50)
+        .winRate(0.6)
+        .pickRate(0.1)
+        .adjustedWinRate(0.55)
+        .rankScore(0.0)
+        .ranking(1)
+        .duoTier(0)
+        .previousRanking(2)
+        .rankDelta(1)
+        .rankingStatus(BottomDuoStatAgg.RankingStatus.RANKED)
         .createdAt(now)
         .updatedAt(now)
         .build();
 
-    when(repository.findTopWinRateDesc("EMERALD", "Ashe", "Lux", 3))
+    when(repository.findLatestPatchVersion()).thenReturn("14.10");
+    when(repository.findTopWinRateDesc("14.10", "EMERALD", "Ashe", "Lux", 3))
         .thenReturn(List.of(entity));
 
     List<BottomDuoStatFinder.StatRow> rows = finder.findStats(
         Tier.EMERALD,
+        null,
         "Ashe",
         "Lux",
         BottomDuoStatFinder.SortKey.WINRATE_DESC,
@@ -72,16 +98,40 @@ class BottomDuoStatFinderImplTest {
     assertThat(row.tier()).isEqualTo(Tier.EMERALD);
     assertThat(row.wins()).isEqualTo(30);
     assertThat(row.games()).isEqualTo(50);
-    verify(repository).findTopWinRateDesc("EMERALD", "Ashe", "Lux", 3);
+    assertThat(row.duoTier()).isEqualTo(0);
+    assertThat(row.ranking()).isEqualTo(1);
+    assertThat(row.rankDelta()).isEqualTo(1);
+    verify(repository).findLatestPatchVersion();
+    verify(repository).findTopWinRateDesc("14.10", "EMERALD", "Ashe", "Lux", 3);
+  }
+
+  @Test
+  void findStatsUsesProvidedPatchVersionWhenPresent() {
+    when(repository.findTopWinRateDesc("14.9", "GOLD", null, null, 2))
+        .thenReturn(List.of());
+
+    finder.findStats(
+        Tier.GOLD,
+        "14.9",
+        null,
+        null,
+        BottomDuoStatFinder.SortKey.WINRATE_DESC,
+        0,
+        2);
+
+    verify(repository).findTopWinRateDesc("14.9", "GOLD", null, null, 2);
+    verify(repository, never()).findLatestPatchVersion();
   }
 
   @Test
   void findStatsTrimsInputsAndEnforcesMinimumLimitForWinRateAsc() {
-    when(repository.findTopWinRateAsc("SILVER", "Caitlyn", null, 1))
+    when(repository.findLatestPatchVersion()).thenReturn("14.10");
+    when(repository.findTopWinRateAsc("14.10", "SILVER", "Caitlyn", null, 1))
         .thenReturn(List.of());
 
     finder.findStats(
         Tier.SILVER,
+        null,
         "  Caitlyn  ",
         "   ",
         BottomDuoStatFinder.SortKey.WINRATE_ASC,
@@ -92,7 +142,9 @@ class BottomDuoStatFinderImplTest {
     ArgumentCaptor<String> supCaptor = ArgumentCaptor.forClass(String.class);
     ArgumentCaptor<Integer> limitCaptor = ArgumentCaptor.forClass(Integer.class);
 
+    verify(repository).findLatestPatchVersion();
     verify(repository).findTopWinRateAsc(
+        eq("14.10"),
         eq("SILVER"),
         adcCaptor.capture(),
         supCaptor.capture(),
@@ -105,33 +157,77 @@ class BottomDuoStatFinderImplTest {
 
   @Test
   void findStatsPassesTierTotalGamesForPickRateDesc() {
-    when(repository.findTopPickRateDesc("DIAMOND", null, null, 777, 5))
+    when(repository.findLatestPatchVersion()).thenReturn("14.10");
+    when(repository.findTopPickRateDesc("14.10", "DIAMOND", null, null, 777, 5))
         .thenReturn(List.of());
 
     finder.findStats(
         Tier.DIAMOND,
         null,
         null,
+        null,
         BottomDuoStatFinder.SortKey.PICKRATE_DESC,
         777,
         5);
 
-    verify(repository).findTopPickRateDesc("DIAMOND", null, null, 777, 5);
+    verify(repository).findLatestPatchVersion();
+    verify(repository).findTopPickRateDesc("14.10", "DIAMOND", null, null, 777, 5);
   }
 
   @Test
   void findStatsUsesPickRateAscQuery() {
-    when(repository.findTopPickRateAsc("BRONZE", null, "Thresh", 321, 2))
+    when(repository.findLatestPatchVersion()).thenReturn("14.10");
+    when(repository.findTopPickRateAsc("14.10", "BRONZE", null, "Thresh", 321, 2))
         .thenReturn(List.of());
 
     finder.findStats(
         Tier.BRONZE,
+        null,
         null,
         "Thresh",
         BottomDuoStatFinder.SortKey.PICKRATE_ASC,
         321,
         2);
 
-    verify(repository).findTopPickRateAsc("BRONZE", null, "Thresh", 321, 2);
+    verify(repository).findLatestPatchVersion();
+    verify(repository).findTopPickRateAsc("14.10", "BRONZE", null, "Thresh", 321, 2);
+  }
+
+  @Test
+  void findStatsUsesDuoTierAscQuery() {
+    when(repository.findLatestPatchVersion()).thenReturn("14.10");
+    when(repository.findTopDuoTierAsc("14.10", "PLATINUM", null, null, 4))
+        .thenReturn(List.of());
+
+    finder.findStats(
+        Tier.PLATINUM,
+        null,
+        null,
+        null,
+        BottomDuoStatFinder.SortKey.DUO_TIER_ASC,
+        0,
+        4);
+
+    verify(repository).findLatestPatchVersion();
+    verify(repository).findTopDuoTierAsc("14.10", "PLATINUM", null, null, 4);
+  }
+
+  @Test
+  void findStatsUsesRankingDescQuery() {
+    when(repository.findLatestPatchVersion()).thenReturn("14.10");
+    when(repository.findTopRankingDesc("14.10", "GOLD", "Senna", null, 6))
+        .thenReturn(List.of());
+
+    finder.findStats(
+        Tier.GOLD,
+        null,
+        "Senna",
+        null,
+        BottomDuoStatFinder.SortKey.RANKING_DESC,
+        0,
+        6);
+
+    verify(repository).findLatestPatchVersion();
+    verify(repository).findTopRankingDesc("14.10", "GOLD", "Senna", null, 6);
   }
 }

--- a/src/test/java/com/bestduo_BE/infra/riot/LeagueEntriesSeedLoaderImplTest.java
+++ b/src/test/java/com/bestduo_BE/infra/riot/LeagueEntriesSeedLoaderImplTest.java
@@ -6,8 +6,10 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 import com.bestduo_BE.infra.riot.dto.LeagueEntry;
+import com.bestduo_BE.infra.riot.dto.LeagueList;
 import com.bestduo_BE.infra.riot.exception.RiotApiException;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
@@ -32,43 +34,43 @@ class LeagueEntriesSeedLoaderImplTest {
   }
 
   @Test
-  void loadEntries_returnsEntriesFromPlatformEndpoint() {
-    LeagueEntry entry1 = new LeagueEntry("puuid-1", "MASTER", "RANKED_SOLO_5x5", "I", 100L);
-    LeagueEntry entry2 = new LeagueEntry("puuid-2", "MASTER", "RANKED_SOLO_5x5", "I", 80L);
+  void loadEntries_returnsEntriesFromPaginatedEndpoint() {
+    LeagueEntry entry1 = new LeagueEntry("puuid-1", "DIAMOND", "RANKED_SOLO_5x5", "I", 100L);
+    LeagueEntry entry2 = new LeagueEntry("puuid-2", "DIAMOND", "RANKED_SOLO_5x5", "I", 80L);
     given(platformRestTemplate.getForObject(
         "/lol/league/v4/entries/{queue}/{tier}/{division}?page={page}",
         LeagueEntry[].class,
         "RANKED_SOLO_5x5",
-        "MASTER",
+        "DIAMOND",
         "I",
         3
     )).willReturn(new LeagueEntry[]{entry1, entry2});
 
-    List<LeagueEntry> result = loader.loadEntries("RANKED_SOLO_5x5", "MASTER", "I", 3);
+    List<LeagueEntry> result = loader.loadEntries("RANKED_SOLO_5x5", "DIAMOND", "I", 3);
 
     assertEquals(List.of(entry1, entry2), result);
     then(platformRestTemplate).should().getForObject(
         eq("/lol/league/v4/entries/{queue}/{tier}/{division}?page={page}"),
         eq(LeagueEntry[].class),
         eq("RANKED_SOLO_5x5"),
-        eq("MASTER"),
+        eq("DIAMOND"),
         eq("I"),
         eq(3)
     );
   }
 
   @Test
-  void loadEntries_returnsEmptyListWhenApiReturnsNull() {
+  void loadEntries_returnsEmptyListWhenPaginatedApiReturnsNull() {
     given(platformRestTemplate.getForObject(
         "/lol/league/v4/entries/{queue}/{tier}/{division}?page={page}",
         LeagueEntry[].class,
         "RANKED_FLEX_SR",
-        "CHALLENGER",
+        "PLATINUM",
         "II",
         1
     )).willReturn(null);
 
-    List<LeagueEntry> result = loader.loadEntries("RANKED_FLEX_SR", "CHALLENGER", "II", 1);
+    List<LeagueEntry> result = loader.loadEntries("RANKED_FLEX_SR", "PLATINUM", "II", 1);
 
     assertTrue(result.isEmpty());
   }
@@ -86,5 +88,55 @@ class LeagueEntriesSeedLoaderImplTest {
 
     assertThrows(RiotApiException.class,
         () -> loader.loadEntries("RANKED_SOLO_5x5", "DIAMOND", "III", 2));
+  }
+
+  @Test
+  void loadEntries_fetchesTopTierEntriesFromDedicatedEndpoint() {
+    LeagueEntry entry1 = new LeagueEntry("puuid-1", "CHALLENGER", "RANKED_SOLO_5x5", "I", 500L);
+    LeagueEntry entry2 = new LeagueEntry("puuid-2", "CHALLENGER", "RANKED_SOLO_5x5", "I", 450L);
+    LeagueList leagueList = new LeagueList(List.of(entry1, entry2));
+    given(platformRestTemplate.getForObject(
+        "/lol/league/v4/challengerleagues/by-queue/{queue}",
+        LeagueList.class,
+        "RANKED_SOLO_5x5"
+    )).willReturn(leagueList);
+
+    List<LeagueEntry> result = loader.loadEntries("RANKED_SOLO_5x5", "CHALLENGER", "I", 1);
+
+    assertEquals(List.of(entry1, entry2), result);
+    then(platformRestTemplate).should().getForObject(
+        eq("/lol/league/v4/challengerleagues/by-queue/{queue}"),
+        eq(LeagueList.class),
+        eq("RANKED_SOLO_5x5")
+    );
+  }
+
+  @Test
+  void loadEntries_fetchesMasterTierEntriesFromDedicatedEndpoint() {
+    LeagueEntry entry1 = new LeagueEntry("puuid-3", "MASTER", "RANKED_SOLO_5x5", "I", 250L);
+    LeagueEntry entry2 = new LeagueEntry("puuid-4", "MASTER", "RANKED_SOLO_5x5", "I", 200L);
+    LeagueList leagueList = new LeagueList(List.of(entry1, entry2));
+    given(platformRestTemplate.getForObject(
+        "/lol/league/v4/masterleagues/by-queue/{queue}",
+        LeagueList.class,
+        "RANKED_SOLO_5x5"
+    )).willReturn(leagueList);
+
+    List<LeagueEntry> result = loader.loadEntries("RANKED_SOLO_5x5", "MASTER", "I", 1);
+
+    assertEquals(List.of(entry1, entry2), result);
+    then(platformRestTemplate).should().getForObject(
+        eq("/lol/league/v4/masterleagues/by-queue/{queue}"),
+        eq(LeagueList.class),
+        eq("RANKED_SOLO_5x5")
+    );
+  }
+
+  @Test
+  void loadEntries_returnsEmptyListForTopTierWhenPageGreaterThanOne() {
+    List<LeagueEntry> result = loader.loadEntries("RANKED_SOLO_5x5", "MASTER", "I", 2);
+
+    assertTrue(result.isEmpty());
+    verifyNoInteractions(platformRestTemplate);
   }
 }

--- a/src/test/java/com/bestduo_BE/presentation/api/BottomDuoAggregateControllerTest.java
+++ b/src/test/java/com/bestduo_BE/presentation/api/BottomDuoAggregateControllerTest.java
@@ -27,7 +27,7 @@ class BottomDuoAggregateControllerTest {
 
   @Test
   void aggregateReturnsUseCaseResult() throws Exception {
-    AggregateBottomDuoStat.Result result = new AggregateBottomDuoStat.Result(10);
+    AggregateBottomDuoStat.Result result = new AggregateBottomDuoStat.Result(10, 7);
     when(aggregateBottomDuoStat.execute()).thenReturn(result);
 
     mockMvc.perform(post("/admin/aggregate/bottom-duo-stat"))

--- a/src/test/java/com/bestduo_BE/presentation/api/BottomDuoDetailStatisticsControllerTest.java
+++ b/src/test/java/com/bestduo_BE/presentation/api/BottomDuoDetailStatisticsControllerTest.java
@@ -38,6 +38,7 @@ class BottomDuoDetailStatisticsControllerTest {
   void listReturnsUseCaseResponse() throws Exception {
     BottomDuoDetailStatisticsResponse response = new BottomDuoDetailStatisticsResponse(
         "GOLD",
+        "14.10",
         200,
         new BottomDuoDetailStatisticsResponse.DuoMeta("ashe", "Ashe", "a.png", "lux", "Lux", "l.png"),
         List.of(new BottomDuoDetailStatisticsResponse.Item(
@@ -55,6 +56,7 @@ class BottomDuoDetailStatisticsControllerTest {
 
     when(viewBottomDuoDetailStatistics.execute(
         Tier.GOLD,
+        "14.10",
         "ashe",
         "lux",
         "jinx",
@@ -64,6 +66,7 @@ class BottomDuoDetailStatisticsControllerTest {
 
     mockMvc.perform(get("/bottom-duo/matchups")
             .param("tier", "GOLD")
+            .param("patchVersion", "14.10")
             .param("adcChampionId", "ashe")
             .param("supChampionId", "lux")
             .param("oppAdcChampionId", "jinx")
@@ -74,6 +77,7 @@ class BottomDuoDetailStatisticsControllerTest {
 
     verify(viewBottomDuoDetailStatistics).execute(
         Tier.GOLD,
+        "14.10",
         "ashe",
         "lux",
         "jinx",
@@ -86,22 +90,24 @@ class BottomDuoDetailStatisticsControllerTest {
   void countersReturnsCounterUseCaseResponse() throws Exception {
     BottomDuoCounterResponse response = new BottomDuoCounterResponse(
         "DIAMOND",
+        "14.9",
         500,
         new BottomDuoCounterResponse.DuoMeta("ashe", "Ashe", "a.png", "lux", "Lux", "l.png"),
         5,
         List.of()
     );
 
-    when(viewBottomDuoCounters.execute(Tier.DIAMOND, "ashe", "lux", 5)).thenReturn(response);
+    when(viewBottomDuoCounters.execute(Tier.DIAMOND, "14.9", "ashe", "lux", 5)).thenReturn(response);
 
     mockMvc.perform(get("/bottom-duo/counters")
             .param("tier", "DIAMOND")
+            .param("patchVersion", "14.9")
             .param("adcChampionId", "ashe")
             .param("supChampionId", "lux")
             .param("size", "5"))
         .andExpect(status().isOk())
         .andExpect(content().json(objectMapper.writeValueAsString(response)));
 
-    verify(viewBottomDuoCounters).execute(Tier.DIAMOND, "ashe", "lux", 5);
+    verify(viewBottomDuoCounters).execute(Tier.DIAMOND, "14.9", "ashe", "lux", 5);
   }
 }

--- a/src/test/java/com/bestduo_BE/presentation/api/BottomDuoDetailStatisticsControllerTest.java
+++ b/src/test/java/com/bestduo_BE/presentation/api/BottomDuoDetailStatisticsControllerTest.java
@@ -39,10 +39,12 @@ class BottomDuoDetailStatisticsControllerTest {
     BottomDuoDetailStatisticsResponse response = new BottomDuoDetailStatisticsResponse(
         "GOLD",
         200,
-        new BottomDuoDetailStatisticsResponse.DuoMeta("Ashe", "a.png", "Lux", "l.png"),
+        new BottomDuoDetailStatisticsResponse.DuoMeta("ashe", "Ashe", "a.png", "lux", "Lux", "l.png"),
         List.of(new BottomDuoDetailStatisticsResponse.Item(
+            "jinx",
             "Jinx",
             "j.png",
+            "morgana",
             "Morgana",
             "m.png",
             0.45,
@@ -85,7 +87,7 @@ class BottomDuoDetailStatisticsControllerTest {
     BottomDuoCounterResponse response = new BottomDuoCounterResponse(
         "DIAMOND",
         500,
-        new BottomDuoCounterResponse.DuoMeta("Ashe", "a.png", "Lux", "l.png"),
+        new BottomDuoCounterResponse.DuoMeta("ashe", "Ashe", "a.png", "lux", "Lux", "l.png"),
         5,
         List.of()
     );

--- a/src/test/java/com/bestduo_BE/presentation/api/BottomDuoStatisticsControllerTest.java
+++ b/src/test/java/com/bestduo_BE/presentation/api/BottomDuoStatisticsControllerTest.java
@@ -35,8 +35,10 @@ class BottomDuoStatisticsControllerTest {
         "GOLD",
         500,
         List.of(new BottomDuoStatisticsResponse.Item(
+            "ashe",
             "Ashe",
             "adc.png",
+            "thresh",
             "Thresh",
             "sup.png",
             0.55,

--- a/src/test/java/com/bestduo_BE/presentation/api/BottomDuoStatisticsControllerTest.java
+++ b/src/test/java/com/bestduo_BE/presentation/api/BottomDuoStatisticsControllerTest.java
@@ -43,12 +43,16 @@ class BottomDuoStatisticsControllerTest {
             "sup.png",
             0.55,
             0.12,
-            60
+            60,
+            2,
+            5,
+            -1
         ))
     );
 
     when(viewBottomDuoStatistics.execute(
         Tier.GOLD,
+        "14.10",
         "Ashe",
         "Thresh",
         BottomDuoStatFinder.SortKey.WINRATE_ASC
@@ -56,6 +60,7 @@ class BottomDuoStatisticsControllerTest {
 
     mockMvc.perform(get("/bottom-duo/stats")
             .param("tier", "GOLD")
+            .param("patchVersion", "14.10")
             .param("adcChampionId", "Ashe")
             .param("supChampionId", "Thresh")
             .param("sort", "WINRATE_ASC"))
@@ -64,6 +69,7 @@ class BottomDuoStatisticsControllerTest {
 
     verify(viewBottomDuoStatistics).execute(
         Tier.GOLD,
+        "14.10",
         "Ashe",
         "Thresh",
         BottomDuoStatFinder.SortKey.WINRATE_ASC
@@ -77,6 +83,7 @@ class BottomDuoStatisticsControllerTest {
         Tier.SILVER,
         null,
         null,
+        null,
         BottomDuoStatFinder.SortKey.PICKRATE_DESC
     )).thenReturn(response);
 
@@ -87,6 +94,7 @@ class BottomDuoStatisticsControllerTest {
 
     verify(viewBottomDuoStatistics).execute(
         Tier.SILVER,
+        null,
         null,
         null,
         BottomDuoStatFinder.SortKey.PICKRATE_DESC

--- a/src/test/java/com/bestduo_BE/presentation/api/BottomDuoStatisticsControllerTest.java
+++ b/src/test/java/com/bestduo_BE/presentation/api/BottomDuoStatisticsControllerTest.java
@@ -33,6 +33,7 @@ class BottomDuoStatisticsControllerTest {
   void getListReturnsUseCaseResponse() throws Exception {
     BottomDuoStatisticsResponse response = new BottomDuoStatisticsResponse(
         "GOLD",
+        "14.10",
         500,
         List.of(new BottomDuoStatisticsResponse.Item(
             "ashe",
@@ -78,7 +79,7 @@ class BottomDuoStatisticsControllerTest {
 
   @Test
   void getListUsesDefaultSortWhenNotProvided() throws Exception {
-    BottomDuoStatisticsResponse response = new BottomDuoStatisticsResponse("SILVER", 0, List.of());
+    BottomDuoStatisticsResponse response = new BottomDuoStatisticsResponse("SILVER", null, 0, List.of());
     when(viewBottomDuoStatistics.execute(
         Tier.SILVER,
         null,

--- a/src/test/java/com/bestduo_BE/presentation/api/SeedBootstrapControllerTest.java
+++ b/src/test/java/com/bestduo_BE/presentation/api/SeedBootstrapControllerTest.java
@@ -41,7 +41,8 @@ class SeedBootstrapControllerTest {
             .param("seedTier", "CHALLENGER")
             .param("startPage", "2")
             .param("endPage", "4")
-            .param("matchesPerPuuid", "15"))
+            .param("matchesPerPuuid", "15")
+            .param("maxEntries", "50"))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.pagesProcessed").value(1))
         .andExpect(jsonPath("$.entriesFetched").value(2))
@@ -58,6 +59,7 @@ class SeedBootstrapControllerTest {
     assertThat(command.startPage()).isEqualTo(2);
     assertThat(command.endPage()).isEqualTo(4);
     assertThat(command.matchesPerPuuid()).isEqualTo(15);
+    assertThat(command.maxEntries()).isEqualTo(50);
   }
 
   @Test
@@ -80,5 +82,6 @@ class SeedBootstrapControllerTest {
     assertThat(command.startPage()).isEqualTo(1);
     assertThat(command.endPage()).isEqualTo(3);
     assertThat(command.matchesPerPuuid()).isEqualTo(10);
+    assertThat(command.maxEntries()).isZero();
   }
 }


### PR DESCRIPTION
-내부 메모리 확인 할 수 있는 모니터링 툴 적용
- seed 받아오기 마스터 ~ 챌린저까지 확장
- 바텀 듀오 통계 자체티어, rank, 이전 랭크와 차이 보이도록 수정