### PR TITLE
FEAT : summoner tier metadata Phase 2 추가

### DIFF
--- a/src/main/java/com/bestduo_BE/common/infra/persistence/entity/Summoner.java
+++ b/src/main/java/com/bestduo_BE/common/infra/persistence/entity/Summoner.java
@@ -1,7 +1,10 @@
 package com.bestduo_BE.common.infra.persistence.entity;
 
+import com.bestduo_BE.common.domain.model.Tier;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import java.time.OffsetDateTime;
@@ -26,6 +29,16 @@ public class Summoner {
   @Column(name = "last_match_start_time")
   private Long lastMatchStartTime; // epoch seconds
 
+  @Enumerated(EnumType.STRING)
+  @Column(name = "last_known_tier")
+  private Tier lastKnownTier;
+
+  @Column(name = "tier_observed_at")
+  private OffsetDateTime tierObservedAt;
+
+  @Column(name = "last_seen_patch")
+  private String lastSeenPatch;
+
   @Column(name = "created_at", nullable = false)
   private OffsetDateTime createdAt;
 
@@ -37,9 +50,18 @@ public class Summoner {
     return Summoner.builder()
         .puuid(puuid)
         .lastMatchStartTime(null)
+        .lastKnownTier(null)
+        .tierObservedAt(null)
+        .lastSeenPatch(null)
         .createdAt(now)
         .updatedAt(now)
         .build();
+  }
+
+  public void observeTier(Tier tier, OffsetDateTime observedAt) {
+    this.lastKnownTier = tier;
+    this.tierObservedAt = observedAt;
+    this.updatedAt = OffsetDateTime.now();
   }
 
   public void advanceLastMatchStartTime(Long newLastMatchStartTimeOrNull) {

--- a/src/main/java/com/bestduo_BE/common/infra/persistence/repository/SummonerJpaRepository.java
+++ b/src/main/java/com/bestduo_BE/common/infra/persistence/repository/SummonerJpaRepository.java
@@ -35,12 +35,35 @@ public interface SummonerJpaRepository extends JpaRepository<Summoner, String> {
       """, nativeQuery = true)
   int insertIfAbsent(@Param("puuid") String puuid, @Param("now") OffsetDateTime now);
 
+  @Modifying(clearAutomatically = true, flushAutomatically = true)
+  @Query(value = """
+      update summoner
+      set last_known_tier = :lastKnownTier,
+          tier_observed_at = :tierObservedAt,
+          updated_at = now()
+      where puuid = :puuid
+      """, nativeQuery = true)
+  int updateTierMetadata(
+      @Param("puuid") String puuid,
+      @Param("lastKnownTier") String lastKnownTier,
+      @Param("tierObservedAt") OffsetDateTime tierObservedAt
+  );
+
   @Query(value = """
       select s.*
       from summoner s
-      order by s.updated_at asc
+      order by
+        case
+          when :requestedTier = 'ALL_TIERS' then 0
+          when s.last_known_tier = :requestedTier then 0
+          when s.last_known_tier is null then 1
+          else 2
+        end asc,
+        case when s.tier_observed_at is null then 0 else 1 end asc,
+        s.tier_observed_at asc,
+        s.updated_at asc
       limit :limit
       """, nativeQuery = true)
-  List<Summoner> findRefreshTargets(@Param("limit") int limit);
+  List<Summoner> findRefreshTargets(@Param("limit") int limit, @Param("requestedTier") String requestedTier);
 
 }

--- a/src/main/java/com/bestduo_BE/refresh/application/RefreshBatchExecutor.java
+++ b/src/main/java/com/bestduo_BE/refresh/application/RefreshBatchExecutor.java
@@ -19,7 +19,7 @@ public class RefreshBatchExecutor {
   }
 
   public Result execute(int limit, Tier requestedTier) {
-    var targets = summonerJpaRepository.findRefreshTargets(limit);
+    var targets = summonerJpaRepository.findRefreshTargets(limit, requestedTier.name());
 
     int processed = 0;
     int success = 0;

--- a/src/main/java/com/bestduo_BE/refresh/application/RefreshSummonerMatches.java
+++ b/src/main/java/com/bestduo_BE/refresh/application/RefreshSummonerMatches.java
@@ -8,6 +8,7 @@ import com.bestduo_BE.common.domain.model.Tier;
 import com.bestduo_BE.common.infra.persistence.entity.Summoner;
 import com.bestduo_BE.common.infra.riot.dto.LeagueEntry;
 import java.time.Instant;
+import java.time.OffsetDateTime;
 import java.util.Comparator;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -41,6 +42,8 @@ public class RefreshSummonerMatches {
         summonerRefreshStatusUpdater.syncRefreshCursor(puuid, summoner.getLastMatchStartTime());
         return new Result(puuid, 0, collectionTier, summoner.getLastMatchStartTime());
       }
+
+      summonerRefreshStatusUpdater.syncResolvedTier(puuid, collectionTier, OffsetDateTime.now());
 
       if (requestedTier != null && requestedTier != Tier.ALL_TIERS && requestedTier != collectionTier) {
         summonerRefreshStatusUpdater.syncRefreshCursor(puuid, summoner.getLastMatchStartTime());

--- a/src/main/java/com/bestduo_BE/refresh/application/port/SummonerRefreshStatusUpdater.java
+++ b/src/main/java/com/bestduo_BE/refresh/application/port/SummonerRefreshStatusUpdater.java
@@ -1,10 +1,14 @@
 package com.bestduo_BE.refresh.application.port;
 
+import com.bestduo_BE.common.domain.model.Tier;
 import com.bestduo_BE.common.infra.persistence.entity.Summoner;
+import java.time.OffsetDateTime;
 
 public interface SummonerRefreshStatusUpdater {
 
   Summoner findOrCreate(String puuid);
+
+  void syncResolvedTier(String puuid, Tier tier, OffsetDateTime observedAt);
 
   void syncRefreshCursor(String puuid, Long newLastMatchStartTime);
 }

--- a/src/main/java/com/bestduo_BE/refresh/infra/persistence/SummonerRefreshStatusUpdaterImpl.java
+++ b/src/main/java/com/bestduo_BE/refresh/infra/persistence/SummonerRefreshStatusUpdaterImpl.java
@@ -1,8 +1,10 @@
 package com.bestduo_BE.refresh.infra.persistence;
 
+import com.bestduo_BE.common.domain.model.Tier;
 import com.bestduo_BE.refresh.application.port.SummonerRefreshStatusUpdater;
 import com.bestduo_BE.common.infra.persistence.entity.Summoner;
 import com.bestduo_BE.common.infra.persistence.repository.SummonerJpaRepository;
+import java.time.OffsetDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,6 +20,12 @@ public class SummonerRefreshStatusUpdaterImpl implements SummonerRefreshStatusUp
   public Summoner findOrCreate(String puuid) {
     return repository.findById(puuid)
         .orElseGet(() -> repository.save(Summoner.create(puuid)));
+  }
+
+  @Override
+  @Transactional
+  public void syncResolvedTier(String puuid, Tier tier, OffsetDateTime observedAt) {
+    repository.updateTierMetadata(puuid, tier == null ? null : tier.name(), observedAt);
   }
 
   @Override

--- a/src/test/java/com/bestduo_BE/common/infra/persistence/entity/SummonerTest.java
+++ b/src/test/java/com/bestduo_BE/common/infra/persistence/entity/SummonerTest.java
@@ -2,6 +2,8 @@ package com.bestduo_BE.common.infra.persistence.entity;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.bestduo_BE.common.domain.model.Tier;
+import java.time.OffsetDateTime;
 import org.junit.jupiter.api.Test;
 
 class SummonerTest {
@@ -12,8 +14,22 @@ class SummonerTest {
 
     assertThat(summoner.getPuuid()).isEqualTo("p-1");
     assertThat(summoner.getLastMatchStartTime()).isNull();
+    assertThat(summoner.getLastKnownTier()).isNull();
+    assertThat(summoner.getTierObservedAt()).isNull();
+    assertThat(summoner.getLastSeenPatch()).isNull();
     assertThat(summoner.getCreatedAt()).isNotNull();
     assertThat(summoner.getUpdatedAt()).isNotNull();
+  }
+
+  @Test
+  void observeTierStoresLatestTierMetadata() {
+    Summoner summoner = Summoner.create("p-tier");
+    OffsetDateTime observedAt = OffsetDateTime.now().minusMinutes(1);
+
+    summoner.observeTier(Tier.MASTER, observedAt);
+
+    assertThat(summoner.getLastKnownTier()).isEqualTo(Tier.MASTER);
+    assertThat(summoner.getTierObservedAt()).isEqualTo(observedAt);
   }
 
   @Test

--- a/src/test/java/com/bestduo_BE/common/infra/persistence/repository/SummonerJpaRepositoryTest.java
+++ b/src/test/java/com/bestduo_BE/common/infra/persistence/repository/SummonerJpaRepositoryTest.java
@@ -1,0 +1,63 @@
+package com.bestduo_BE.common.infra.persistence.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.bestduo_BE.common.domain.model.Tier;
+import com.bestduo_BE.common.infra.persistence.entity.Summoner;
+import java.time.OffsetDateTime;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.test.context.TestPropertySource;
+
+@DataJpaTest
+@TestPropertySource(properties = {
+    "spring.datasource.url=jdbc:h2:mem:summoner-repo;MODE=PostgreSQL;DB_CLOSE_DELAY=-1",
+    "spring.datasource.username=sa",
+    "spring.datasource.password=",
+    "spring.datasource.driver-class-name=org.h2.Driver",
+    "spring.jpa.hibernate.ddl-auto=create",
+    "spring.jpa.show-sql=false"
+})
+class SummonerJpaRepositoryTest {
+
+  @Autowired
+  private SummonerJpaRepository repository;
+
+  @Test
+  void findRefreshTargetsPrefersRequestedTierThenUnknownTier() {
+    Summoner gold = repository.save(summoner("gold", Tier.GOLD, OffsetDateTime.now().minusHours(2), OffsetDateTime.now().minusHours(2)));
+    repository.save(summoner("unknown", null, null, OffsetDateTime.now().minusHours(3)));
+    repository.save(summoner("silver", Tier.SILVER, OffsetDateTime.now().minusHours(4), OffsetDateTime.now().minusHours(4)));
+
+    List<Summoner> targets = repository.findRefreshTargets(2, Tier.GOLD.name());
+
+    assertThat(targets).extracting(Summoner::getPuuid).containsExactly(gold.getPuuid(), "unknown");
+  }
+
+  @Test
+  void updateTierMetadataStoresObservedTier() {
+    repository.save(Summoner.create("p-1"));
+    OffsetDateTime observedAt = OffsetDateTime.now().minusMinutes(5);
+
+    repository.updateTierMetadata("p-1", Tier.MASTER.name(), observedAt);
+
+    Summoner updated = repository.findById("p-1").orElseThrow();
+    assertThat(updated.getLastKnownTier()).isEqualTo(Tier.MASTER);
+    assertThat(updated.getTierObservedAt()).isEqualTo(observedAt);
+  }
+
+  private Summoner summoner(String puuid, Tier tier, OffsetDateTime observedAt, OffsetDateTime updatedAt) {
+    OffsetDateTime createdAt = updatedAt != null ? updatedAt.minusHours(1) : OffsetDateTime.now().minusHours(1);
+    return Summoner.builder()
+        .puuid(puuid)
+        .lastMatchStartTime(null)
+        .lastKnownTier(tier)
+        .tierObservedAt(observedAt)
+        .lastSeenPatch(null)
+        .createdAt(createdAt)
+        .updatedAt(updatedAt != null ? updatedAt : OffsetDateTime.now())
+        .build();
+  }
+}

--- a/src/test/java/com/bestduo_BE/refresh/application/RefreshBatchExecutorTest.java
+++ b/src/test/java/com/bestduo_BE/refresh/application/RefreshBatchExecutorTest.java
@@ -34,7 +34,7 @@ class RefreshBatchExecutorTest {
   @Test
   void aggregateSuccessAndFailureCounts() {
     List<Summoner> targets = List.of(summoner("p1"), summoner("p2"), summoner("p3"));
-    given(summonerJpaRepository.findRefreshTargets(3)).willReturn(targets);
+    given(summonerJpaRepository.findRefreshTargets(3, Tier.GOLD.name())).willReturn(targets);
     given(refreshSummonerMatches.execute("p1", Tier.GOLD))
         .willReturn(new RefreshSummonerMatches.Result("p1", 2, Tier.GOLD, 1L));
     given(refreshSummonerMatches.execute("p2", Tier.GOLD))
@@ -44,7 +44,7 @@ class RefreshBatchExecutorTest {
 
     RefreshBatchExecutor.Result result = useCase.execute(3, Tier.GOLD);
 
-    verify(summonerJpaRepository).findRefreshTargets(3);
+    verify(summonerJpaRepository).findRefreshTargets(3, Tier.GOLD.name());
     assertThat(result.processed()).isEqualTo(3);
     assertThat(result.success()).isEqualTo(2);
     assertThat(result.failed()).isEqualTo(1);
@@ -53,7 +53,7 @@ class RefreshBatchExecutorTest {
 
   @Test
   void returnZerosWhenNoTargetsFound() {
-    given(summonerJpaRepository.findRefreshTargets(5)).willReturn(List.of());
+    given(summonerJpaRepository.findRefreshTargets(5, Tier.ALL_TIERS.name())).willReturn(List.of());
 
     RefreshBatchExecutor.Result result = useCase.execute(5, Tier.ALL_TIERS);
 
@@ -65,7 +65,7 @@ class RefreshBatchExecutorTest {
 
   @Test
   void defaultExecuteUsesAllTiers() {
-    given(summonerJpaRepository.findRefreshTargets(1)).willReturn(List.of(summoner("p1")));
+    given(summonerJpaRepository.findRefreshTargets(1, Tier.ALL_TIERS.name())).willReturn(List.of(summoner("p1")));
     given(refreshSummonerMatches.execute("p1", Tier.ALL_TIERS))
         .willReturn(new RefreshSummonerMatches.Result("p1", 1, Tier.GOLD, 1L));
 
@@ -77,13 +77,13 @@ class RefreshBatchExecutorTest {
 
   @Test
   void stillForwardsRequestedTierToRefreshWorker() {
-    given(summonerJpaRepository.findRefreshTargets(2)).willReturn(List.of(summoner("p1")));
+    given(summonerJpaRepository.findRefreshTargets(2, Tier.EMERALD.name())).willReturn(List.of(summoner("p1")));
     given(refreshSummonerMatches.execute("p1", Tier.EMERALD))
         .willReturn(new RefreshSummonerMatches.Result("p1", 1, Tier.EMERALD, 1L));
 
     RefreshBatchExecutor.Result result = useCase.execute(2, Tier.EMERALD);
 
-    verify(summonerJpaRepository).findRefreshTargets(2);
+    verify(summonerJpaRepository).findRefreshTargets(2, Tier.EMERALD.name());
     verify(refreshSummonerMatches).execute("p1", Tier.EMERALD);
     assertThat(result.success()).isEqualTo(1);
   }

--- a/src/test/java/com/bestduo_BE/refresh/application/RefreshSummonerMatchesTest.java
+++ b/src/test/java/com/bestduo_BE/refresh/application/RefreshSummonerMatchesTest.java
@@ -77,6 +77,7 @@ class RefreshSummonerMatchesTest {
     RefreshSummonerMatches.Result result = useCase.execute("p-new", Tier.EMERALD);
     long after = Instant.now().getEpochSecond();
 
+    verify(summonerRefreshStatusUpdater).syncResolvedTier(org.mockito.ArgumentMatchers.eq("p-new"), org.mockito.ArgumentMatchers.eq(Tier.EMERALD), org.mockito.ArgumentMatchers.any(OffsetDateTime.class));
     verify(matchQueueEnqueuer).enqueueAllIdempotent(List.of("m-1", "m-2"), Tier.EMERALD, 10);
     assertThat(result.matchIdsEnqueued()).isEqualTo(2);
     assertThat(result.collectionTier()).isEqualTo(Tier.EMERALD);
@@ -125,6 +126,7 @@ class RefreshSummonerMatchesTest {
 
     RefreshSummonerMatches.Result result = useCase.execute("p-miss", Tier.GOLD);
 
+    verify(summonerRefreshStatusUpdater).syncResolvedTier(org.mockito.ArgumentMatchers.eq("p-miss"), org.mockito.ArgumentMatchers.eq(Tier.EMERALD), org.mockito.ArgumentMatchers.any(OffsetDateTime.class));
     verify(summonerRefreshStatusUpdater).syncRefreshCursor("p-miss", 777L);
     verifyNoInteractions(matchIdsFinder, matchQueueEnqueuer);
     assertThat(result.matchIdsEnqueued()).isZero();


### PR DESCRIPTION
## 요약
- `Summoner`에 nullable tier metadata(`lastKnownTier`, `tierObservedAt`, `lastSeenPatch`)를 추가했습니다.
- refresh batch가 요청 tier를 기준으로 대상을 우선 선택하도록 tier-aware selector를 연결했습니다.
- refresh 시점에 resolved tier를 summoner metadata에 동기화하고, 관련 단위/저장소 테스트를 추가했습니다.

## 검증
- ./gradlew test --tests \"com.bestduo_BE.common.infra.persistence.entity.SummonerTest\" --tests \"com.bestduo_BE.common.infra.persistence.repository.SummonerJpaRepositoryTest\" --tests \"com.bestduo_BE.refresh.application.RefreshBatchExecutorTest\" --tests \"com.bestduo_BE.refresh.application.RefreshSummonerMatchesTest\"

## 범위
- 이번 브랜치는 Phase 2 최소 범위만 포함합니다.
- seed-time metadata 초기화와 ingest participant discovery metadata 확장은 포함하지 않았습니다.