### PR TITLE
FIX : 바텀 듀오 집계를 선택한 패치와 티어 범위로 제한

### DIFF
--- a/src/main/java/com/bestduo_BE/aggregate/application/AggregateBottomDuoStats.java
+++ b/src/main/java/com/bestduo_BE/aggregate/application/AggregateBottomDuoStats.java
@@ -1,6 +1,7 @@
 package com.bestduo_BE.aggregate.application;
 
 import com.bestduo_BE.aggregate.application.port.BottomDuoStatAggregator;
+import com.bestduo_BE.common.domain.model.Tier;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -11,10 +12,18 @@ public class AggregateBottomDuoStats {
   private final BottomDuoStatAggregator aggregator;
   private final ComputeBottomDuoRanking ranking;
 
-  public Result execute() {
-    int affected = aggregator.aggregateAll();
-    ComputeBottomDuoRanking.Result rankingResult = ranking.execute();
+  public Result execute(String patchVersion, Tier tier) {
+    String tierScope = normalizeTierScope(tier);
+    int affected = aggregator.aggregate(patchVersion, tierScope);
+    ComputeBottomDuoRanking.Result rankingResult = ranking.execute(patchVersion, tierScope);
     return new Result(affected, rankingResult.updatedRows());
+  }
+
+  private String normalizeTierScope(Tier tier) {
+    if (tier == null || tier == Tier.ALL_TIERS) {
+      return null;
+    }
+    return tier.name();
   }
 
   public record Result(int affectedRows, int rankingsUpdated) {}

--- a/src/main/java/com/bestduo_BE/aggregate/application/ComputeBottomDuoRanking.java
+++ b/src/main/java/com/bestduo_BE/aggregate/application/ComputeBottomDuoRanking.java
@@ -23,25 +23,24 @@ public class ComputeBottomDuoRanking {
   private final BottomDuoStatAggregateJpaRepository repository;
 
   @Transactional
-  public Result execute() {
-    String currentPatch = findCurrentPatch();
-    if (currentPatch == null) {
+  public Result execute(String patchVersion, String tier) {
+    if (patchVersion == null) {
       return new Result(null, 0);
     }
 
-    List<BottomDuoStatAggregate> currentStats = loadCurrentStats(currentPatch);
+    List<BottomDuoStatAggregate> currentStats = loadCurrentStats(patchVersion, tier);
     if (currentStats.isEmpty()) {
-      return new Result(currentPatch, 0);
+      return new Result(patchVersion, 0);
     }
 
     Map<String, Integer> totalGamesByTier = calculateTotalGamesByTier(currentStats);
-    Map<String, Integer> previousRankings = loadPreviousRankings(currentPatch);
+    Map<String, Integer> previousRankings = loadPreviousRankings(patchVersion, tier);
     Map<String, List<BottomDuoStatAggregate>> statsByTier = groupStatsByTier(currentStats);
 
     int updatedRows = applyRankings(statsByTier, totalGamesByTier, previousRankings);
 
     repository.saveAll(currentStats);
-    return new Result(currentPatch, updatedRows);
+    return new Result(patchVersion, updatedRows);
   }
 
   private int applyRankings(Map<String, List<BottomDuoStatAggregate>> statsByTier,
@@ -134,20 +133,24 @@ public class ComputeBottomDuoRanking {
             Collectors.summingInt(BottomDuoStatAggregate::getGames)));
   }
 
-  private String findCurrentPatch() {
-    return repository.findLatestPatchVersion();
+  private List<BottomDuoStatAggregate> loadCurrentStats(String patchVersion, String tier) {
+    if (tier == null) {
+      return repository.findByPatchVersion(patchVersion);
+    }
+    return repository.findByPatchVersionAndTier(patchVersion, tier);
   }
 
-  private List<BottomDuoStatAggregate> loadCurrentStats(String patchVersion) {
-    return repository.findByPatchVersion(patchVersion);
-  }
-
-  private Map<String, Integer> loadPreviousRankings(String currentPatch) {
+  private Map<String, Integer> loadPreviousRankings(String currentPatch, String tier) {
     String previousPatch = repository.findPreviousPatchVersion(currentPatch);
     if (previousPatch == null) {
       return Map.of();
     }
-    return repository.findByPatchVersion(previousPatch).stream()
+
+    List<BottomDuoStatAggregate> previousStats = tier == null
+        ? repository.findByPatchVersion(previousPatch)
+        : repository.findByPatchVersionAndTier(previousPatch, tier);
+
+    return previousStats.stream()
         .filter(e -> e.getRanking() != null)
         .collect(Collectors.toMap(BottomDuoStatAggregate::duoKey, BottomDuoStatAggregate::getRanking, (left, right) -> left, HashMap::new));
   }

--- a/src/main/java/com/bestduo_BE/aggregate/application/port/BottomDuoStatAggregator.java
+++ b/src/main/java/com/bestduo_BE/aggregate/application/port/BottomDuoStatAggregator.java
@@ -1,5 +1,5 @@
 package com.bestduo_BE.aggregate.application.port;
 
 public interface BottomDuoStatAggregator {
-  int aggregateAll();
+  int aggregate(String patchVersion, String tier);
 }

--- a/src/main/java/com/bestduo_BE/aggregate/infra/persistence/BottomDuoStatAggregatorImpl.java
+++ b/src/main/java/com/bestduo_BE/aggregate/infra/persistence/BottomDuoStatAggregatorImpl.java
@@ -11,7 +11,7 @@ public class BottomDuoStatAggregatorImpl implements BottomDuoStatAggregator {
   private final BottomDuoStatAggregateJpaRepository repository;
 
   @Override
-  public int aggregateAll() {
-    return repository.upsertAllFromRaw();
+  public int aggregate(String patchVersion, String tier) {
+    return repository.upsertFromRawByScope(patchVersion, tier);
   }
 }

--- a/src/main/java/com/bestduo_BE/aggregate/infra/persistence/repository/BottomDuoStatAggregateJpaRepository.java
+++ b/src/main/java/com/bestduo_BE/aggregate/infra/persistence/repository/BottomDuoStatAggregateJpaRepository.java
@@ -3,6 +3,8 @@ package com.bestduo_BE.aggregate.infra.persistence.repository;
 import com.bestduo_BE.aggregate.infra.persistence.entity.BottomDuoStatAggregate;
 import com.bestduo_BE.aggregate.infra.persistence.entity.BottomDuoStatAggregateId;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -10,6 +12,8 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.transaction.annotation.Transactional;
 
 public interface BottomDuoStatAggregateJpaRepository extends JpaRepository<BottomDuoStatAggregate, BottomDuoStatAggregateId> {
+  Pattern PATCH_VERSION_PATTERN = Pattern.compile("^(\\d+)\\.(\\d+)$");
+
   // ✅ Phase3 집계: raw -> agg upsert
   @Modifying
   @Transactional
@@ -54,6 +58,8 @@ public interface BottomDuoStatAggregateJpaRepository extends JpaRepository<Botto
         now(),
         now()
       from bottom_duo_raw r
+      where coalesce(r.patch, 'UNKNOWN') = :patchVersion
+        and (:tier is null or r.collection_tier = :tier)
       group by
         coalesce(r.patch, 'UNKNOWN'),
         r.adc_champion_id,
@@ -70,7 +76,10 @@ public interface BottomDuoStatAggregateJpaRepository extends JpaRepository<Botto
         ranking_status = excluded.ranking_status,
         updated_at = now()
       """, nativeQuery = true)
-  int upsertAllFromRaw();
+  int upsertFromRawByScope(
+      @Param("patchVersion") String patchVersion,
+      @Param("tier") String tier
+  );
 
   @Query(value = """
       select coalesce(sum(games), 0)
@@ -83,24 +92,60 @@ public interface BottomDuoStatAggregateJpaRepository extends JpaRepository<Botto
       @Param("patchVersion") String patchVersion,
       @Param("tier") String tier);
 
-  @Query(value = """
-      select patch_version
-      from bottom_duo_stat_agg
-      order by updated_at desc
-      limit 1
-      """, nativeQuery = true)
-  String findLatestPatchVersion();
+  @Query("""
+      select distinct b.patchVersion
+      from BottomDuoStatAggregate b
+      where b.patchVersion is not null
+        and b.patchVersion <> 'UNKNOWN'
+      """)
+  List<String> findCandidatePatchVersions();
 
-  @Query(value = """
-      select patch_version
-      from bottom_duo_stat_agg
-      where patch_version < :currentPatch
-      order by patch_version desc
-      limit 1
-      """, nativeQuery = true)
-  String findPreviousPatchVersion(@Param("currentPatch") String currentPatch);
+  default String findLatestPatchVersion() {
+    return findCandidatePatchVersions().stream()
+        .filter(BottomDuoStatAggregateJpaRepository::isParseablePatchVersion)
+        .max(BottomDuoStatAggregateJpaRepository::comparePatchVersion)
+        .orElse(null);
+  }
+
+  default String findPreviousPatchVersion(@Param("currentPatch") String currentPatch) {
+    if (!isParseablePatchVersion(currentPatch)) {
+      return null;
+    }
+
+    return findCandidatePatchVersions().stream()
+        .filter(BottomDuoStatAggregateJpaRepository::isParseablePatchVersion)
+        .filter(candidate -> comparePatchVersion(candidate, currentPatch) < 0)
+        .max(BottomDuoStatAggregateJpaRepository::comparePatchVersion)
+        .orElse(null);
+  }
 
   List<BottomDuoStatAggregate> findByPatchVersion(String patchVersion);
+
+  List<BottomDuoStatAggregate> findByPatchVersionAndTier(String patchVersion, String tier);
+
+  private static boolean isParseablePatchVersion(String raw) {
+    return raw != null && PATCH_VERSION_PATTERN.matcher(raw.trim()).matches();
+  }
+
+  private static int comparePatchVersion(String left, String right) {
+    int byMajor = Integer.compare(patchMajor(left), patchMajor(right));
+    if (byMajor != 0) {
+      return byMajor;
+    }
+    return Integer.compare(patchMinor(left), patchMinor(right));
+  }
+
+  private static int patchMajor(String raw) {
+    Matcher matcher = PATCH_VERSION_PATTERN.matcher(raw.trim());
+    matcher.matches();
+    return Integer.parseInt(matcher.group(1));
+  }
+
+  private static int patchMinor(String raw) {
+    Matcher matcher = PATCH_VERSION_PATTERN.matcher(raw.trim());
+    matcher.matches();
+    return Integer.parseInt(matcher.group(2));
+  }
 
   // ✅ WINRATE DESC
   @Query(value = """

--- a/src/main/java/com/bestduo_BE/aggregate/presentation/api/BottomDuoAggregateController.java
+++ b/src/main/java/com/bestduo_BE/aggregate/presentation/api/BottomDuoAggregateController.java
@@ -1,9 +1,11 @@
 package com.bestduo_BE.aggregate.presentation.api;
 
 import com.bestduo_BE.aggregate.application.AggregateBottomDuoStats;
+import com.bestduo_BE.common.domain.model.Tier;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -14,7 +16,10 @@ public class BottomDuoAggregateController {
   private final AggregateBottomDuoStats useCase;
 
   @PostMapping("/bottom-duo-stat")
-  public AggregateBottomDuoStats.Result aggregate() {
-    return useCase.execute();
+  public AggregateBottomDuoStats.Result aggregate(
+      @RequestParam String patchVersion,
+      @RequestParam(required = false) Tier tier
+  ) {
+    return useCase.execute(patchVersion, tier);
   }
 }

--- a/src/test/java/com/bestduo_BE/aggregate/application/AggregateBottomDuoStatsTest.java
+++ b/src/test/java/com/bestduo_BE/aggregate/application/AggregateBottomDuoStatsTest.java
@@ -1,0 +1,58 @@
+package com.bestduo_BE.aggregate.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.bestduo_BE.aggregate.application.port.BottomDuoStatAggregator;
+import com.bestduo_BE.common.domain.model.Tier;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class AggregateBottomDuoStatsTest {
+
+  @Mock
+  private BottomDuoStatAggregator aggregator;
+
+  @Mock
+  private ComputeBottomDuoRanking ranking;
+
+  private AggregateBottomDuoStats useCase;
+
+  @BeforeEach
+  void setUp() {
+    useCase = new AggregateBottomDuoStats(aggregator, ranking);
+  }
+
+  @Test
+  void executeUsesSamePatchAndTierScopeForAggregationAndRanking() {
+    when(aggregator.aggregate("14.10", "EMERALD")).thenReturn(12);
+    when(ranking.execute("14.10", "EMERALD"))
+        .thenReturn(new ComputeBottomDuoRanking.Result("14.10", 7));
+
+    AggregateBottomDuoStats.Result result = useCase.execute("14.10", Tier.EMERALD);
+
+    assertThat(result.affectedRows()).isEqualTo(12);
+    assertThat(result.rankingsUpdated()).isEqualTo(7);
+    verify(aggregator).aggregate("14.10", "EMERALD");
+    verify(ranking).execute("14.10", "EMERALD");
+  }
+
+  @Test
+  void executeTreatsAllTiersAsPatchWideScope() {
+    when(aggregator.aggregate("14.10", null)).thenReturn(25);
+    when(ranking.execute("14.10", null))
+        .thenReturn(new ComputeBottomDuoRanking.Result("14.10", 18));
+
+    AggregateBottomDuoStats.Result result = useCase.execute("14.10", Tier.ALL_TIERS);
+
+    assertThat(result.affectedRows()).isEqualTo(25);
+    assertThat(result.rankingsUpdated()).isEqualTo(18);
+    verify(aggregator).aggregate("14.10", null);
+    verify(ranking).execute("14.10", null);
+  }
+}

--- a/src/test/java/com/bestduo_BE/aggregate/application/ComputeBottomDuoRankingTest.java
+++ b/src/test/java/com/bestduo_BE/aggregate/application/ComputeBottomDuoRankingTest.java
@@ -30,10 +30,8 @@ class ComputeBottomDuoRankingTest {
   }
 
   @Test
-  void returnZeroWhenNoPatchDataExists() {
-    when(repository.findLatestPatchVersion()).thenReturn(null);
-
-    ComputeBottomDuoRanking.Result result = useCase.execute();
+  void returnZeroWhenPatchVersionIsMissing() {
+    ComputeBottomDuoRanking.Result result = useCase.execute(null, null);
 
     assertThat(result.patchVersion()).isNull();
     assertThat(result.updatedRows()).isZero();
@@ -102,7 +100,6 @@ class ComputeBottomDuoRankingTest {
         .updatedAt(now.minusDays(5))
         .build();
 
-    when(repository.findLatestPatchVersion()).thenReturn("14.10");
     when(repository.findByPatchVersion("14.10"))
         .thenReturn(List.of(asheLux, jinxThresh));
     when(repository.findPreviousPatchVersion("14.10"))
@@ -110,7 +107,7 @@ class ComputeBottomDuoRankingTest {
     when(repository.findByPatchVersion("14.9"))
         .thenReturn(List.of(prevAsheLux));
 
-    ComputeBottomDuoRanking.Result result = useCase.execute();
+    ComputeBottomDuoRanking.Result result = useCase.execute("14.10", null);
 
     assertThat(result.patchVersion()).isEqualTo("14.10");
     assertThat(result.updatedRows()).isEqualTo(2);
@@ -148,17 +145,74 @@ class ComputeBottomDuoRankingTest {
         .updatedAt(now)
         .build();
 
-    when(repository.findLatestPatchVersion()).thenReturn("14.10");
     when(repository.findByPatchVersion("14.10"))
         .thenReturn(List.of(lowSample));
     when(repository.findPreviousPatchVersion("14.10")).thenReturn(null);
 
-    ComputeBottomDuoRanking.Result result = useCase.execute();
+    ComputeBottomDuoRanking.Result result = useCase.execute("14.10", null);
 
     assertThat(result.updatedRows()).isEqualTo(1);
     verify(repository).saveAll(List.of(lowSample));
     assertThat(lowSample.getRanking()).isNull();
     assertThat(lowSample.getDuoTier()).isEqualTo(5);
     assertThat(lowSample.getRankingStatus()).isEqualTo(BottomDuoStatAggregate.RankingStatus.INSUFFICIENT);
+  }
+
+  @Test
+  void computeRankingUsesRequestedTierScopeForCurrentAndPreviousPatch() {
+    OffsetDateTime now = OffsetDateTime.now();
+    BottomDuoStatAggregate emeraldCurrent = BottomDuoStatAggregate.builder()
+        .patchVersion("14.10")
+        .adcChampionId("Ashe")
+        .supChampionId("Lux")
+        .tier("EMERALD")
+        .wins(20)
+        .games(25)
+        .winRate(0.8)
+        .pickRate(0)
+        .adjustedWinRate(0.72)
+        .rankScore(0)
+        .ranking(null)
+        .duoTier(null)
+        .previousRanking(null)
+        .rankDelta(null)
+        .rankingStatus(BottomDuoStatAggregate.RankingStatus.PENDING)
+        .createdAt(now)
+        .updatedAt(now)
+        .build();
+    BottomDuoStatAggregate emeraldPrevious = BottomDuoStatAggregate.builder()
+        .patchVersion("14.9")
+        .adcChampionId("Ashe")
+        .supChampionId("Lux")
+        .tier("EMERALD")
+        .wins(10)
+        .games(15)
+        .winRate(0.66)
+        .pickRate(0)
+        .adjustedWinRate(0.6)
+        .rankScore(0)
+        .ranking(3)
+        .duoTier(2)
+        .previousRanking(null)
+        .rankDelta(null)
+        .rankingStatus(BottomDuoStatAggregate.RankingStatus.RANKED)
+        .createdAt(now.minusDays(10))
+        .updatedAt(now.minusDays(5))
+        .build();
+
+    when(repository.findByPatchVersionAndTier("14.10", "EMERALD"))
+        .thenReturn(List.of(emeraldCurrent));
+    when(repository.findPreviousPatchVersion("14.10")).thenReturn("14.9");
+    when(repository.findByPatchVersionAndTier("14.9", "EMERALD"))
+        .thenReturn(List.of(emeraldPrevious));
+
+    ComputeBottomDuoRanking.Result result = useCase.execute("14.10", "EMERALD");
+
+    assertThat(result.patchVersion()).isEqualTo("14.10");
+    assertThat(result.updatedRows()).isEqualTo(1);
+    verify(repository).findByPatchVersionAndTier("14.10", "EMERALD");
+    verify(repository).findByPatchVersionAndTier("14.9", "EMERALD");
+    verify(repository).saveAll(List.of(emeraldCurrent));
+    assertThat(emeraldCurrent.getPreviousRanking()).isEqualTo(3);
   }
 }

--- a/src/test/java/com/bestduo_BE/aggregate/infra/persistence/BottomDuoStatAggregateJpaRepositoryTest.java
+++ b/src/test/java/com/bestduo_BE/aggregate/infra/persistence/BottomDuoStatAggregateJpaRepositoryTest.java
@@ -1,0 +1,122 @@
+package com.bestduo_BE.aggregate.infra.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.bestduo_BE.aggregate.infra.persistence.entity.BottomDuoStatAggregate;
+import com.bestduo_BE.aggregate.infra.persistence.repository.BottomDuoStatAggregateJpaRepository;
+import java.time.OffsetDateTime;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.TestPropertySource;
+
+@SpringBootTest
+@TestPropertySource(properties = {
+    "spring.datasource.url=jdbc:h2:mem:bottom-duo-stat-repo;MODE=PostgreSQL;DB_CLOSE_DELAY=-1",
+    "spring.datasource.username=sa",
+    "spring.datasource.password=",
+    "spring.datasource.driver-class-name=org.h2.Driver",
+    "spring.jpa.hibernate.ddl-auto=create",
+    "spring.jpa.show-sql=false",
+    "spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect",
+    "external.riot.api-key=dummy"
+})
+class BottomDuoStatAggregateJpaRepositoryTest {
+
+  @Autowired
+  private BottomDuoStatAggregateJpaRepository repository;
+
+  @AfterEach
+  void cleanUp() {
+    repository.deleteAll();
+  }
+
+  @Test
+  void findLatestPatchVersionUsesNumericOrdering() {
+    saveRow("14.9", "Ashe", "Lux");
+    saveRow("14.10", "Jinx", "Thresh");
+    saveRow("14.11", "Caitlyn", "Morgana");
+
+    String latestPatch = repository.findLatestPatchVersion();
+
+    assertThat(latestPatch).isEqualTo("14.11");
+  }
+
+  @Test
+  void findLatestPatchVersionIgnoresUnknownPatch() {
+    saveRow("UNKNOWN", "Ashe", "Lux");
+    saveRow("14.10", "Jinx", "Thresh");
+
+    String latestPatch = repository.findLatestPatchVersion();
+
+    assertThat(latestPatch).isEqualTo("14.10");
+  }
+
+  @Test
+  void findPreviousPatchVersionUsesNumericOrderingInsteadOfLexicalOrdering() {
+    saveRow("14.9", "Ashe", "Lux");
+    saveRow("14.10", "Jinx", "Thresh");
+    saveRow("14.11", "Caitlyn", "Morgana");
+
+    String previousPatch = repository.findPreviousPatchVersion("14.11");
+
+    assertThat(previousPatch).isEqualTo("14.10");
+  }
+
+  @Test
+  void findLatestPatchVersionReturnsNullWhenNoParseablePatchExists() {
+    saveRow("UNKNOWN", "Ashe", "Lux");
+
+    String latestPatch = repository.findLatestPatchVersion();
+
+    assertThat(latestPatch).isNull();
+  }
+
+  @Test
+  void findByPatchVersionAndTierReturnsOnlyRequestedScope() {
+    saveRow("14.10", "Ashe", "Lux");
+    saveRow("14.10", "Jinx", "Thresh", "GOLD");
+    saveRow("14.11", "Caitlyn", "Morgana");
+
+    assertThat(repository.findByPatchVersionAndTier("14.10", "EMERALD").stream()
+        .map(BottomDuoStatAggregate::getAdcChampionId)
+        .toList()).containsExactly("Ashe");
+  }
+
+  @Test
+  void findByPatchVersionReturnsAllTiersWithinPatch() {
+    saveRow("14.10", "Ashe", "Lux");
+    saveRow("14.10", "Jinx", "Thresh", "GOLD");
+    saveRow("14.11", "Caitlyn", "Morgana");
+
+    assertThat(repository.findByPatchVersion("14.10")).hasSize(2);
+  }
+
+  private void saveRow(String patchVersion, String adcChampionId, String supChampionId) {
+    saveRow(patchVersion, adcChampionId, supChampionId, "EMERALD");
+  }
+
+  private void saveRow(String patchVersion, String adcChampionId, String supChampionId, String tier) {
+    OffsetDateTime now = OffsetDateTime.now();
+    repository.save(BottomDuoStatAggregate.builder()
+        .patchVersion(patchVersion)
+        .adcChampionId(adcChampionId)
+        .supChampionId(supChampionId)
+        .tier(tier)
+        .wins(10)
+        .games(20)
+        .winRate(0.5)
+        .pickRate(0.1)
+        .adjustedWinRate(0.5)
+        .rankScore(0.0)
+        .ranking(1)
+        .duoTier(1)
+        .previousRanking(null)
+        .rankDelta(null)
+        .rankingStatus(BottomDuoStatAggregate.RankingStatus.RANKED)
+        .createdAt(now)
+        .updatedAt(now)
+        .build());
+  }
+}

--- a/src/test/java/com/bestduo_BE/aggregate/infra/persistence/BottomDuoStatAggregatorImplTest.java
+++ b/src/test/java/com/bestduo_BE/aggregate/infra/persistence/BottomDuoStatAggregatorImplTest.java
@@ -25,12 +25,12 @@ class BottomDuoStatAggregatorImplTest {
   }
 
   @Test
-  void aggregateAllDelegatesToRepository() {
-    when(repository.upsertAllFromRaw()).thenReturn(42);
+  void aggregateDelegatesScopedPatchAndTierToRepository() {
+    when(repository.upsertFromRawByScope("14.10", "EMERALD")).thenReturn(42);
 
-    int updatedRows = aggregator.aggregateAll();
+    int updatedRows = aggregator.aggregate("14.10", "EMERALD");
 
     assertThat(updatedRows).isEqualTo(42);
-    verify(repository).upsertAllFromRaw();
+    verify(repository).upsertFromRawByScope("14.10", "EMERALD");
   }
 }

--- a/src/test/java/com/bestduo_BE/aggregate/presentation/api/BottomDuoAggregateControllerTest.java
+++ b/src/test/java/com/bestduo_BE/aggregate/presentation/api/BottomDuoAggregateControllerTest.java
@@ -1,12 +1,14 @@
 package com.bestduo_BE.aggregate.presentation.api;
 
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.bestduo_BE.aggregate.application.AggregateBottomDuoStats;
+import com.bestduo_BE.common.domain.model.Tier;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -26,14 +28,37 @@ class BottomDuoAggregateControllerTest {
   private AggregateBottomDuoStats aggregateBottomDuoStat;
 
   @Test
-  void aggregateReturnsUseCaseResult() throws Exception {
+  void aggregateReturnsUseCaseResultWithPatchScope() throws Exception {
     AggregateBottomDuoStats.Result result = new AggregateBottomDuoStats.Result(10, 7);
-    when(aggregateBottomDuoStat.execute()).thenReturn(result);
+    when(aggregateBottomDuoStat.execute("14.10", null)).thenReturn(result);
 
-    mockMvc.perform(post("/admin/aggregate/bottom-duo-stat"))
+    mockMvc.perform(post("/admin/aggregate/bottom-duo-stat")
+            .param("patchVersion", "14.10"))
         .andExpect(status().isOk())
         .andExpect(content().json(objectMapper.writeValueAsString(result)));
 
-    verify(aggregateBottomDuoStat).execute();
+    verify(aggregateBottomDuoStat).execute("14.10", null);
+  }
+
+  @Test
+  void aggregatePassesTierWhenProvided() throws Exception {
+    AggregateBottomDuoStats.Result result = new AggregateBottomDuoStats.Result(4, 3);
+    when(aggregateBottomDuoStat.execute("14.10", Tier.EMERALD)).thenReturn(result);
+
+    mockMvc.perform(post("/admin/aggregate/bottom-duo-stat")
+            .param("patchVersion", "14.10")
+            .param("tier", "EMERALD"))
+        .andExpect(status().isOk())
+        .andExpect(content().json(objectMapper.writeValueAsString(result)));
+
+    verify(aggregateBottomDuoStat).execute("14.10", Tier.EMERALD);
+  }
+
+  @Test
+  void aggregateRequiresPatchVersion() throws Exception {
+    mockMvc.perform(post("/admin/aggregate/bottom-duo-stat"))
+        .andExpect(status().isBadRequest());
+
+    verifyNoInteractions(aggregateBottomDuoStat);
   }
 }


### PR DESCRIPTION
## Summary
- 바텀 듀오 집계 admin API가 patchVersion 필수, tier 선택 범위를 받도록 변경했습니다.
- 원본 집계와 랭킹 계산이 선택한 patch/tier 범위만 처리하도록 맞췄습니다.
- 패치 선택 로직과 aggregate 테스트를 보강해 latest/previous patch 해석과 범위 회귀를 검증했습니다.

## Test
- ./gradlew test --tests 'com.bestduo_BE.aggregate.*'