### PR TITLE
FEAT : coverage bucket Phase 1 추가

### DIFF
--- a/src/main/java/com/bestduo_BE/coverage/application/CoverageBucketService.java
+++ b/src/main/java/com/bestduo_BE/coverage/application/CoverageBucketService.java
@@ -1,0 +1,79 @@
+package com.bestduo_BE.coverage.application;
+
+import com.bestduo_BE.coverage.application.exception.CoverageBucketAlreadyExistsException;
+import com.bestduo_BE.coverage.application.exception.CoverageBucketNotFoundException;
+import com.bestduo_BE.coverage.infra.persistence.entity.CoverageBucket;
+import com.bestduo_BE.coverage.infra.persistence.repository.CoverageBucketCountJpaRepository;
+import com.bestduo_BE.coverage.infra.persistence.repository.CoverageBucketJpaRepository;
+import com.bestduo_BE.coverage.presentation.api.dto.CoverageBucketCreateRequest;
+import com.bestduo_BE.coverage.presentation.api.dto.CoverageBucketResponse;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CoverageBucketService {
+
+  static final int DEFAULT_PRIORITY = 100;
+
+  private final CoverageBucketJpaRepository coverageBucketRepository;
+  private final CoverageBucketCountJpaRepository coverageBucketCountRepository;
+
+  @Transactional
+  public CoverageBucketResponse create(CoverageBucketCreateRequest request) {
+    if (coverageBucketRepository.existsByPatchAndTier(request.patch(), request.tier())) {
+      throw new CoverageBucketAlreadyExistsException(request.patch(), request.tier().name());
+    }
+
+    CoverageBucket bucket = CoverageBucket.create(
+        request.patch(),
+        request.tier(),
+        request.targetMatchCount(),
+        request.priority() != null ? request.priority() : DEFAULT_PRIORITY
+    );
+    bucket.refreshCount(currentCount(bucket));
+    try {
+      return toResponse(coverageBucketRepository.save(bucket));
+    } catch (DataIntegrityViolationException e) {
+      throw new CoverageBucketAlreadyExistsException(request.patch(), request.tier().name(), e);
+    }
+  }
+
+  @Transactional
+  public CoverageBucketResponse get(Long id) {
+    CoverageBucket bucket = coverageBucketRepository.findById(id)
+        .orElseThrow(() -> new CoverageBucketNotFoundException(id));
+    bucket.refreshCount(currentCount(bucket));
+    return toResponse(bucket);
+  }
+
+  @Transactional
+  public List<CoverageBucketResponse> getAll() {
+    return coverageBucketRepository.findAllByOrderByPriorityAscIdAsc().stream()
+        .peek(bucket -> bucket.refreshCount(currentCount(bucket)))
+        .map(this::toResponse)
+        .toList();
+  }
+
+  private long currentCount(CoverageBucket bucket) {
+    return coverageBucketCountRepository.countDistinctMatches(bucket.getPatch(), bucket.getTier().name());
+  }
+
+  private CoverageBucketResponse toResponse(CoverageBucket bucket) {
+    long deficitMatchCount = Math.max(bucket.getTargetMatchCount() - bucket.getCurrentMatchCount(), 0L);
+    return new CoverageBucketResponse(
+        bucket.getId(),
+        bucket.getPatch(),
+        bucket.getTier(),
+        bucket.getTargetMatchCount(),
+        bucket.getCurrentMatchCount(),
+        deficitMatchCount,
+        bucket.getStatus().name(),
+        bucket.getPriority(),
+        bucket.getLastEvaluatedAt()
+    );
+  }
+}

--- a/src/main/java/com/bestduo_BE/coverage/application/exception/CoverageBucketAlreadyExistsException.java
+++ b/src/main/java/com/bestduo_BE/coverage/application/exception/CoverageBucketAlreadyExistsException.java
@@ -1,0 +1,12 @@
+package com.bestduo_BE.coverage.application.exception;
+
+public class CoverageBucketAlreadyExistsException extends RuntimeException {
+
+  public CoverageBucketAlreadyExistsException(String patch, String tier) {
+    super("Coverage bucket already exists. patch=%s tier=%s".formatted(patch, tier));
+  }
+
+  public CoverageBucketAlreadyExistsException(String patch, String tier, Throwable cause) {
+    super("Coverage bucket already exists. patch=%s tier=%s".formatted(patch, tier), cause);
+  }
+}

--- a/src/main/java/com/bestduo_BE/coverage/application/exception/CoverageBucketNotFoundException.java
+++ b/src/main/java/com/bestduo_BE/coverage/application/exception/CoverageBucketNotFoundException.java
@@ -1,0 +1,8 @@
+package com.bestduo_BE.coverage.application.exception;
+
+public class CoverageBucketNotFoundException extends RuntimeException {
+
+  public CoverageBucketNotFoundException(Long id) {
+    super("Coverage bucket not found. id=" + id);
+  }
+}

--- a/src/main/java/com/bestduo_BE/coverage/domain/model/CoverageBucketStatus.java
+++ b/src/main/java/com/bestduo_BE/coverage/domain/model/CoverageBucketStatus.java
@@ -1,0 +1,6 @@
+package com.bestduo_BE.coverage.domain.model;
+
+public enum CoverageBucketStatus {
+  COLLECTING,
+  SUFFICIENT
+}

--- a/src/main/java/com/bestduo_BE/coverage/infra/persistence/entity/CoverageBucket.java
+++ b/src/main/java/com/bestduo_BE/coverage/infra/persistence/entity/CoverageBucket.java
@@ -1,0 +1,88 @@
+package com.bestduo_BE.coverage.infra.persistence.entity;
+
+import com.bestduo_BE.common.domain.model.Tier;
+import com.bestduo_BE.coverage.domain.model.CoverageBucketStatus;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.OffsetDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(
+    name = "coverage_bucket",
+    uniqueConstraints = @UniqueConstraint(name = "uk_coverage_bucket_patch_tier", columnNames = {"patch", "tier"})
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class CoverageBucket {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(nullable = false)
+  private String patch;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  private Tier tier;
+
+  @Column(name = "target_match_count", nullable = false)
+  private long targetMatchCount;
+
+  @Column(name = "current_match_count", nullable = false)
+  private long currentMatchCount;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  private CoverageBucketStatus status;
+
+  @Column(nullable = false)
+  private int priority;
+
+  @Column(name = "last_evaluated_at", nullable = false)
+  private OffsetDateTime lastEvaluatedAt;
+
+  @Column(name = "created_at", nullable = false)
+  private OffsetDateTime createdAt;
+
+  @Column(name = "updated_at", nullable = false)
+  private OffsetDateTime updatedAt;
+
+  public static CoverageBucket create(String patch, Tier tier, long targetMatchCount, int priority) {
+    OffsetDateTime now = OffsetDateTime.now();
+    return CoverageBucket.builder()
+        .patch(patch)
+        .tier(tier)
+        .targetMatchCount(targetMatchCount)
+        .currentMatchCount(0L)
+        .status(CoverageBucketStatus.COLLECTING)
+        .priority(priority)
+        .lastEvaluatedAt(now)
+        .createdAt(now)
+        .updatedAt(now)
+        .build();
+  }
+
+  public void refreshCount(long currentMatchCount) {
+    this.currentMatchCount = currentMatchCount;
+    this.status = currentMatchCount >= targetMatchCount
+        ? CoverageBucketStatus.SUFFICIENT
+        : CoverageBucketStatus.COLLECTING;
+    this.lastEvaluatedAt = OffsetDateTime.now();
+    this.updatedAt = this.lastEvaluatedAt;
+  }
+}

--- a/src/main/java/com/bestduo_BE/coverage/infra/persistence/repository/CoverageBucketCountJpaRepository.java
+++ b/src/main/java/com/bestduo_BE/coverage/infra/persistence/repository/CoverageBucketCountJpaRepository.java
@@ -1,0 +1,18 @@
+package com.bestduo_BE.coverage.infra.persistence.repository;
+
+import com.bestduo_BE.common.infra.persistence.entity.BottomDuoRawEntity;
+import com.bestduo_BE.common.infra.persistence.entity.BottomDuoRawId;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.Repository;
+import org.springframework.data.repository.query.Param;
+
+public interface CoverageBucketCountJpaRepository extends Repository<BottomDuoRawEntity, BottomDuoRawId> {
+
+  @Query(value = """
+      select count(distinct r.match_id)
+      from bottom_duo_raw r
+      where r.patch = :patch
+        and r.collection_tier = :tier
+      """, nativeQuery = true)
+  long countDistinctMatches(@Param("patch") String patch, @Param("tier") String tier);
+}

--- a/src/main/java/com/bestduo_BE/coverage/infra/persistence/repository/CoverageBucketJpaRepository.java
+++ b/src/main/java/com/bestduo_BE/coverage/infra/persistence/repository/CoverageBucketJpaRepository.java
@@ -1,0 +1,16 @@
+package com.bestduo_BE.coverage.infra.persistence.repository;
+
+import com.bestduo_BE.common.domain.model.Tier;
+import com.bestduo_BE.coverage.infra.persistence.entity.CoverageBucket;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CoverageBucketJpaRepository extends JpaRepository<CoverageBucket, Long> {
+
+  boolean existsByPatchAndTier(String patch, Tier tier);
+
+  Optional<CoverageBucket> findByPatchAndTier(String patch, Tier tier);
+
+  List<CoverageBucket> findAllByOrderByPriorityAscIdAsc();
+}

--- a/src/main/java/com/bestduo_BE/coverage/presentation/api/AdminCoverageController.java
+++ b/src/main/java/com/bestduo_BE/coverage/presentation/api/AdminCoverageController.java
@@ -1,0 +1,56 @@
+package com.bestduo_BE.coverage.presentation.api;
+
+import com.bestduo_BE.common.domain.model.Tier;
+import com.bestduo_BE.coverage.application.CoverageBucketService;
+import com.bestduo_BE.coverage.application.exception.CoverageBucketAlreadyExistsException;
+import com.bestduo_BE.coverage.application.exception.CoverageBucketNotFoundException;
+import com.bestduo_BE.coverage.presentation.api.dto.CoverageBucketCreateRequest;
+import com.bestduo_BE.coverage.presentation.api.dto.CoverageBucketResponse;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/admin/coverage")
+public class AdminCoverageController {
+
+  private final CoverageBucketService coverageBucketService;
+
+  @PostMapping
+  @ResponseStatus(HttpStatus.CREATED)
+  public CoverageBucketResponse create(
+      @RequestParam String patch,
+      @RequestParam Tier tier,
+      @RequestParam long targetMatchCount,
+      @RequestParam(required = false) Integer priority
+  ) {
+    try {
+      return coverageBucketService.create(new CoverageBucketCreateRequest(patch, tier, targetMatchCount, priority));
+    } catch (CoverageBucketAlreadyExistsException e) {
+      throw new ResponseStatusException(HttpStatus.CONFLICT, e.getMessage());
+    }
+  }
+
+  @GetMapping
+  public List<CoverageBucketResponse> getAll() {
+    return coverageBucketService.getAll();
+  }
+
+  @GetMapping("/{id}")
+  public CoverageBucketResponse get(@PathVariable Long id) {
+    try {
+      return coverageBucketService.get(id);
+    } catch (CoverageBucketNotFoundException e) {
+      throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
+    }
+  }
+}

--- a/src/main/java/com/bestduo_BE/coverage/presentation/api/dto/CoverageBucketCreateRequest.java
+++ b/src/main/java/com/bestduo_BE/coverage/presentation/api/dto/CoverageBucketCreateRequest.java
@@ -1,0 +1,11 @@
+package com.bestduo_BE.coverage.presentation.api.dto;
+
+import com.bestduo_BE.common.domain.model.Tier;
+
+public record CoverageBucketCreateRequest(
+    String patch,
+    Tier tier,
+    long targetMatchCount,
+    Integer priority
+) {
+}

--- a/src/main/java/com/bestduo_BE/coverage/presentation/api/dto/CoverageBucketResponse.java
+++ b/src/main/java/com/bestduo_BE/coverage/presentation/api/dto/CoverageBucketResponse.java
@@ -1,0 +1,17 @@
+package com.bestduo_BE.coverage.presentation.api.dto;
+
+import com.bestduo_BE.common.domain.model.Tier;
+import java.time.OffsetDateTime;
+
+public record CoverageBucketResponse(
+    Long id,
+    String patch,
+    Tier tier,
+    long targetMatchCount,
+    long currentMatchCount,
+    long deficitMatchCount,
+    String status,
+    int priority,
+    OffsetDateTime lastEvaluatedAt
+) {
+}

--- a/src/test/java/com/bestduo_BE/coverage/application/CoverageBucketServiceTest.java
+++ b/src/test/java/com/bestduo_BE/coverage/application/CoverageBucketServiceTest.java
@@ -1,0 +1,131 @@
+package com.bestduo_BE.coverage.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import com.bestduo_BE.common.domain.model.Tier;
+import com.bestduo_BE.coverage.application.exception.CoverageBucketAlreadyExistsException;
+import com.bestduo_BE.coverage.application.exception.CoverageBucketNotFoundException;
+import com.bestduo_BE.coverage.domain.model.CoverageBucketStatus;
+import com.bestduo_BE.coverage.infra.persistence.entity.CoverageBucket;
+import com.bestduo_BE.coverage.infra.persistence.repository.CoverageBucketCountJpaRepository;
+import com.bestduo_BE.coverage.infra.persistence.repository.CoverageBucketJpaRepository;
+import com.bestduo_BE.coverage.presentation.api.dto.CoverageBucketCreateRequest;
+import com.bestduo_BE.coverage.presentation.api.dto.CoverageBucketResponse;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+
+@ExtendWith(MockitoExtension.class)
+class CoverageBucketServiceTest {
+
+  @Mock
+  private CoverageBucketJpaRepository coverageBucketRepository;
+
+  @Mock
+  private CoverageBucketCountJpaRepository coverageBucketCountRepository;
+
+  private CoverageBucketService service;
+
+  @BeforeEach
+  void setUp() {
+    service = new CoverageBucketService(coverageBucketRepository, coverageBucketCountRepository);
+  }
+
+  @Test
+  void createUsesCurrentCoverageCountAndDefaultPriority() {
+    CoverageBucketCreateRequest request = new CoverageBucketCreateRequest("15.7", Tier.MASTER, 20_000L, null);
+    given(coverageBucketRepository.existsByPatchAndTier("15.7", Tier.MASTER)).willReturn(false);
+    given(coverageBucketCountRepository.countDistinctMatches("15.7", "MASTER")).willReturn(3_400L);
+    given(coverageBucketRepository.save(org.mockito.ArgumentMatchers.any(CoverageBucket.class)))
+        .willAnswer(invocation -> invocation.getArgument(0));
+
+    CoverageBucketResponse response = service.create(request);
+
+    ArgumentCaptor<CoverageBucket> captor = ArgumentCaptor.forClass(CoverageBucket.class);
+    verify(coverageBucketRepository).save(captor.capture());
+    CoverageBucket saved = captor.getValue();
+    assertThat(saved.getPatch()).isEqualTo("15.7");
+    assertThat(saved.getTier()).isEqualTo(Tier.MASTER);
+    assertThat(saved.getTargetMatchCount()).isEqualTo(20_000L);
+    assertThat(saved.getCurrentMatchCount()).isEqualTo(3_400L);
+    assertThat(saved.getStatus()).isEqualTo(CoverageBucketStatus.COLLECTING);
+    assertThat(saved.getPriority()).isEqualTo(CoverageBucketService.DEFAULT_PRIORITY);
+
+    assertThat(response.patch()).isEqualTo("15.7");
+    assertThat(response.currentMatchCount()).isEqualTo(3_400L);
+    assertThat(response.deficitMatchCount()).isEqualTo(16_600L);
+    assertThat(response.status()).isEqualTo("COLLECTING");
+    assertThat(response.lastEvaluatedAt()).isNotNull();
+  }
+
+  @Test
+  void createRejectsDuplicatePatchTierBucket() {
+    CoverageBucketCreateRequest request = new CoverageBucketCreateRequest("15.7", Tier.MASTER, 20_000L, 1);
+    given(coverageBucketRepository.existsByPatchAndTier("15.7", Tier.MASTER)).willReturn(true);
+
+    assertThatThrownBy(() -> service.create(request))
+        .isInstanceOf(CoverageBucketAlreadyExistsException.class)
+        .hasMessageContaining("Coverage bucket already exists");
+  }
+
+  @Test
+  void createTranslatesUniqueConstraintViolationToConflictStyleException() {
+    CoverageBucketCreateRequest request = new CoverageBucketCreateRequest("15.7", Tier.MASTER, 20_000L, 1);
+    given(coverageBucketRepository.existsByPatchAndTier("15.7", Tier.MASTER)).willReturn(false);
+    given(coverageBucketCountRepository.countDistinctMatches("15.7", "MASTER")).willReturn(0L);
+    given(coverageBucketRepository.save(org.mockito.ArgumentMatchers.any(CoverageBucket.class)))
+        .willThrow(new DataIntegrityViolationException("duplicate key"));
+
+    assertThatThrownBy(() -> service.create(request))
+        .isInstanceOf(CoverageBucketAlreadyExistsException.class)
+        .hasMessageContaining("Coverage bucket already exists");
+  }
+
+  @Test
+  void getThrowsCoverageBucketNotFoundExceptionWhenMissing() {
+    given(coverageBucketRepository.findById(99L)).willReturn(Optional.empty());
+
+    assertThatThrownBy(() -> service.get(99L))
+        .isInstanceOf(CoverageBucketNotFoundException.class)
+        .hasMessageContaining("Coverage bucket not found");
+  }
+
+  @Test
+  void getReevaluatesCurrentCountAndMarksBucketSufficient() {
+    CoverageBucket bucket = CoverageBucket.create("15.7", Tier.MASTER, 2_000L, 5);
+    given(coverageBucketRepository.findById(7L)).willReturn(Optional.of(bucket));
+    given(coverageBucketCountRepository.countDistinctMatches("15.7", "MASTER")).willReturn(2_500L);
+
+    CoverageBucketResponse response = service.get(7L);
+
+    assertThat(response.currentMatchCount()).isEqualTo(2_500L);
+    assertThat(response.deficitMatchCount()).isZero();
+    assertThat(response.status()).isEqualTo("SUFFICIENT");
+  }
+
+  @Test
+  void getAllReturnsBucketsOrderedByPriorityAndId() {
+    CoverageBucket first = CoverageBucket.create("15.7", Tier.MASTER, 100L, 1);
+    CoverageBucket second = CoverageBucket.create("15.7", Tier.DIAMOND, 100L, 2);
+    given(coverageBucketRepository.findAllByOrderByPriorityAscIdAsc()).willReturn(List.of(first, second));
+    given(coverageBucketCountRepository.countDistinctMatches("15.7", "MASTER")).willReturn(10L);
+    given(coverageBucketCountRepository.countDistinctMatches("15.7", "DIAMOND")).willReturn(20L);
+
+    List<CoverageBucketResponse> responses = service.getAll();
+
+    assertThat(responses).hasSize(2);
+    assertThat(responses.get(0).tier()).isEqualTo(Tier.MASTER);
+    assertThat(responses.get(0).currentMatchCount()).isEqualTo(10L);
+    assertThat(responses.get(1).tier()).isEqualTo(Tier.DIAMOND);
+    assertThat(responses.get(1).currentMatchCount()).isEqualTo(20L);
+  }
+}

--- a/src/test/java/com/bestduo_BE/coverage/infra/persistence/repository/CoverageBucketCountJpaRepositoryTest.java
+++ b/src/test/java/com/bestduo_BE/coverage/infra/persistence/repository/CoverageBucketCountJpaRepositoryTest.java
@@ -1,0 +1,49 @@
+package com.bestduo_BE.coverage.infra.persistence.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.bestduo_BE.common.domain.model.BottomDuoRaw;
+import com.bestduo_BE.common.domain.model.Tier;
+import com.bestduo_BE.common.infra.persistence.entity.BottomDuoRawEntity;
+import com.bestduo_BE.common.infra.persistence.repository.BottomDuoRawJpaRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.test.context.TestPropertySource;
+
+@DataJpaTest
+@TestPropertySource(properties = {
+    "spring.datasource.url=jdbc:h2:mem:coverage;MODE=PostgreSQL;DB_CLOSE_DELAY=-1",
+    "spring.datasource.username=sa",
+    "spring.datasource.password=",
+    "spring.datasource.driver-class-name=org.h2.Driver",
+    "spring.jpa.hibernate.ddl-auto=create",
+    "spring.jpa.show-sql=false",
+    "spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect"
+})
+class CoverageBucketCountJpaRepositoryTest {
+
+  @Autowired
+  private BottomDuoRawJpaRepository bottomDuoRawRepository;
+
+  @Autowired
+  private CoverageBucketCountJpaRepository coverageBucketCountRepository;
+
+  @AfterEach
+  void cleanUp() {
+    bottomDuoRawRepository.deleteAll();
+  }
+
+  @Test
+  void countDistinctMatchesCountsOneMatchForTwoTeamRowsAndFiltersByPatchAndTier() {
+    bottomDuoRawRepository.save(BottomDuoRawEntity.fromDomain(new BottomDuoRaw("KR_1", 100, 1, 2, true, "15.7", Tier.MASTER)));
+    bottomDuoRawRepository.save(BottomDuoRawEntity.fromDomain(new BottomDuoRaw("KR_1", 200, 3, 4, false, "15.7", Tier.MASTER)));
+    bottomDuoRawRepository.save(BottomDuoRawEntity.fromDomain(new BottomDuoRaw("KR_2", 100, 5, 6, true, "15.6", Tier.MASTER)));
+    bottomDuoRawRepository.save(BottomDuoRawEntity.fromDomain(new BottomDuoRaw("KR_3", 100, 7, 8, true, "15.7", Tier.DIAMOND)));
+
+    long count = coverageBucketCountRepository.countDistinctMatches("15.7", "MASTER");
+
+    assertThat(count).isEqualTo(1L);
+  }
+}

--- a/src/test/java/com/bestduo_BE/coverage/presentation/api/AdminCoverageControllerTest.java
+++ b/src/test/java/com/bestduo_BE/coverage/presentation/api/AdminCoverageControllerTest.java
@@ -1,0 +1,108 @@
+package com.bestduo_BE.coverage.presentation.api;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.bestduo_BE.common.domain.model.Tier;
+import com.bestduo_BE.coverage.application.CoverageBucketService;
+import com.bestduo_BE.coverage.application.exception.CoverageBucketAlreadyExistsException;
+import com.bestduo_BE.coverage.application.exception.CoverageBucketNotFoundException;
+import com.bestduo_BE.coverage.presentation.api.dto.CoverageBucketResponse;
+import java.time.OffsetDateTime;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(AdminCoverageController.class)
+class AdminCoverageControllerTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @MockitoBean
+  private CoverageBucketService coverageBucketService;
+
+  @Test
+  void createDelegatesToServiceAndReturnsCreatedBucket() throws Exception {
+    CoverageBucketResponse response = new CoverageBucketResponse(
+        1L,
+        "15.7",
+        Tier.MASTER,
+        20_000L,
+        3_400L,
+        16_600L,
+        "COLLECTING",
+        7,
+        OffsetDateTime.parse("2026-03-30T10:15:30+09:00")
+    );
+    given(coverageBucketService.create(any())).willReturn(response);
+
+    mockMvc.perform(post("/admin/coverage")
+            .param("patch", "15.7")
+            .param("tier", "MASTER")
+            .param("targetMatchCount", "20000")
+            .param("priority", "7"))
+        .andExpect(status().isCreated())
+        .andExpect(jsonPath("$.patch").value("15.7"))
+        .andExpect(jsonPath("$.tier").value("MASTER"))
+        .andExpect(jsonPath("$.currentMatchCount").value(3400))
+        .andExpect(jsonPath("$.deficitMatchCount").value(16600))
+        .andExpect(jsonPath("$.status").value("COLLECTING"));
+
+    then(coverageBucketService).should().create(any());
+  }
+
+  @Test
+  void createReturnsConflictWhenDuplicateBucketExists() throws Exception {
+    given(coverageBucketService.create(any())).willThrow(new CoverageBucketAlreadyExistsException("15.7", "MASTER"));
+
+    mockMvc.perform(post("/admin/coverage")
+            .param("patch", "15.7")
+            .param("tier", "MASTER")
+            .param("targetMatchCount", "20000"))
+        .andExpect(status().isConflict());
+  }
+
+  @Test
+  void getAllReturnsBuckets() throws Exception {
+    given(coverageBucketService.getAll()).willReturn(List.of(
+        new CoverageBucketResponse(1L, "15.7", Tier.MASTER, 20_000L, 3_400L, 16_600L, "COLLECTING", 1,
+            OffsetDateTime.parse("2026-03-30T10:15:30+09:00"))
+    ));
+
+    mockMvc.perform(get("/admin/coverage"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$[0].tier").value("MASTER"))
+        .andExpect(jsonPath("$[0].currentMatchCount").value(3400));
+  }
+
+  @Test
+  void getReturnsBucket() throws Exception {
+    given(coverageBucketService.get(1L)).willReturn(
+        new CoverageBucketResponse(1L, "15.7", Tier.MASTER, 20_000L, 3_400L, 16_600L, "COLLECTING", 1,
+            OffsetDateTime.parse("2026-03-30T10:15:30+09:00"))
+    );
+
+    mockMvc.perform(get("/admin/coverage/1"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.id").value(1))
+        .andExpect(jsonPath("$.tier").value("MASTER"))
+        .andExpect(jsonPath("$.deficitMatchCount").value(16600));
+  }
+
+  @Test
+  void getReturnsNotFoundWhenBucketIsMissing() throws Exception {
+    given(coverageBucketService.get(99L)).willThrow(new CoverageBucketNotFoundException(99L));
+
+    mockMvc.perform(get("/admin/coverage/99"))
+        .andExpect(status().isNotFound());
+  }
+}


### PR DESCRIPTION
## 요약
- patch+tier 단위로 목표 수집량을 관리하는 Phase 1 coverage bucket 저장 구조와 admin API를 추가했습니다.
- `bottom_duo_raw`에서 `COUNT(DISTINCT match_id)`로 현재 coverage를 계산하고, 기존 Phase 1 응답 계약은 그대로 유지했습니다.
- coverage 모듈 내부를 enum 기반 status, 전용 예외, 더 좁은 MVC/JPA 테스트 슬라이스로 정리했습니다.

## 검증
- ./gradlew test --tests "com.bestduo_BE.coverage.application.CoverageBucketServiceTest" --tests "com.bestduo_BE.coverage.presentation.api.AdminCoverageControllerTest" --tests "com.bestduo_BE.coverage.infra.persistence.repository.CoverageBucketCountJpaRepositoryTest"

## 참고
- `BottomDuoStatisticsController.java`, `application.yml`, docs에 있던 기존 워킹트리 변경은 이번 PR에 포함하지 않았습니다.
- 전체 `./gradlew test`에는 coverage 모듈 밖의 기존 실패가 남아 있습니다.