### PR TITLE
FEAT : riot multi key Phase 3 추가

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,8 @@ PGPASSWORD=your-password
 
 # Riot API (https://developer.riotgames.com/)
 EXTERNAL_RIOT_API_KEY=RGAPI-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+EXTERNAL_RIOT_API_KEYS=RGAPI-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx,RGAPI-yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy
+EXTERNAL_RIOT_MULTI_KEY_ENABLED=false
 
 # Worker 모드 (API 서버: false, Worker 서버: true)
 SESSION_RUN_REQUEST_WORKER_ENABLED=false

--- a/src/main/java/com/bestduo_BE/common/infra/riot/KeyLease.java
+++ b/src/main/java/com/bestduo_BE/common/infra/riot/KeyLease.java
@@ -1,0 +1,28 @@
+package com.bestduo_BE.common.infra.riot;
+
+import java.time.Duration;
+
+public class KeyLease implements AutoCloseable {
+
+  private final RiotKeyState keyState;
+
+  public KeyLease(RiotKeyState keyState) {
+    this.keyState = keyState;
+  }
+
+  public String apiKey() {
+    return keyState.apiKey();
+  }
+
+  public void acquire() {
+    keyState.acquire();
+  }
+
+  public void markRateLimited(Duration retryAfter) {
+    keyState.markRateLimited(retryAfter);
+  }
+
+  @Override
+  public void close() {
+  }
+}

--- a/src/main/java/com/bestduo_BE/common/infra/riot/RiotApiConfig.java
+++ b/src/main/java/com/bestduo_BE/common/infra/riot/RiotApiConfig.java
@@ -1,62 +1,49 @@
 package com.bestduo_BE.common.infra.riot;
 
-import java.time.Duration;
-import org.springframework.beans.factory.annotation.Value;
+import com.bestduo_BE.config.RiotApiProperties;
+import java.time.Clock;
 import org.springframework.boot.restclient.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.client.ClientHttpRequestInterceptor;
 import org.springframework.web.client.RestTemplate;
 
 @Configuration
 public class RiotApiConfig {
 
   @Bean
-  public DualWindowRateLimiter riotRateLimiter() {
-    return new DualWindowRateLimiter(
-        10, Duration.ofSeconds(1),
-        60, Duration.ofMinutes(2)
-    );
+  public RiotKeyPool riotKeyPool(RiotApiProperties properties) {
+    return RiotKeyPool.fromKeys(properties.resolvedApiKeys(), Clock.systemUTC());
   }
 
   @Bean
-  public RiotRateLimitInterceptor riotRateLimitInterceptor(DualWindowRateLimiter limiter) {
-    return new RiotRateLimitInterceptor(limiter);
+  public RiotRateLimitInterceptor riotRateLimitInterceptor(RiotKeyPool keyPool) {
+    return new RiotRateLimitInterceptor(keyPool);
   }
 
   @Bean(name = "riotPlatformRestTemplate")
   public RestTemplate riotPlatformRestTemplate(
       RestTemplateBuilder restTemplateBuilder,
       RiotRateLimitInterceptor rateLimitInterceptor,
-      @Value("${external.riot.platform-base-url}") String platformBaseUrl,
-      @Value("${external.riot.api-key}") String apiKey) {
-    return buildRiotRestTemplate(restTemplateBuilder, platformBaseUrl, apiKey, rateLimitInterceptor);
+      RiotApiProperties properties) {
+    return buildRiotRestTemplate(restTemplateBuilder, properties.getPlatformBaseUrl(), rateLimitInterceptor);
   }
 
   @Bean(name = "riotRegionalRestTemplate")
   public RestTemplate riotRegionalRestTemplate(
       RestTemplateBuilder restTemplateBuilder,
       RiotRateLimitInterceptor rateLimitInterceptor,
-      @Value("${external.riot.regional-base-url}") String regionalBaseUrl,
-      @Value("${external.riot.api-key}") String apiKey) {
-    return buildRiotRestTemplate(restTemplateBuilder, regionalBaseUrl, apiKey, rateLimitInterceptor);
+      RiotApiProperties properties) {
+    return buildRiotRestTemplate(restTemplateBuilder, properties.getRegionalBaseUrl(), rateLimitInterceptor);
   }
 
   private RestTemplate buildRiotRestTemplate(
       RestTemplateBuilder restTemplateBuilder,
       String baseUrl,
-      String apiKey,
       RiotRateLimitInterceptor rateLimitInterceptor) {
-
-    ClientHttpRequestInterceptor authInterceptor = (request, body, execution) -> {
-      request.getHeaders().add("X-Riot-Token", apiKey);
-      return execution.execute(request, body);
-    };
 
     return restTemplateBuilder
         .rootUri(baseUrl)
-        // ✅ 여기서 List.of 쓰지 말고 varargs로!
-        .additionalInterceptors(rateLimitInterceptor, authInterceptor)
+        .additionalInterceptors(rateLimitInterceptor)
         .build();
   }
 }

--- a/src/main/java/com/bestduo_BE/common/infra/riot/RiotKeyPool.java
+++ b/src/main/java/com/bestduo_BE/common/infra/riot/RiotKeyPool.java
@@ -1,0 +1,48 @@
+package com.bestduo_BE.common.infra.riot;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class RiotKeyPool {
+
+  private static final Duration DEFAULT_RETRY_AFTER = Duration.ofSeconds(10);
+
+  private final List<RiotKeyState> keyStates;
+  private final AtomicInteger nextIndex = new AtomicInteger();
+
+  public RiotKeyPool(List<RiotKeyState> keyStates) {
+    this.keyStates = List.copyOf(keyStates);
+  }
+
+  public static RiotKeyPool fromKeys(List<String> apiKeys, Clock clock) {
+    return new RiotKeyPool(apiKeys.stream()
+        .map(key -> new RiotKeyState(
+            key,
+            new DualWindowRateLimiter(10, Duration.ofSeconds(1), 60, Duration.ofMinutes(2)),
+            clock
+        ))
+        .toList());
+  }
+
+  public KeyLease lease() {
+    if (keyStates.isEmpty()) {
+      throw new IllegalStateException("No Riot API keys configured");
+    }
+
+    int start = Math.floorMod(nextIndex.getAndIncrement(), keyStates.size());
+    for (int offset = 0; offset < keyStates.size(); offset++) {
+      RiotKeyState state = keyStates.get((start + offset) % keyStates.size());
+      if (state.isAvailable()) {
+        return new KeyLease(state);
+      }
+    }
+
+    throw new IllegalStateException("All Riot API keys are cooling down");
+  }
+
+  public Duration defaultRetryAfter() {
+    return DEFAULT_RETRY_AFTER;
+  }
+}

--- a/src/main/java/com/bestduo_BE/common/infra/riot/RiotKeyState.java
+++ b/src/main/java/com/bestduo_BE/common/infra/riot/RiotKeyState.java
@@ -1,0 +1,37 @@
+package com.bestduo_BE.common.infra.riot;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+
+public class RiotKeyState {
+
+  private final String apiKey;
+  private final DualWindowRateLimiter rateLimiter;
+  private final Clock clock;
+  private Instant cooldownUntil;
+
+  public RiotKeyState(String apiKey, DualWindowRateLimiter rateLimiter, Clock clock) {
+    this.apiKey = apiKey;
+    this.rateLimiter = rateLimiter;
+    this.clock = clock;
+    this.cooldownUntil = Instant.EPOCH;
+  }
+
+  public String apiKey() {
+    return apiKey;
+  }
+
+  public void acquire() {
+    rateLimiter.acquire();
+  }
+
+  public synchronized boolean isAvailable() {
+    return !clock.instant().isBefore(cooldownUntil);
+  }
+
+  public synchronized void markRateLimited(Duration retryAfter) {
+    Duration cooldown = retryAfter == null || retryAfter.isNegative() ? Duration.ofSeconds(10) : retryAfter;
+    this.cooldownUntil = clock.instant().plus(cooldown);
+  }
+}

--- a/src/main/java/com/bestduo_BE/common/infra/riot/RiotKeyState.java
+++ b/src/main/java/com/bestduo_BE/common/infra/riot/RiotKeyState.java
@@ -32,6 +32,9 @@ public class RiotKeyState {
 
   public synchronized void markRateLimited(Duration retryAfter) {
     Duration cooldown = retryAfter == null || retryAfter.isNegative() ? Duration.ofSeconds(10) : retryAfter;
-    this.cooldownUntil = clock.instant().plus(cooldown);
+    Instant candidateCooldownUntil = clock.instant().plus(cooldown);
+    if (candidateCooldownUntil.isAfter(this.cooldownUntil)) {
+      this.cooldownUntil = candidateCooldownUntil;
+    }
   }
 }

--- a/src/main/java/com/bestduo_BE/common/infra/riot/RiotRateLimitInterceptor.java
+++ b/src/main/java/com/bestduo_BE/common/infra/riot/RiotRateLimitInterceptor.java
@@ -3,6 +3,7 @@ package com.bestduo_BE.common.infra.riot;
 import com.bestduo_BE.common.infra.riot.budget.RiotRequestBudget;
 import com.bestduo_BE.common.infra.riot.exception.RiotRateLimitedException;
 import java.io.IOException;
+import java.time.Duration;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpRequest;
 import org.springframework.http.HttpStatus;
@@ -13,7 +14,7 @@ import org.springframework.http.client.ClientHttpResponse;
 @RequiredArgsConstructor
 public class RiotRateLimitInterceptor implements ClientHttpRequestInterceptor {
 
-  private final DualWindowRateLimiter rateLimiter;
+  private final RiotKeyPool keyPool;
 
   @Override
   public ClientHttpResponse intercept(
@@ -21,21 +22,32 @@ public class RiotRateLimitInterceptor implements ClientHttpRequestInterceptor {
   ) throws IOException {
 
     RiotRequestBudget.consume(1);
-    // ✅ 모든 Riot API 요청에 공통 적용
-    rateLimiter.acquire();
+    try (KeyLease lease = keyPool.lease()) {
+      request.getHeaders().set("X-Riot-Token", lease.apiKey());
+      lease.acquire();
 
-    ClientHttpResponse response = execution.execute(request, body);
+      ClientHttpResponse response = execution.execute(request, body);
 
-    // ✅ 429 감지 (개발키 보호 모드에서 유용)
-    if (response.getStatusCode() == HttpStatus.TOO_MANY_REQUESTS) {
-      String retryAfter = response.getHeaders().getFirst("Retry-After");
-      String msg = "Riot API rate limited (429). retry-after=" + retryAfter
-          + ", uri=" + request.getURI();
+      if (response.getStatusCode() == HttpStatus.TOO_MANY_REQUESTS) {
+        String retryAfter = response.getHeaders().getFirst("Retry-After");
+        lease.markRateLimited(parseRetryAfter(retryAfter));
+        String msg = "Riot API rate limited (429). retry-after=" + retryAfter
+            + ", uri=" + request.getURI();
 
-      // response body를 읽고 싶다면 여기서 읽어야 하지만, 보통 헤더/URI만으로 충분
-      throw new RiotRateLimitedException(msg);
+        throw new RiotRateLimitedException(msg);
+      }
+
+      return response;
     }
+  }
 
-    return response;
+  private Duration parseRetryAfter(String retryAfter) {
+    try {
+      return retryAfter == null || retryAfter.isBlank()
+          ? keyPool.defaultRetryAfter()
+          : Duration.ofSeconds(Long.parseLong(retryAfter));
+    } catch (NumberFormatException e) {
+      return keyPool.defaultRetryAfter();
+    }
   }
 }

--- a/src/main/java/com/bestduo_BE/common/infra/riot/RiotRateLimitInterceptor.java
+++ b/src/main/java/com/bestduo_BE/common/infra/riot/RiotRateLimitInterceptor.java
@@ -33,6 +33,7 @@ public class RiotRateLimitInterceptor implements ClientHttpRequestInterceptor {
         lease.markRateLimited(parseRetryAfter(retryAfter));
         String msg = "Riot API rate limited (429). retry-after=" + retryAfter
             + ", uri=" + request.getURI();
+        response.close();
 
         throw new RiotRateLimitedException(msg);
       }

--- a/src/main/java/com/bestduo_BE/config/RiotApiProperties.java
+++ b/src/main/java/com/bestduo_BE/config/RiotApiProperties.java
@@ -21,6 +21,7 @@ public class RiotApiProperties {
   public List<String> resolvedApiKeys() {
     List<String> sanitizedKeys = apiKeys == null ? List.of() : apiKeys.stream()
           .filter(key -> key != null && !key.isBlank())
+          .map(String::trim)
           .distinct()
           .toList();
 
@@ -32,6 +33,6 @@ public class RiotApiProperties {
       return List.of();
     }
 
-    return List.of(apiKey);
+    return List.of(apiKey.trim());
   }
 }

--- a/src/main/java/com/bestduo_BE/config/RiotApiProperties.java
+++ b/src/main/java/com/bestduo_BE/config/RiotApiProperties.java
@@ -1,0 +1,37 @@
+package com.bestduo_BE.config;
+
+import java.util.List;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties(prefix = "external.riot")
+@Getter
+@Setter
+public class RiotApiProperties {
+
+  private String platformBaseUrl;
+  private String regionalBaseUrl;
+  private String apiKey;
+  private List<String> apiKeys = List.of();
+  private boolean multiKeyEnabled = false;
+
+  public List<String> resolvedApiKeys() {
+    List<String> sanitizedKeys = apiKeys == null ? List.of() : apiKeys.stream()
+          .filter(key -> key != null && !key.isBlank())
+          .distinct()
+          .toList();
+
+    if (multiKeyEnabled && !sanitizedKeys.isEmpty()) {
+      return sanitizedKeys;
+    }
+
+    if (apiKey == null || apiKey.isBlank()) {
+      return List.of();
+    }
+
+    return List.of(apiKey);
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -26,6 +26,8 @@ external:
     platform-base-url: https://kr.api.riotgames.com
     regional-base-url: https://asia.api.riotgames.com
     api-key: ${EXTERNAL_RIOT_API_KEY:}
+    api-keys: ${EXTERNAL_RIOT_API_KEYS:}
+    multi-key-enabled: ${EXTERNAL_RIOT_MULTI_KEY_ENABLED:false}
 
 collector:
   seed-puuids: [] # TODO populate with seed accounts to crawl

--- a/src/test/java/com/bestduo_BE/common/infra/riot/RiotApiConfigTest.java
+++ b/src/test/java/com/bestduo_BE/common/infra/riot/RiotApiConfigTest.java
@@ -1,0 +1,74 @@
+package com.bestduo_BE.common.infra.riot;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.bestduo_BE.config.RiotApiProperties;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.restclient.RestTemplateBuilder;
+import org.springframework.web.client.RestTemplate;
+
+class RiotApiConfigTest {
+
+  private final RiotApiConfig config = new RiotApiConfig();
+
+  @Test
+  void riotKeyPoolFallsBackToSingleKeyWhenMultiKeyDisabled() {
+    RiotApiProperties properties = new RiotApiProperties();
+    properties.setApiKey("single-key");
+    properties.setApiKeys(List.of("key-a", "key-b"));
+    properties.setMultiKeyEnabled(false);
+
+    RiotKeyPool keyPool = config.riotKeyPool(properties);
+
+    try (KeyLease first = keyPool.lease(); KeyLease second = keyPool.lease()) {
+      assertThat(first.apiKey()).isEqualTo("single-key");
+      assertThat(second.apiKey()).isEqualTo("single-key");
+    }
+  }
+
+  @Test
+  void riotKeyPoolUsesDistinctMultiKeysWhenEnabled() {
+    RiotApiProperties properties = new RiotApiProperties();
+    properties.setApiKey("single-key");
+    properties.setApiKeys(List.of("key-a", "key-a", "key-b"));
+    properties.setMultiKeyEnabled(true);
+
+    RiotKeyPool keyPool = config.riotKeyPool(properties);
+
+    try (KeyLease first = keyPool.lease(); KeyLease second = keyPool.lease()) {
+      assertThat(first.apiKey()).isEqualTo("key-a");
+      assertThat(second.apiKey()).isEqualTo("key-b");
+    }
+  }
+
+  @Test
+  void riotKeyPoolFallsBackToSingleKeyWhenMultiKeyListIsBlank() {
+    RiotApiProperties properties = new RiotApiProperties();
+    properties.setApiKey("single-key");
+    properties.setApiKeys(List.of(" ", ""));
+    properties.setMultiKeyEnabled(true);
+
+    RiotKeyPool keyPool = config.riotKeyPool(properties);
+
+    try (KeyLease first = keyPool.lease(); KeyLease second = keyPool.lease()) {
+      assertThat(first.apiKey()).isEqualTo("single-key");
+      assertThat(second.apiKey()).isEqualTo("single-key");
+    }
+  }
+
+  @Test
+  void restTemplateBeansAreStillCreatedWithExistingNames() {
+    RiotApiProperties properties = new RiotApiProperties();
+    properties.setPlatformBaseUrl("https://kr.api.riotgames.com");
+    properties.setRegionalBaseUrl("https://asia.api.riotgames.com");
+    properties.setApiKey("single-key");
+    RiotRateLimitInterceptor interceptor = new RiotRateLimitInterceptor(config.riotKeyPool(properties));
+
+    RestTemplate platform = config.riotPlatformRestTemplate(new RestTemplateBuilder(), interceptor, properties);
+    RestTemplate regional = config.riotRegionalRestTemplate(new RestTemplateBuilder(), interceptor, properties);
+
+    assertThat(platform).isNotNull();
+    assertThat(regional).isNotNull();
+  }
+}

--- a/src/test/java/com/bestduo_BE/common/infra/riot/RiotKeyPoolTest.java
+++ b/src/test/java/com/bestduo_BE/common/infra/riot/RiotKeyPoolTest.java
@@ -1,0 +1,74 @@
+package com.bestduo_BE.common.infra.riot;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class RiotKeyPoolTest {
+
+  @Test
+  void leaseRotatesAcrossAvailableKeys() {
+    Clock clock = Clock.fixed(Instant.parse("2026-03-30T00:00:00Z"), ZoneOffset.UTC);
+    RiotKeyPool keyPool = RiotKeyPool.fromKeys(List.of("key-a", "key-b"), clock);
+
+    try (KeyLease first = keyPool.lease(); KeyLease second = keyPool.lease()) {
+      assertThat(first.apiKey()).isEqualTo("key-a");
+      assertThat(second.apiKey()).isEqualTo("key-b");
+    }
+  }
+
+  @Test
+  void leaseSkipsRateLimitedKey() {
+    MutableClock clock = new MutableClock(Instant.parse("2026-03-30T00:00:00Z"));
+    RiotKeyState first = new RiotKeyState("key-a", new DualWindowRateLimiter(10, Duration.ofMillis(1), 60, Duration.ofMinutes(2)), clock);
+    RiotKeyState second = new RiotKeyState("key-b", new DualWindowRateLimiter(10, Duration.ofMillis(1), 60, Duration.ofMinutes(2)), clock);
+    RiotKeyPool keyPool = new RiotKeyPool(List.of(first, second));
+
+    first.markRateLimited(Duration.ofSeconds(30));
+
+    try (KeyLease lease = keyPool.lease()) {
+      assertThat(lease.apiKey()).isEqualTo("key-b");
+    }
+  }
+
+  @Test
+  void leaseFailsWhenAllKeysCoolingDown() {
+    MutableClock clock = new MutableClock(Instant.parse("2026-03-30T00:00:00Z"));
+    RiotKeyState first = new RiotKeyState("key-a", new DualWindowRateLimiter(10, Duration.ofMillis(1), 60, Duration.ofMinutes(2)), clock);
+    RiotKeyPool keyPool = new RiotKeyPool(List.of(first));
+    first.markRateLimited(Duration.ofSeconds(30));
+
+    assertThatThrownBy(keyPool::lease)
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("All Riot API keys are cooling down");
+  }
+
+  private static final class MutableClock extends Clock {
+    private Instant instant;
+
+    private MutableClock(Instant instant) {
+      this.instant = instant;
+    }
+
+    @Override
+    public ZoneOffset getZone() {
+      return ZoneOffset.UTC;
+    }
+
+    @Override
+    public Clock withZone(java.time.ZoneId zone) {
+      return this;
+    }
+
+    @Override
+    public Instant instant() {
+      return instant;
+    }
+  }
+}

--- a/src/test/java/com/bestduo_BE/common/infra/riot/RiotKeyPoolTest.java
+++ b/src/test/java/com/bestduo_BE/common/infra/riot/RiotKeyPoolTest.java
@@ -49,6 +49,21 @@ class RiotKeyPoolTest {
         .hasMessageContaining("All Riot API keys are cooling down");
   }
 
+  @Test
+  void longerCooldownIsNotShortenedByLaterShorterRetryAfter() {
+    MutableClock clock = new MutableClock(Instant.parse("2026-03-30T00:00:00Z"));
+    RiotKeyState state = new RiotKeyState("key-a", new DualWindowRateLimiter(10, Duration.ofMillis(1), 60, Duration.ofMinutes(2)), clock);
+
+    state.markRateLimited(Duration.ofSeconds(30));
+    clock.advance(Duration.ofSeconds(5));
+    state.markRateLimited(Duration.ofSeconds(1));
+    clock.advance(Duration.ofSeconds(20));
+
+    assertThat(state.isAvailable()).isFalse();
+    clock.advance(Duration.ofSeconds(5));
+    assertThat(state.isAvailable()).isTrue();
+  }
+
   private static final class MutableClock extends Clock {
     private Instant instant;
 
@@ -69,6 +84,10 @@ class RiotKeyPoolTest {
     @Override
     public Instant instant() {
       return instant;
+    }
+
+    private void advance(Duration duration) {
+      this.instant = this.instant.plus(duration);
     }
   }
 }

--- a/src/test/java/com/bestduo_BE/common/infra/riot/RiotRateLimitInterceptorTest.java
+++ b/src/test/java/com/bestduo_BE/common/infra/riot/RiotRateLimitInterceptorTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -52,7 +53,11 @@ class RiotRateLimitInterceptorTest {
   @Test
   void throwsRiotRateLimitedExceptionOnTooManyRequests() throws Exception {
     ClientHttpRequestExecution execution = mock(ClientHttpRequestExecution.class);
-    MockClientHttpResponse tooMany = new MockClientHttpResponse(new byte[0], HttpStatus.TOO_MANY_REQUESTS);
+    ClientHttpResponse tooMany = mock(ClientHttpResponse.class);
+    var headers = new org.springframework.http.HttpHeaders();
+    headers.set("Retry-After", "10");
+    when(tooMany.getStatusCode()).thenReturn(HttpStatus.TOO_MANY_REQUESTS);
+    when(tooMany.getHeaders()).thenReturn(headers);
     tooMany.getHeaders().set("Retry-After", "10");
     when(keyPool.lease()).thenReturn(keyLease);
     when(keyLease.apiKey()).thenReturn("key-a");
@@ -65,5 +70,19 @@ class RiotRateLimitInterceptorTest {
 
     verify(keyLease).acquire();
     verify(keyLease).markRateLimited(Duration.ofSeconds(10));
+    verify(tooMany).close();
+  }
+
+  @Test
+  void doesNotMarkRateLimitedWhenRequestSucceeds() throws Exception {
+    ClientHttpRequestExecution execution = mock(ClientHttpRequestExecution.class);
+    ClientHttpResponse ok = new MockClientHttpResponse(new byte[0], HttpStatus.OK);
+    when(keyPool.lease()).thenReturn(keyLease);
+    when(keyLease.apiKey()).thenReturn("key-a");
+    when(execution.execute(any(), any())).thenReturn(ok);
+
+    interceptor.intercept(request, new byte[0], execution);
+
+    verify(keyLease, never()).markRateLimited(any());
   }
 }

--- a/src/test/java/com/bestduo_BE/common/infra/riot/RiotRateLimitInterceptorTest.java
+++ b/src/test/java/com/bestduo_BE/common/infra/riot/RiotRateLimitInterceptorTest.java
@@ -7,10 +7,9 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.bestduo_BE.common.infra.riot.DualWindowRateLimiter;
-import com.bestduo_BE.common.infra.riot.RiotRateLimitInterceptor;
 import com.bestduo_BE.common.infra.riot.exception.RiotRateLimitedException;
 import java.net.URI;
+import java.time.Duration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
@@ -21,14 +20,16 @@ import org.springframework.mock.http.client.MockClientHttpResponse;
 
 class RiotRateLimitInterceptorTest {
 
-  private DualWindowRateLimiter rateLimiter;
+  private RiotKeyPool keyPool;
+  private KeyLease keyLease;
   private RiotRateLimitInterceptor interceptor;
   private MockClientHttpRequest request;
 
   @BeforeEach
   void setUp() {
-    rateLimiter = mock(DualWindowRateLimiter.class);
-    interceptor = new RiotRateLimitInterceptor(rateLimiter);
+    keyPool = mock(RiotKeyPool.class);
+    keyLease = mock(KeyLease.class);
+    interceptor = new RiotRateLimitInterceptor(keyPool);
     request = new MockClientHttpRequest();
     request.setURI(URI.create("https://riot.api/test"));
   }
@@ -37,12 +38,15 @@ class RiotRateLimitInterceptorTest {
   void acquireCalledAndResponseReturnedWhenRequestSucceeds() throws Exception {
     ClientHttpRequestExecution execution = mock(ClientHttpRequestExecution.class);
     ClientHttpResponse ok = new MockClientHttpResponse(new byte[0], HttpStatus.OK);
+    when(keyPool.lease()).thenReturn(keyLease);
+    when(keyLease.apiKey()).thenReturn("key-a");
     when(execution.execute(any(), any())).thenReturn(ok);
 
     ClientHttpResponse result = interceptor.intercept(request, new byte[0], execution);
 
     assertThat(result).isSameAs(ok);
-    verify(rateLimiter).acquire();
+    assertThat(request.getHeaders().getFirst("X-Riot-Token")).isEqualTo("key-a");
+    verify(keyLease).acquire();
   }
 
   @Test
@@ -50,6 +54,8 @@ class RiotRateLimitInterceptorTest {
     ClientHttpRequestExecution execution = mock(ClientHttpRequestExecution.class);
     MockClientHttpResponse tooMany = new MockClientHttpResponse(new byte[0], HttpStatus.TOO_MANY_REQUESTS);
     tooMany.getHeaders().set("Retry-After", "10");
+    when(keyPool.lease()).thenReturn(keyLease);
+    when(keyLease.apiKey()).thenReturn("key-a");
     when(execution.execute(any(), any())).thenReturn(tooMany);
 
     assertThatThrownBy(() -> interceptor.intercept(request, new byte[0], execution))
@@ -57,6 +63,7 @@ class RiotRateLimitInterceptorTest {
         .hasMessageContaining("retry-after=10")
         .hasMessageContaining("uri=" + request.getURI());
 
-    verify(rateLimiter).acquire();
+    verify(keyLease).acquire();
+    verify(keyLease).markRateLimited(Duration.ofSeconds(10));
   }
 }

--- a/src/test/java/com/bestduo_BE/config/RiotApiPropertiesTest.java
+++ b/src/test/java/com/bestduo_BE/config/RiotApiPropertiesTest.java
@@ -1,0 +1,29 @@
+package com.bestduo_BE.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class RiotApiPropertiesTest {
+
+  @Test
+  void resolvedApiKeysFallsBackToSingleKeyWhenMultiKeyDisabled() {
+    RiotApiProperties properties = new RiotApiProperties();
+    properties.setApiKey("single-key");
+    properties.setApiKeys(List.of("key-a", "key-b"));
+    properties.setMultiKeyEnabled(false);
+
+    assertThat(properties.resolvedApiKeys()).containsExactly("single-key");
+  }
+
+  @Test
+  void resolvedApiKeysUsesConfiguredMultiKeysWhenEnabled() {
+    RiotApiProperties properties = new RiotApiProperties();
+    properties.setApiKey("single-key");
+    properties.setApiKeys(List.of("key-a", "key-b"));
+    properties.setMultiKeyEnabled(true);
+
+    assertThat(properties.resolvedApiKeys()).containsExactly("key-a", "key-b");
+  }
+}

--- a/src/test/java/com/bestduo_BE/config/RiotApiPropertiesTest.java
+++ b/src/test/java/com/bestduo_BE/config/RiotApiPropertiesTest.java
@@ -26,4 +26,24 @@ class RiotApiPropertiesTest {
 
     assertThat(properties.resolvedApiKeys()).containsExactly("key-a", "key-b");
   }
+
+  @Test
+  void resolvedApiKeysTrimsAndDeduplicatesConfiguredKeys() {
+    RiotApiProperties properties = new RiotApiProperties();
+    properties.setApiKey("  single-key  ");
+    properties.setApiKeys(List.of(" key-a ", "key-a", " key-b "));
+    properties.setMultiKeyEnabled(true);
+
+    assertThat(properties.resolvedApiKeys()).containsExactly("key-a", "key-b");
+  }
+
+  @Test
+  void resolvedApiKeysTrimsSingleKeyFallback() {
+    RiotApiProperties properties = new RiotApiProperties();
+    properties.setApiKey("  single-key  ");
+    properties.setApiKeys(List.of(" ", ""));
+    properties.setMultiKeyEnabled(true);
+
+    assertThat(properties.resolvedApiKeys()).containsExactly("single-key");
+  }
 }


### PR DESCRIPTION
## 요약
- Riot API 설정을 단일 key와 multi-key를 함께 지원하는 구조로 확장했습니다.
- `RiotKeyPool`, `RiotKeyState`, `KeyLease`를 도입하고 key별 `DualWindowRateLimiter`를 사용하도록 변경했습니다.
- 기존 `riotPlatformRestTemplate` / `riotRegionalRestTemplate` 이름은 유지하면서 내부에서 key lease를 선택하도록 연결했습니다.
- 후속 리팩터링으로 blank key fallback, duplicate key dedupe, cooldown 단축 방지, 429 응답 close를 보강했습니다.

## 검증
- ./gradlew test --tests \"com.bestduo_BE.config.RiotApiPropertiesTest\" --tests \"com.bestduo_BE.common.infra.riot.RiotApiConfigTest\" --tests \"com.bestduo_BE.common.infra.riot.RiotKeyPoolTest\" --tests \"com.bestduo_BE.common.infra.riot.RiotRateLimitInterceptorTest\" --tests \"com.bestduo_BE.common.infra.riot.MatchIdsFinderImplTest\" --tests \"com.bestduo_BE.common.infra.riot.LeagueEntriesSeedLoaderImplTest\" --tests \"com.bestduo_BE.common.infra.riot.LeagueEntriesRefreshLoaderImplTest\" --tests \"com.bestduo_BE.common.infra.riot.RiotMatchLoaderImplTest\" --tests \"com.bestduo_BE.orchestration.application.ExecutionPipelineTest\"

## 범위
- 이번 PR은 Phase 3 범위만 포함합니다.
- work item worker 구조나 coverage scheduler 변경은 포함하지 않았습니다.