### PR TITLE
FEAT : work item 기반 병렬 worker 구조 (Phase 4)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,6 +7,8 @@ PGPASSWORD=your-password
 
 # Riot API (https://developer.riotgames.com/)
 EXTERNAL_RIOT_API_KEY=RGAPI-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+EXTERNAL_RIOT_API_KEYS=RGAPI-xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx,RGAPI-yyyyyyyy-yyyy-yyyy-yyyy-yyyyyyyyyyyy
+EXTERNAL_RIOT_MULTI_KEY_ENABLED=false
 
 # Worker 모드 (API 서버: false, Worker 서버: true)
 SESSION_RUN_REQUEST_WORKER_ENABLED=false

--- a/src/main/java/com/bestduo_BE/BestduoBeApplication.java
+++ b/src/main/java/com/bestduo_BE/BestduoBeApplication.java
@@ -3,8 +3,10 @@ package com.bestduo_BE;
 import io.github.cdimascio.dotenv.Dotenv;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
+@EnableScheduling
 public class BestduoBeApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/bestduo_BE/common/infra/persistence/entity/Summoner.java
+++ b/src/main/java/com/bestduo_BE/common/infra/persistence/entity/Summoner.java
@@ -1,7 +1,10 @@
 package com.bestduo_BE.common.infra.persistence.entity;
 
+import com.bestduo_BE.common.domain.model.Tier;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import java.time.OffsetDateTime;
@@ -26,6 +29,16 @@ public class Summoner {
   @Column(name = "last_match_start_time")
   private Long lastMatchStartTime; // epoch seconds
 
+  @Enumerated(EnumType.STRING)
+  @Column(name = "last_known_tier")
+  private Tier lastKnownTier;
+
+  @Column(name = "tier_observed_at")
+  private OffsetDateTime tierObservedAt;
+
+  @Column(name = "last_seen_patch")
+  private String lastSeenPatch;
+
   @Column(name = "created_at", nullable = false)
   private OffsetDateTime createdAt;
 
@@ -37,9 +50,18 @@ public class Summoner {
     return Summoner.builder()
         .puuid(puuid)
         .lastMatchStartTime(null)
+        .lastKnownTier(null)
+        .tierObservedAt(null)
+        .lastSeenPatch(null)
         .createdAt(now)
         .updatedAt(now)
         .build();
+  }
+
+  public void observeTier(Tier tier, OffsetDateTime observedAt) {
+    this.lastKnownTier = tier;
+    this.tierObservedAt = observedAt;
+    this.updatedAt = OffsetDateTime.now();
   }
 
   public void advanceLastMatchStartTime(Long newLastMatchStartTimeOrNull) {

--- a/src/main/java/com/bestduo_BE/common/infra/persistence/repository/IngestQueueStatsJpaRepository.java
+++ b/src/main/java/com/bestduo_BE/common/infra/persistence/repository/IngestQueueStatsJpaRepository.java
@@ -61,4 +61,21 @@ public interface IngestQueueStatsJpaRepository extends Repository<MatchQueue, St
       and mq.updated_at >= now() - (:minutes || ' minutes')::interval
     """, nativeQuery = true)
   long countDoneInLastMinutes(@Param("minutes") int minutes);
+
+  @Query(value = """
+    select count(*)
+    from match_queue mq
+    where mq.status = 'READY'
+      and (:collectionTier is null or mq.collection_tier = :collectionTier)
+    """, nativeQuery = true)
+  long countReadyByTier(@Param("collectionTier") String collectionTier);
+
+  @Query(value = """
+    select count(*)
+    from match_queue mq
+    where mq.status = 'DONE'
+      and mq.updated_at >= now() - (:minutes || ' minutes')::interval
+      and (:collectionTier is null or mq.collection_tier = :collectionTier)
+    """, nativeQuery = true)
+  long countDoneInLastMinutesByTier(@Param("minutes") int minutes, @Param("collectionTier") String collectionTier);
 }

--- a/src/main/java/com/bestduo_BE/common/infra/persistence/repository/SummonerJpaRepository.java
+++ b/src/main/java/com/bestduo_BE/common/infra/persistence/repository/SummonerJpaRepository.java
@@ -35,12 +35,35 @@ public interface SummonerJpaRepository extends JpaRepository<Summoner, String> {
       """, nativeQuery = true)
   int insertIfAbsent(@Param("puuid") String puuid, @Param("now") OffsetDateTime now);
 
+  @Modifying(clearAutomatically = true, flushAutomatically = true)
+  @Query(value = """
+      update summoner
+      set last_known_tier = :lastKnownTier,
+          tier_observed_at = :tierObservedAt,
+          updated_at = now()
+      where puuid = :puuid
+      """, nativeQuery = true)
+  int updateTierMetadata(
+      @Param("puuid") String puuid,
+      @Param("lastKnownTier") String lastKnownTier,
+      @Param("tierObservedAt") OffsetDateTime tierObservedAt
+  );
+
   @Query(value = """
       select s.*
       from summoner s
-      order by s.updated_at asc
+      order by
+        case
+          when :requestedTier = 'ALL_TIERS' then 0
+          when s.last_known_tier = :requestedTier then 0
+          when s.last_known_tier is null then 1
+          else 2
+        end asc,
+        case when s.tier_observed_at is null then 0 else 1 end asc,
+        s.tier_observed_at asc,
+        s.updated_at asc
       limit :limit
       """, nativeQuery = true)
-  List<Summoner> findRefreshTargets(@Param("limit") int limit);
+  List<Summoner> findRefreshTargets(@Param("limit") int limit, @Param("requestedTier") String requestedTier);
 
 }

--- a/src/main/java/com/bestduo_BE/common/infra/persistence/repository/SummonerJpaRepository.java
+++ b/src/main/java/com/bestduo_BE/common/infra/persistence/repository/SummonerJpaRepository.java
@@ -1,5 +1,6 @@
 package com.bestduo_BE.common.infra.persistence.repository;
 
+import com.bestduo_BE.common.domain.model.Tier;
 import com.bestduo_BE.common.infra.persistence.entity.Summoner;
 import java.time.OffsetDateTime;
 import java.util.List;
@@ -65,5 +66,15 @@ public interface SummonerJpaRepository extends JpaRepository<Summoner, String> {
       limit :limit
       """, nativeQuery = true)
   List<Summoner> findRefreshTargets(@Param("limit") int limit, @Param("requestedTier") String requestedTier);
+
+  long countByLastKnownTier(Tier tier);
+
+  @Query(value = """
+      select count(*)
+      from summoner s
+      where (s.last_known_tier = :requestedTier or s.last_known_tier is null)
+        and s.tier_observed_at is null
+      """, nativeQuery = true)
+  long countUnverifiedCandidates(@Param("requestedTier") String requestedTier);
 
 }

--- a/src/main/java/com/bestduo_BE/common/infra/riot/KeyLease.java
+++ b/src/main/java/com/bestduo_BE/common/infra/riot/KeyLease.java
@@ -1,0 +1,28 @@
+package com.bestduo_BE.common.infra.riot;
+
+import java.time.Duration;
+
+public class KeyLease implements AutoCloseable {
+
+  private final RiotKeyState keyState;
+
+  public KeyLease(RiotKeyState keyState) {
+    this.keyState = keyState;
+  }
+
+  public String apiKey() {
+    return keyState.apiKey();
+  }
+
+  public void acquire() {
+    keyState.acquire();
+  }
+
+  public void markRateLimited(Duration retryAfter) {
+    keyState.markRateLimited(retryAfter);
+  }
+
+  @Override
+  public void close() {
+  }
+}

--- a/src/main/java/com/bestduo_BE/common/infra/riot/KeyLease.java
+++ b/src/main/java/com/bestduo_BE/common/infra/riot/KeyLease.java
@@ -5,9 +5,15 @@ import java.time.Duration;
 public class KeyLease implements AutoCloseable {
 
   private final RiotKeyState keyState;
+  private final boolean releasable;
 
   public KeyLease(RiotKeyState keyState) {
+    this(keyState, true);
+  }
+
+  public KeyLease(RiotKeyState keyState, boolean releasable) {
     this.keyState = keyState;
+    this.releasable = releasable;
   }
 
   public String apiKey() {
@@ -24,5 +30,8 @@ public class KeyLease implements AutoCloseable {
 
   @Override
   public void close() {
+    if (releasable) {
+      keyState.releaseLease();
+    }
   }
 }

--- a/src/main/java/com/bestduo_BE/common/infra/riot/RiotApiConfig.java
+++ b/src/main/java/com/bestduo_BE/common/infra/riot/RiotApiConfig.java
@@ -1,62 +1,49 @@
 package com.bestduo_BE.common.infra.riot;
 
-import java.time.Duration;
-import org.springframework.beans.factory.annotation.Value;
+import com.bestduo_BE.config.RiotApiProperties;
+import java.time.Clock;
 import org.springframework.boot.restclient.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.client.ClientHttpRequestInterceptor;
 import org.springframework.web.client.RestTemplate;
 
 @Configuration
 public class RiotApiConfig {
 
   @Bean
-  public DualWindowRateLimiter riotRateLimiter() {
-    return new DualWindowRateLimiter(
-        10, Duration.ofSeconds(1),
-        60, Duration.ofMinutes(2)
-    );
+  public RiotKeyPool riotKeyPool(RiotApiProperties properties) {
+    return RiotKeyPool.fromKeys(properties.resolvedApiKeys(), Clock.systemUTC());
   }
 
   @Bean
-  public RiotRateLimitInterceptor riotRateLimitInterceptor(DualWindowRateLimiter limiter) {
-    return new RiotRateLimitInterceptor(limiter);
+  public RiotRateLimitInterceptor riotRateLimitInterceptor(RiotKeyPool keyPool) {
+    return new RiotRateLimitInterceptor(keyPool);
   }
 
   @Bean(name = "riotPlatformRestTemplate")
   public RestTemplate riotPlatformRestTemplate(
       RestTemplateBuilder restTemplateBuilder,
       RiotRateLimitInterceptor rateLimitInterceptor,
-      @Value("${external.riot.platform-base-url}") String platformBaseUrl,
-      @Value("${external.riot.api-key}") String apiKey) {
-    return buildRiotRestTemplate(restTemplateBuilder, platformBaseUrl, apiKey, rateLimitInterceptor);
+      RiotApiProperties properties) {
+    return buildRiotRestTemplate(restTemplateBuilder, properties.getPlatformBaseUrl(), rateLimitInterceptor);
   }
 
   @Bean(name = "riotRegionalRestTemplate")
   public RestTemplate riotRegionalRestTemplate(
       RestTemplateBuilder restTemplateBuilder,
       RiotRateLimitInterceptor rateLimitInterceptor,
-      @Value("${external.riot.regional-base-url}") String regionalBaseUrl,
-      @Value("${external.riot.api-key}") String apiKey) {
-    return buildRiotRestTemplate(restTemplateBuilder, regionalBaseUrl, apiKey, rateLimitInterceptor);
+      RiotApiProperties properties) {
+    return buildRiotRestTemplate(restTemplateBuilder, properties.getRegionalBaseUrl(), rateLimitInterceptor);
   }
 
   private RestTemplate buildRiotRestTemplate(
       RestTemplateBuilder restTemplateBuilder,
       String baseUrl,
-      String apiKey,
       RiotRateLimitInterceptor rateLimitInterceptor) {
-
-    ClientHttpRequestInterceptor authInterceptor = (request, body, execution) -> {
-      request.getHeaders().add("X-Riot-Token", apiKey);
-      return execution.execute(request, body);
-    };
 
     return restTemplateBuilder
         .rootUri(baseUrl)
-        // ✅ 여기서 List.of 쓰지 말고 varargs로!
-        .additionalInterceptors(rateLimitInterceptor, authInterceptor)
+        .additionalInterceptors(rateLimitInterceptor)
         .build();
   }
 }

--- a/src/main/java/com/bestduo_BE/common/infra/riot/RiotKeyPool.java
+++ b/src/main/java/com/bestduo_BE/common/infra/riot/RiotKeyPool.java
@@ -11,6 +11,7 @@ public class RiotKeyPool {
 
   private final List<RiotKeyState> keyStates;
   private final AtomicInteger nextIndex = new AtomicInteger();
+  private final ThreadLocal<RiotKeyState> workerLease = new ThreadLocal<>();
 
   public RiotKeyPool(List<RiotKeyState> keyStates) {
     this.keyStates = List.copyOf(keyStates);
@@ -26,7 +27,28 @@ public class RiotKeyPool {
         .toList());
   }
 
+  public KeyLease leaseForWorker() {
+    KeyLease lease = selectAvailableLease();
+    workerLease.set(keyStates.stream()
+        .filter(state -> state.apiKey().equals(lease.apiKey()))
+        .findFirst()
+        .orElseThrow());
+    return lease;
+  }
+
+  public KeyLease leaseForRequest() {
+    RiotKeyState reserved = workerLease.get();
+    if (reserved != null) {
+      return new KeyLease(reserved, false);
+    }
+    return selectAvailableLease();
+  }
+
   public KeyLease lease() {
+    return leaseForRequest();
+  }
+
+  private KeyLease selectAvailableLease() {
     if (keyStates.isEmpty()) {
       throw new IllegalStateException("No Riot API keys configured");
     }
@@ -34,7 +56,7 @@ public class RiotKeyPool {
     int start = Math.floorMod(nextIndex.getAndIncrement(), keyStates.size());
     for (int offset = 0; offset < keyStates.size(); offset++) {
       RiotKeyState state = keyStates.get((start + offset) % keyStates.size());
-      if (state.isAvailable()) {
+      if (state.tryLease()) {
         return new KeyLease(state);
       }
     }
@@ -44,5 +66,9 @@ public class RiotKeyPool {
 
   public Duration defaultRetryAfter() {
     return DEFAULT_RETRY_AFTER;
+  }
+
+  public void clearWorkerLease() {
+    workerLease.remove();
   }
 }

--- a/src/main/java/com/bestduo_BE/common/infra/riot/RiotKeyPool.java
+++ b/src/main/java/com/bestduo_BE/common/infra/riot/RiotKeyPool.java
@@ -1,0 +1,48 @@
+package com.bestduo_BE.common.infra.riot;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class RiotKeyPool {
+
+  private static final Duration DEFAULT_RETRY_AFTER = Duration.ofSeconds(10);
+
+  private final List<RiotKeyState> keyStates;
+  private final AtomicInteger nextIndex = new AtomicInteger();
+
+  public RiotKeyPool(List<RiotKeyState> keyStates) {
+    this.keyStates = List.copyOf(keyStates);
+  }
+
+  public static RiotKeyPool fromKeys(List<String> apiKeys, Clock clock) {
+    return new RiotKeyPool(apiKeys.stream()
+        .map(key -> new RiotKeyState(
+            key,
+            new DualWindowRateLimiter(10, Duration.ofSeconds(1), 60, Duration.ofMinutes(2)),
+            clock
+        ))
+        .toList());
+  }
+
+  public KeyLease lease() {
+    if (keyStates.isEmpty()) {
+      throw new IllegalStateException("No Riot API keys configured");
+    }
+
+    int start = Math.floorMod(nextIndex.getAndIncrement(), keyStates.size());
+    for (int offset = 0; offset < keyStates.size(); offset++) {
+      RiotKeyState state = keyStates.get((start + offset) % keyStates.size());
+      if (state.isAvailable()) {
+        return new KeyLease(state);
+      }
+    }
+
+    throw new IllegalStateException("All Riot API keys are cooling down");
+  }
+
+  public Duration defaultRetryAfter() {
+    return DEFAULT_RETRY_AFTER;
+  }
+}

--- a/src/main/java/com/bestduo_BE/common/infra/riot/RiotKeyState.java
+++ b/src/main/java/com/bestduo_BE/common/infra/riot/RiotKeyState.java
@@ -1,0 +1,37 @@
+package com.bestduo_BE.common.infra.riot;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+
+public class RiotKeyState {
+
+  private final String apiKey;
+  private final DualWindowRateLimiter rateLimiter;
+  private final Clock clock;
+  private Instant cooldownUntil;
+
+  public RiotKeyState(String apiKey, DualWindowRateLimiter rateLimiter, Clock clock) {
+    this.apiKey = apiKey;
+    this.rateLimiter = rateLimiter;
+    this.clock = clock;
+    this.cooldownUntil = Instant.EPOCH;
+  }
+
+  public String apiKey() {
+    return apiKey;
+  }
+
+  public void acquire() {
+    rateLimiter.acquire();
+  }
+
+  public synchronized boolean isAvailable() {
+    return !clock.instant().isBefore(cooldownUntil);
+  }
+
+  public synchronized void markRateLimited(Duration retryAfter) {
+    Duration cooldown = retryAfter == null || retryAfter.isNegative() ? Duration.ofSeconds(10) : retryAfter;
+    this.cooldownUntil = clock.instant().plus(cooldown);
+  }
+}

--- a/src/main/java/com/bestduo_BE/common/infra/riot/RiotKeyState.java
+++ b/src/main/java/com/bestduo_BE/common/infra/riot/RiotKeyState.java
@@ -32,6 +32,9 @@ public class RiotKeyState {
 
   public synchronized void markRateLimited(Duration retryAfter) {
     Duration cooldown = retryAfter == null || retryAfter.isNegative() ? Duration.ofSeconds(10) : retryAfter;
-    this.cooldownUntil = clock.instant().plus(cooldown);
+    Instant candidateCooldownUntil = clock.instant().plus(cooldown);
+    if (candidateCooldownUntil.isAfter(this.cooldownUntil)) {
+      this.cooldownUntil = candidateCooldownUntil;
+    }
   }
 }

--- a/src/main/java/com/bestduo_BE/common/infra/riot/RiotKeyState.java
+++ b/src/main/java/com/bestduo_BE/common/infra/riot/RiotKeyState.java
@@ -10,12 +10,14 @@ public class RiotKeyState {
   private final DualWindowRateLimiter rateLimiter;
   private final Clock clock;
   private Instant cooldownUntil;
+  private boolean leased;
 
   public RiotKeyState(String apiKey, DualWindowRateLimiter rateLimiter, Clock clock) {
     this.apiKey = apiKey;
     this.rateLimiter = rateLimiter;
     this.clock = clock;
     this.cooldownUntil = Instant.EPOCH;
+    this.leased = false;
   }
 
   public String apiKey() {
@@ -27,7 +29,19 @@ public class RiotKeyState {
   }
 
   public synchronized boolean isAvailable() {
-    return !clock.instant().isBefore(cooldownUntil);
+    return !leased && !clock.instant().isBefore(cooldownUntil);
+  }
+
+  public synchronized boolean tryLease() {
+    if (!isAvailable()) {
+      return false;
+    }
+    this.leased = true;
+    return true;
+  }
+
+  public synchronized void releaseLease() {
+    this.leased = false;
   }
 
   public synchronized void markRateLimited(Duration retryAfter) {

--- a/src/main/java/com/bestduo_BE/common/infra/riot/RiotRateLimitInterceptor.java
+++ b/src/main/java/com/bestduo_BE/common/infra/riot/RiotRateLimitInterceptor.java
@@ -22,7 +22,7 @@ public class RiotRateLimitInterceptor implements ClientHttpRequestInterceptor {
   ) throws IOException {
 
     RiotRequestBudget.consume(1);
-    try (KeyLease lease = keyPool.lease()) {
+    try (KeyLease lease = keyPool.leaseForRequest()) {
       request.getHeaders().set("X-Riot-Token", lease.apiKey());
       lease.acquire();
 

--- a/src/main/java/com/bestduo_BE/common/infra/riot/RiotRateLimitInterceptor.java
+++ b/src/main/java/com/bestduo_BE/common/infra/riot/RiotRateLimitInterceptor.java
@@ -3,6 +3,7 @@ package com.bestduo_BE.common.infra.riot;
 import com.bestduo_BE.common.infra.riot.budget.RiotRequestBudget;
 import com.bestduo_BE.common.infra.riot.exception.RiotRateLimitedException;
 import java.io.IOException;
+import java.time.Duration;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpRequest;
 import org.springframework.http.HttpStatus;
@@ -13,7 +14,7 @@ import org.springframework.http.client.ClientHttpResponse;
 @RequiredArgsConstructor
 public class RiotRateLimitInterceptor implements ClientHttpRequestInterceptor {
 
-  private final DualWindowRateLimiter rateLimiter;
+  private final RiotKeyPool keyPool;
 
   @Override
   public ClientHttpResponse intercept(
@@ -21,21 +22,32 @@ public class RiotRateLimitInterceptor implements ClientHttpRequestInterceptor {
   ) throws IOException {
 
     RiotRequestBudget.consume(1);
-    // ✅ 모든 Riot API 요청에 공통 적용
-    rateLimiter.acquire();
+    try (KeyLease lease = keyPool.lease()) {
+      request.getHeaders().set("X-Riot-Token", lease.apiKey());
+      lease.acquire();
 
-    ClientHttpResponse response = execution.execute(request, body);
+      ClientHttpResponse response = execution.execute(request, body);
 
-    // ✅ 429 감지 (개발키 보호 모드에서 유용)
-    if (response.getStatusCode() == HttpStatus.TOO_MANY_REQUESTS) {
-      String retryAfter = response.getHeaders().getFirst("Retry-After");
-      String msg = "Riot API rate limited (429). retry-after=" + retryAfter
-          + ", uri=" + request.getURI();
+      if (response.getStatusCode() == HttpStatus.TOO_MANY_REQUESTS) {
+        String retryAfter = response.getHeaders().getFirst("Retry-After");
+        lease.markRateLimited(parseRetryAfter(retryAfter));
+        String msg = "Riot API rate limited (429). retry-after=" + retryAfter
+            + ", uri=" + request.getURI();
 
-      // response body를 읽고 싶다면 여기서 읽어야 하지만, 보통 헤더/URI만으로 충분
-      throw new RiotRateLimitedException(msg);
+        throw new RiotRateLimitedException(msg);
+      }
+
+      return response;
     }
+  }
 
-    return response;
+  private Duration parseRetryAfter(String retryAfter) {
+    try {
+      return retryAfter == null || retryAfter.isBlank()
+          ? keyPool.defaultRetryAfter()
+          : Duration.ofSeconds(Long.parseLong(retryAfter));
+    } catch (NumberFormatException e) {
+      return keyPool.defaultRetryAfter();
+    }
   }
 }

--- a/src/main/java/com/bestduo_BE/common/infra/riot/RiotRateLimitInterceptor.java
+++ b/src/main/java/com/bestduo_BE/common/infra/riot/RiotRateLimitInterceptor.java
@@ -33,6 +33,7 @@ public class RiotRateLimitInterceptor implements ClientHttpRequestInterceptor {
         lease.markRateLimited(parseRetryAfter(retryAfter));
         String msg = "Riot API rate limited (429). retry-after=" + retryAfter
             + ", uri=" + request.getURI();
+        response.close();
 
         throw new RiotRateLimitedException(msg);
       }

--- a/src/main/java/com/bestduo_BE/config/RiotApiProperties.java
+++ b/src/main/java/com/bestduo_BE/config/RiotApiProperties.java
@@ -21,6 +21,7 @@ public class RiotApiProperties {
   public List<String> resolvedApiKeys() {
     List<String> sanitizedKeys = apiKeys == null ? List.of() : apiKeys.stream()
           .filter(key -> key != null && !key.isBlank())
+          .map(String::trim)
           .distinct()
           .toList();
 
@@ -32,6 +33,6 @@ public class RiotApiProperties {
       return List.of();
     }
 
-    return List.of(apiKey);
+    return List.of(apiKey.trim());
   }
 }

--- a/src/main/java/com/bestduo_BE/config/RiotApiProperties.java
+++ b/src/main/java/com/bestduo_BE/config/RiotApiProperties.java
@@ -1,0 +1,37 @@
+package com.bestduo_BE.config;
+
+import java.util.List;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties(prefix = "external.riot")
+@Getter
+@Setter
+public class RiotApiProperties {
+
+  private String platformBaseUrl;
+  private String regionalBaseUrl;
+  private String apiKey;
+  private List<String> apiKeys = List.of();
+  private boolean multiKeyEnabled = false;
+
+  public List<String> resolvedApiKeys() {
+    List<String> sanitizedKeys = apiKeys == null ? List.of() : apiKeys.stream()
+          .filter(key -> key != null && !key.isBlank())
+          .distinct()
+          .toList();
+
+    if (multiKeyEnabled && !sanitizedKeys.isEmpty()) {
+      return sanitizedKeys;
+    }
+
+    if (apiKey == null || apiKey.isBlank()) {
+      return List.of();
+    }
+
+    return List.of(apiKey);
+  }
+}

--- a/src/main/java/com/bestduo_BE/config/WorkItemProperties.java
+++ b/src/main/java/com/bestduo_BE/config/WorkItemProperties.java
@@ -1,0 +1,43 @@
+package com.bestduo_BE.config;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Component
+@ConfigurationProperties(prefix = "work-item")
+@Getter
+@Setter
+public class WorkItemProperties {
+
+  private boolean workerEnabled = false;
+  private int poolSize = 4;
+  private long pollingIntervalMs = 500L;
+  private long schedulerFixedDelayMs = 30_000L;
+  private int staleMinutes = 10;
+  private int duplicatePendingLimit = 1;
+
+  private final Threshold threshold = new Threshold();
+  private final Batch batch = new Batch();
+
+  @Getter
+  @Setter
+  public static class Threshold {
+    private long verifiedPool = 10L;
+    private long readyMatchQueue = 20L;
+    private long recentIngest = 5L;
+    private long unverifiedBacklog = 5L;
+    private long minSeedTrigger = 3L;
+    private int ingestWindowMinutes = 30;
+  }
+
+  @Getter
+  @Setter
+  public static class Batch {
+    private int verify = 10;
+    private int refresh = 10;
+    private int ingest = 20;
+    private int seed = 1;
+  }
+}

--- a/src/main/java/com/bestduo_BE/coverage/application/CoverageBucketService.java
+++ b/src/main/java/com/bestduo_BE/coverage/application/CoverageBucketService.java
@@ -1,0 +1,79 @@
+package com.bestduo_BE.coverage.application;
+
+import com.bestduo_BE.coverage.application.exception.CoverageBucketAlreadyExistsException;
+import com.bestduo_BE.coverage.application.exception.CoverageBucketNotFoundException;
+import com.bestduo_BE.coverage.infra.persistence.entity.CoverageBucket;
+import com.bestduo_BE.coverage.infra.persistence.repository.CoverageBucketCountJpaRepository;
+import com.bestduo_BE.coverage.infra.persistence.repository.CoverageBucketJpaRepository;
+import com.bestduo_BE.coverage.presentation.api.dto.CoverageBucketCreateRequest;
+import com.bestduo_BE.coverage.presentation.api.dto.CoverageBucketResponse;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CoverageBucketService {
+
+  static final int DEFAULT_PRIORITY = 100;
+
+  private final CoverageBucketJpaRepository coverageBucketRepository;
+  private final CoverageBucketCountJpaRepository coverageBucketCountRepository;
+
+  @Transactional
+  public CoverageBucketResponse create(CoverageBucketCreateRequest request) {
+    if (coverageBucketRepository.existsByPatchAndTier(request.patch(), request.tier())) {
+      throw new CoverageBucketAlreadyExistsException(request.patch(), request.tier().name());
+    }
+
+    CoverageBucket bucket = CoverageBucket.create(
+        request.patch(),
+        request.tier(),
+        request.targetMatchCount(),
+        request.priority() != null ? request.priority() : DEFAULT_PRIORITY
+    );
+    bucket.refreshCount(currentCount(bucket));
+    try {
+      return toResponse(coverageBucketRepository.save(bucket));
+    } catch (DataIntegrityViolationException e) {
+      throw new CoverageBucketAlreadyExistsException(request.patch(), request.tier().name(), e);
+    }
+  }
+
+  @Transactional
+  public CoverageBucketResponse get(Long id) {
+    CoverageBucket bucket = coverageBucketRepository.findById(id)
+        .orElseThrow(() -> new CoverageBucketNotFoundException(id));
+    bucket.refreshCount(currentCount(bucket));
+    return toResponse(bucket);
+  }
+
+  @Transactional
+  public List<CoverageBucketResponse> getAll() {
+    return coverageBucketRepository.findAllByOrderByPriorityAscIdAsc().stream()
+        .peek(bucket -> bucket.refreshCount(currentCount(bucket)))
+        .map(this::toResponse)
+        .toList();
+  }
+
+  private long currentCount(CoverageBucket bucket) {
+    return coverageBucketCountRepository.countDistinctMatches(bucket.getPatch(), bucket.getTier().name());
+  }
+
+  private CoverageBucketResponse toResponse(CoverageBucket bucket) {
+    long deficitMatchCount = Math.max(bucket.getTargetMatchCount() - bucket.getCurrentMatchCount(), 0L);
+    return new CoverageBucketResponse(
+        bucket.getId(),
+        bucket.getPatch(),
+        bucket.getTier(),
+        bucket.getTargetMatchCount(),
+        bucket.getCurrentMatchCount(),
+        deficitMatchCount,
+        bucket.getStatus().name(),
+        bucket.getPriority(),
+        bucket.getLastEvaluatedAt()
+    );
+  }
+}

--- a/src/main/java/com/bestduo_BE/coverage/application/CoverageScheduler.java
+++ b/src/main/java/com/bestduo_BE/coverage/application/CoverageScheduler.java
@@ -1,0 +1,104 @@
+package com.bestduo_BE.coverage.application;
+
+import com.bestduo_BE.coverage.domain.model.CoverageBucketStatus;
+import com.bestduo_BE.coverage.infra.persistence.entity.CoverageBucket;
+import com.bestduo_BE.coverage.infra.persistence.repository.CoverageBucketCountJpaRepository;
+import com.bestduo_BE.coverage.infra.persistence.repository.CoverageBucketJpaRepository;
+import com.bestduo_BE.common.infra.persistence.repository.IngestQueueStatsJpaRepository;
+import com.bestduo_BE.common.infra.persistence.repository.SummonerJpaRepository;
+import com.bestduo_BE.workitem.domain.model.WorkItemStatus;
+import com.bestduo_BE.workitem.domain.model.WorkItemType;
+import com.bestduo_BE.workitem.infra.persistence.entity.WorkItem;
+import com.bestduo_BE.workitem.infra.persistence.repository.WorkItemJpaRepository;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class CoverageScheduler {
+
+  private static final long MIN_VERIFIED_POOL = 10L;
+  private static final long MIN_UNVERIFIED_BACKLOG = 5L;
+  private static final long MIN_READY_MATCH_QUEUE = 20L;
+  private static final long MIN_RECENT_INGEST = 5L;
+
+  private final CoverageBucketJpaRepository coverageBucketRepository;
+  private final CoverageBucketCountJpaRepository coverageBucketCountRepository;
+  private final SummonerJpaRepository summonerJpaRepository;
+  private final IngestQueueStatsJpaRepository ingestQueueStatsJpaRepository;
+  private final WorkItemJpaRepository workItemJpaRepository;
+
+  @Transactional
+  public ScheduleResult schedule() {
+    List<WorkItem> created = new ArrayList<>();
+
+    for (CoverageBucket bucket : coverageBucketRepository.findAllByOrderByPriorityAscIdAsc()) {
+      if (bucket.getStatus() != CoverageBucketStatus.COLLECTING) {
+        continue;
+      }
+
+      bucket.refreshCount(coverageBucketCountRepository.countDistinctMatches(bucket.getPatch(), bucket.getTier().name()));
+      if (bucket.getStatus() != CoverageBucketStatus.COLLECTING) {
+        continue;
+      }
+
+      WorkItemType nextType = determineNextWorkItem(bucket);
+      if (nextType == null || hasPending(bucket, nextType)) {
+        continue;
+      }
+
+      created.add(workItemJpaRepository.save(WorkItem.ready(
+          bucket.getId(),
+          bucket.getPatch(),
+          bucket.getTier(),
+          nextType,
+          bucket.getPriority(),
+          switch (nextType) {
+            case INGEST_MATCH_DETAIL -> 20;
+            case REFRESH_SUMMONERS, VERIFY_SUMMONERS -> 10;
+            case SEED_SUMMONERS -> 1;
+          }
+      )));
+    }
+
+    return new ScheduleResult(created.size(), created);
+  }
+
+  private WorkItemType determineNextWorkItem(CoverageBucket bucket) {
+    long verifiedPool = summonerJpaRepository.countByLastKnownTier(bucket.getTier());
+    if (verifiedPool < MIN_VERIFIED_POOL) {
+      return WorkItemType.VERIFY_SUMMONERS;
+    }
+
+    long queuedMatchIds = ingestQueueStatsJpaRepository.countReadyByTier(bucket.getTier().name());
+    if (queuedMatchIds < MIN_READY_MATCH_QUEUE) {
+      return WorkItemType.REFRESH_SUMMONERS;
+    }
+
+    long recentIngested = ingestQueueStatsJpaRepository.countDoneInLastMinutesByTier(30, bucket.getTier().name());
+    if (recentIngested < MIN_RECENT_INGEST) {
+      return WorkItemType.INGEST_MATCH_DETAIL;
+    }
+
+    long unverifiedBacklog = summonerJpaRepository.countUnverifiedCandidates(bucket.getTier().name());
+    if (unverifiedBacklog < MIN_UNVERIFIED_BACKLOG) {
+      return WorkItemType.SEED_SUMMONERS;
+    }
+
+    return null;
+  }
+
+  private boolean hasPending(CoverageBucket bucket, WorkItemType type) {
+    return workItemJpaRepository.existsByCoverageBucketIdAndTypeAndStatusIn(
+        bucket.getId(),
+        type,
+        List.of(WorkItemStatus.READY, WorkItemStatus.RUNNING)
+    );
+  }
+
+  public record ScheduleResult(int createdCount, List<WorkItem> workItems) {
+  }
+}

--- a/src/main/java/com/bestduo_BE/coverage/application/CoverageScheduler.java
+++ b/src/main/java/com/bestduo_BE/coverage/application/CoverageScheduler.java
@@ -1,18 +1,20 @@
 package com.bestduo_BE.coverage.application;
 
+import com.bestduo_BE.config.WorkItemProperties;
 import com.bestduo_BE.coverage.domain.model.CoverageBucketStatus;
 import com.bestduo_BE.coverage.infra.persistence.entity.CoverageBucket;
 import com.bestduo_BE.coverage.infra.persistence.repository.CoverageBucketCountJpaRepository;
 import com.bestduo_BE.coverage.infra.persistence.repository.CoverageBucketJpaRepository;
 import com.bestduo_BE.common.infra.persistence.repository.IngestQueueStatsJpaRepository;
 import com.bestduo_BE.common.infra.persistence.repository.SummonerJpaRepository;
+import com.bestduo_BE.workitem.application.port.WorkItemDispatcher;
 import com.bestduo_BE.workitem.domain.model.WorkItemStatus;
 import com.bestduo_BE.workitem.domain.model.WorkItemType;
 import com.bestduo_BE.workitem.infra.persistence.entity.WorkItem;
-import com.bestduo_BE.workitem.infra.persistence.repository.WorkItemJpaRepository;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,16 +22,17 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class CoverageScheduler {
 
-  private static final long MIN_VERIFIED_POOL = 10L;
-  private static final long MIN_UNVERIFIED_BACKLOG = 5L;
-  private static final long MIN_READY_MATCH_QUEUE = 20L;
-  private static final long MIN_RECENT_INGEST = 5L;
-
   private final CoverageBucketJpaRepository coverageBucketRepository;
   private final CoverageBucketCountJpaRepository coverageBucketCountRepository;
   private final SummonerJpaRepository summonerJpaRepository;
   private final IngestQueueStatsJpaRepository ingestQueueStatsJpaRepository;
-  private final WorkItemJpaRepository workItemJpaRepository;
+  private final WorkItemDispatcher workItemDispatcher;
+  private final WorkItemProperties workItemProperties;
+
+  @Scheduled(fixedDelayString = "${work-item.scheduler-fixed-delay-ms:30000}")
+  public void scheduledRun() {
+    schedule();
+  }
 
   @Transactional
   public ScheduleResult schedule() {
@@ -50,17 +53,14 @@ public class CoverageScheduler {
         continue;
       }
 
-      created.add(workItemJpaRepository.save(WorkItem.ready(
+      created.add(workItemDispatcher.emit(WorkItem.pending(
           bucket.getId(),
           bucket.getPatch(),
           bucket.getTier(),
           nextType,
           bucket.getPriority(),
-          switch (nextType) {
-            case INGEST_MATCH_DETAIL -> 20;
-            case REFRESH_SUMMONERS, VERIFY_SUMMONERS -> 10;
-            case SEED_SUMMONERS -> 1;
-          }
+          batchLimit(nextType),
+          payloadFor(bucket, nextType)
       )));
     }
 
@@ -69,22 +69,34 @@ public class CoverageScheduler {
 
   private WorkItemType determineNextWorkItem(CoverageBucket bucket) {
     long verifiedPool = summonerJpaRepository.countByLastKnownTier(bucket.getTier());
-    if (verifiedPool < MIN_VERIFIED_POOL) {
+    if (verifiedPool < workItemProperties.getThreshold().getVerifiedPool()) {
       return WorkItemType.VERIFY_SUMMONERS;
     }
 
     long queuedMatchIds = ingestQueueStatsJpaRepository.countReadyByTier(bucket.getTier().name());
-    if (queuedMatchIds < MIN_READY_MATCH_QUEUE) {
+    if (queuedMatchIds < workItemProperties.getThreshold().getReadyMatchQueue()) {
       return WorkItemType.REFRESH_SUMMONERS;
     }
 
-    long recentIngested = ingestQueueStatsJpaRepository.countDoneInLastMinutesByTier(30, bucket.getTier().name());
-    if (recentIngested < MIN_RECENT_INGEST) {
+    long unverifiedBacklog = summonerJpaRepository.countUnverifiedCandidates(bucket.getTier().name());
+    if (unverifiedBacklog > 0) {
+      return WorkItemType.VERIFY_SUMMONERS;
+    }
+
+    if (queuedMatchIds > 0) {
       return WorkItemType.INGEST_MATCH_DETAIL;
     }
 
-    long unverifiedBacklog = summonerJpaRepository.countUnverifiedCandidates(bucket.getTier().name());
-    if (unverifiedBacklog < MIN_UNVERIFIED_BACKLOG) {
+    long recentIngested = ingestQueueStatsJpaRepository.countDoneInLastMinutesByTier(
+        workItemProperties.getThreshold().getIngestWindowMinutes(),
+        bucket.getTier().name()
+    );
+    if (recentIngested < workItemProperties.getThreshold().getRecentIngest()) {
+      return WorkItemType.INGEST_MATCH_DETAIL;
+    }
+
+    if (verifiedPool < workItemProperties.getThreshold().getMinSeedTrigger()
+        || unverifiedBacklog < workItemProperties.getThreshold().getUnverifiedBacklog()) {
       return WorkItemType.SEED_SUMMONERS;
     }
 
@@ -92,11 +104,30 @@ public class CoverageScheduler {
   }
 
   private boolean hasPending(CoverageBucket bucket, WorkItemType type) {
-    return workItemJpaRepository.existsByCoverageBucketIdAndTypeAndStatusIn(
-        bucket.getId(),
+    return workItemDispatcher.countByTypePatchTierStatuses(
         type,
-        List.of(WorkItemStatus.READY, WorkItemStatus.RUNNING)
-    );
+        bucket.getPatch(),
+        bucket.getTier(),
+        List.of(WorkItemStatus.PENDING, WorkItemStatus.RUNNING)
+    )
+        >= workItemProperties.getDuplicatePendingLimit();
+  }
+
+  private int batchLimit(WorkItemType type) {
+    return switch (type) {
+      case INGEST_MATCH_DETAIL -> workItemProperties.getBatch().getIngest();
+      case REFRESH_SUMMONERS -> workItemProperties.getBatch().getRefresh();
+      case VERIFY_SUMMONERS -> workItemProperties.getBatch().getVerify();
+      case SEED_SUMMONERS -> workItemProperties.getBatch().getSeed();
+    };
+  }
+
+  private String payloadFor(CoverageBucket bucket, WorkItemType type) {
+    if (type != WorkItemType.SEED_SUMMONERS) {
+      return null;
+    }
+    return "{\"queue\":\"RANKED_SOLO_5x5\",\"division\":\"I\",\"page\":1,\"tier\":\"%s\"}"
+        .formatted(bucket.getTier().name());
   }
 
   public record ScheduleResult(int createdCount, List<WorkItem> workItems) {

--- a/src/main/java/com/bestduo_BE/coverage/application/exception/CoverageBucketAlreadyExistsException.java
+++ b/src/main/java/com/bestduo_BE/coverage/application/exception/CoverageBucketAlreadyExistsException.java
@@ -1,0 +1,12 @@
+package com.bestduo_BE.coverage.application.exception;
+
+public class CoverageBucketAlreadyExistsException extends RuntimeException {
+
+  public CoverageBucketAlreadyExistsException(String patch, String tier) {
+    super("Coverage bucket already exists. patch=%s tier=%s".formatted(patch, tier));
+  }
+
+  public CoverageBucketAlreadyExistsException(String patch, String tier, Throwable cause) {
+    super("Coverage bucket already exists. patch=%s tier=%s".formatted(patch, tier), cause);
+  }
+}

--- a/src/main/java/com/bestduo_BE/coverage/application/exception/CoverageBucketNotFoundException.java
+++ b/src/main/java/com/bestduo_BE/coverage/application/exception/CoverageBucketNotFoundException.java
@@ -1,0 +1,8 @@
+package com.bestduo_BE.coverage.application.exception;
+
+public class CoverageBucketNotFoundException extends RuntimeException {
+
+  public CoverageBucketNotFoundException(Long id) {
+    super("Coverage bucket not found. id=" + id);
+  }
+}

--- a/src/main/java/com/bestduo_BE/coverage/domain/model/CoverageBucketStatus.java
+++ b/src/main/java/com/bestduo_BE/coverage/domain/model/CoverageBucketStatus.java
@@ -1,0 +1,6 @@
+package com.bestduo_BE.coverage.domain.model;
+
+public enum CoverageBucketStatus {
+  COLLECTING,
+  SUFFICIENT
+}

--- a/src/main/java/com/bestduo_BE/coverage/infra/persistence/entity/CoverageBucket.java
+++ b/src/main/java/com/bestduo_BE/coverage/infra/persistence/entity/CoverageBucket.java
@@ -1,0 +1,88 @@
+package com.bestduo_BE.coverage.infra.persistence.entity;
+
+import com.bestduo_BE.common.domain.model.Tier;
+import com.bestduo_BE.coverage.domain.model.CoverageBucketStatus;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.OffsetDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(
+    name = "coverage_bucket",
+    uniqueConstraints = @UniqueConstraint(name = "uk_coverage_bucket_patch_tier", columnNames = {"patch", "tier"})
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class CoverageBucket {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(nullable = false)
+  private String patch;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  private Tier tier;
+
+  @Column(name = "target_match_count", nullable = false)
+  private long targetMatchCount;
+
+  @Column(name = "current_match_count", nullable = false)
+  private long currentMatchCount;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  private CoverageBucketStatus status;
+
+  @Column(nullable = false)
+  private int priority;
+
+  @Column(name = "last_evaluated_at", nullable = false)
+  private OffsetDateTime lastEvaluatedAt;
+
+  @Column(name = "created_at", nullable = false)
+  private OffsetDateTime createdAt;
+
+  @Column(name = "updated_at", nullable = false)
+  private OffsetDateTime updatedAt;
+
+  public static CoverageBucket create(String patch, Tier tier, long targetMatchCount, int priority) {
+    OffsetDateTime now = OffsetDateTime.now();
+    return CoverageBucket.builder()
+        .patch(patch)
+        .tier(tier)
+        .targetMatchCount(targetMatchCount)
+        .currentMatchCount(0L)
+        .status(CoverageBucketStatus.COLLECTING)
+        .priority(priority)
+        .lastEvaluatedAt(now)
+        .createdAt(now)
+        .updatedAt(now)
+        .build();
+  }
+
+  public void refreshCount(long currentMatchCount) {
+    this.currentMatchCount = currentMatchCount;
+    this.status = currentMatchCount >= targetMatchCount
+        ? CoverageBucketStatus.SUFFICIENT
+        : CoverageBucketStatus.COLLECTING;
+    this.lastEvaluatedAt = OffsetDateTime.now();
+    this.updatedAt = this.lastEvaluatedAt;
+  }
+}

--- a/src/main/java/com/bestduo_BE/coverage/infra/persistence/repository/CoverageBucketCountJpaRepository.java
+++ b/src/main/java/com/bestduo_BE/coverage/infra/persistence/repository/CoverageBucketCountJpaRepository.java
@@ -1,0 +1,18 @@
+package com.bestduo_BE.coverage.infra.persistence.repository;
+
+import com.bestduo_BE.common.infra.persistence.entity.BottomDuoRawEntity;
+import com.bestduo_BE.common.infra.persistence.entity.BottomDuoRawId;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.Repository;
+import org.springframework.data.repository.query.Param;
+
+public interface CoverageBucketCountJpaRepository extends Repository<BottomDuoRawEntity, BottomDuoRawId> {
+
+  @Query(value = """
+      select count(distinct r.match_id)
+      from bottom_duo_raw r
+      where r.patch = :patch
+        and r.collection_tier = :tier
+      """, nativeQuery = true)
+  long countDistinctMatches(@Param("patch") String patch, @Param("tier") String tier);
+}

--- a/src/main/java/com/bestduo_BE/coverage/infra/persistence/repository/CoverageBucketJpaRepository.java
+++ b/src/main/java/com/bestduo_BE/coverage/infra/persistence/repository/CoverageBucketJpaRepository.java
@@ -1,0 +1,16 @@
+package com.bestduo_BE.coverage.infra.persistence.repository;
+
+import com.bestduo_BE.common.domain.model.Tier;
+import com.bestduo_BE.coverage.infra.persistence.entity.CoverageBucket;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface CoverageBucketJpaRepository extends JpaRepository<CoverageBucket, Long> {
+
+  boolean existsByPatchAndTier(String patch, Tier tier);
+
+  Optional<CoverageBucket> findByPatchAndTier(String patch, Tier tier);
+
+  List<CoverageBucket> findAllByOrderByPriorityAscIdAsc();
+}

--- a/src/main/java/com/bestduo_BE/coverage/presentation/api/AdminCoverageController.java
+++ b/src/main/java/com/bestduo_BE/coverage/presentation/api/AdminCoverageController.java
@@ -1,0 +1,56 @@
+package com.bestduo_BE.coverage.presentation.api;
+
+import com.bestduo_BE.common.domain.model.Tier;
+import com.bestduo_BE.coverage.application.CoverageBucketService;
+import com.bestduo_BE.coverage.application.exception.CoverageBucketAlreadyExistsException;
+import com.bestduo_BE.coverage.application.exception.CoverageBucketNotFoundException;
+import com.bestduo_BE.coverage.presentation.api.dto.CoverageBucketCreateRequest;
+import com.bestduo_BE.coverage.presentation.api.dto.CoverageBucketResponse;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/admin/coverage")
+public class AdminCoverageController {
+
+  private final CoverageBucketService coverageBucketService;
+
+  @PostMapping
+  @ResponseStatus(HttpStatus.CREATED)
+  public CoverageBucketResponse create(
+      @RequestParam String patch,
+      @RequestParam Tier tier,
+      @RequestParam long targetMatchCount,
+      @RequestParam(required = false) Integer priority
+  ) {
+    try {
+      return coverageBucketService.create(new CoverageBucketCreateRequest(patch, tier, targetMatchCount, priority));
+    } catch (CoverageBucketAlreadyExistsException e) {
+      throw new ResponseStatusException(HttpStatus.CONFLICT, e.getMessage());
+    }
+  }
+
+  @GetMapping
+  public List<CoverageBucketResponse> getAll() {
+    return coverageBucketService.getAll();
+  }
+
+  @GetMapping("/{id}")
+  public CoverageBucketResponse get(@PathVariable Long id) {
+    try {
+      return coverageBucketService.get(id);
+    } catch (CoverageBucketNotFoundException e) {
+      throw new ResponseStatusException(HttpStatus.NOT_FOUND, e.getMessage());
+    }
+  }
+}

--- a/src/main/java/com/bestduo_BE/coverage/presentation/api/dto/CoverageBucketCreateRequest.java
+++ b/src/main/java/com/bestduo_BE/coverage/presentation/api/dto/CoverageBucketCreateRequest.java
@@ -1,0 +1,11 @@
+package com.bestduo_BE.coverage.presentation.api.dto;
+
+import com.bestduo_BE.common.domain.model.Tier;
+
+public record CoverageBucketCreateRequest(
+    String patch,
+    Tier tier,
+    long targetMatchCount,
+    Integer priority
+) {
+}

--- a/src/main/java/com/bestduo_BE/coverage/presentation/api/dto/CoverageBucketResponse.java
+++ b/src/main/java/com/bestduo_BE/coverage/presentation/api/dto/CoverageBucketResponse.java
@@ -1,0 +1,17 @@
+package com.bestduo_BE.coverage.presentation.api.dto;
+
+import com.bestduo_BE.common.domain.model.Tier;
+import java.time.OffsetDateTime;
+
+public record CoverageBucketResponse(
+    Long id,
+    String patch,
+    Tier tier,
+    long targetMatchCount,
+    long currentMatchCount,
+    long deficitMatchCount,
+    String status,
+    int priority,
+    OffsetDateTime lastEvaluatedAt
+) {
+}

--- a/src/main/java/com/bestduo_BE/refresh/application/RefreshBatchExecutor.java
+++ b/src/main/java/com/bestduo_BE/refresh/application/RefreshBatchExecutor.java
@@ -19,7 +19,7 @@ public class RefreshBatchExecutor {
   }
 
   public Result execute(int limit, Tier requestedTier) {
-    var targets = summonerJpaRepository.findRefreshTargets(limit);
+    var targets = summonerJpaRepository.findRefreshTargets(limit, requestedTier.name());
 
     int processed = 0;
     int success = 0;

--- a/src/main/java/com/bestduo_BE/refresh/application/RefreshSummonerMatches.java
+++ b/src/main/java/com/bestduo_BE/refresh/application/RefreshSummonerMatches.java
@@ -8,6 +8,7 @@ import com.bestduo_BE.common.domain.model.Tier;
 import com.bestduo_BE.common.infra.persistence.entity.Summoner;
 import com.bestduo_BE.common.infra.riot.dto.LeagueEntry;
 import java.time.Instant;
+import java.time.OffsetDateTime;
 import java.util.Comparator;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -41,6 +42,8 @@ public class RefreshSummonerMatches {
         summonerRefreshStatusUpdater.syncRefreshCursor(puuid, summoner.getLastMatchStartTime());
         return new Result(puuid, 0, collectionTier, summoner.getLastMatchStartTime());
       }
+
+      summonerRefreshStatusUpdater.syncResolvedTier(puuid, collectionTier, OffsetDateTime.now());
 
       if (requestedTier != null && requestedTier != Tier.ALL_TIERS && requestedTier != collectionTier) {
         summonerRefreshStatusUpdater.syncRefreshCursor(puuid, summoner.getLastMatchStartTime());

--- a/src/main/java/com/bestduo_BE/refresh/application/port/SummonerRefreshStatusUpdater.java
+++ b/src/main/java/com/bestduo_BE/refresh/application/port/SummonerRefreshStatusUpdater.java
@@ -1,10 +1,14 @@
 package com.bestduo_BE.refresh.application.port;
 
+import com.bestduo_BE.common.domain.model.Tier;
 import com.bestduo_BE.common.infra.persistence.entity.Summoner;
+import java.time.OffsetDateTime;
 
 public interface SummonerRefreshStatusUpdater {
 
   Summoner findOrCreate(String puuid);
+
+  void syncResolvedTier(String puuid, Tier tier, OffsetDateTime observedAt);
 
   void syncRefreshCursor(String puuid, Long newLastMatchStartTime);
 }

--- a/src/main/java/com/bestduo_BE/refresh/infra/persistence/SummonerRefreshStatusUpdaterImpl.java
+++ b/src/main/java/com/bestduo_BE/refresh/infra/persistence/SummonerRefreshStatusUpdaterImpl.java
@@ -1,8 +1,10 @@
 package com.bestduo_BE.refresh.infra.persistence;
 
+import com.bestduo_BE.common.domain.model.Tier;
 import com.bestduo_BE.refresh.application.port.SummonerRefreshStatusUpdater;
 import com.bestduo_BE.common.infra.persistence.entity.Summoner;
 import com.bestduo_BE.common.infra.persistence.repository.SummonerJpaRepository;
+import java.time.OffsetDateTime;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
@@ -18,6 +20,12 @@ public class SummonerRefreshStatusUpdaterImpl implements SummonerRefreshStatusUp
   public Summoner findOrCreate(String puuid) {
     return repository.findById(puuid)
         .orElseGet(() -> repository.save(Summoner.create(puuid)));
+  }
+
+  @Override
+  @Transactional
+  public void syncResolvedTier(String puuid, Tier tier, OffsetDateTime observedAt) {
+    repository.updateTierMetadata(puuid, tier == null ? null : tier.name(), observedAt);
   }
 
   @Override

--- a/src/main/java/com/bestduo_BE/workitem/application/WorkItemPoller.java
+++ b/src/main/java/com/bestduo_BE/workitem/application/WorkItemPoller.java
@@ -1,8 +1,7 @@
 package com.bestduo_BE.workitem.application;
 
-import com.bestduo_BE.workitem.domain.model.WorkItemStatus;
+import com.bestduo_BE.workitem.application.port.WorkItemDispatcher;
 import com.bestduo_BE.workitem.infra.persistence.entity.WorkItem;
-import com.bestduo_BE.workitem.infra.persistence.repository.WorkItemJpaRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -10,17 +9,14 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class WorkItemPoller {
 
-  private final WorkItemJpaRepository workItemJpaRepository;
+  private final WorkItemDispatcher workItemDispatcher;
   private final WorkItemWorker workItemWorker;
 
   public WorkItemWorker.WorkerResult pollOnce() {
-    WorkItem next = workItemJpaRepository.findFirstByStatusOrderByPriorityAscCreatedAtAsc(WorkItemStatus.READY)
-        .orElse(null);
-
+    WorkItem next = workItemDispatcher.pickAndLock(1).stream().findFirst().orElse(null);
     if (next == null) {
       return null;
     }
-
-    return workItemWorker.execute(next.getId());
+    return workItemWorker.execute(next);
   }
 }

--- a/src/main/java/com/bestduo_BE/workitem/application/WorkItemPoller.java
+++ b/src/main/java/com/bestduo_BE/workitem/application/WorkItemPoller.java
@@ -3,7 +3,6 @@ package com.bestduo_BE.workitem.application;
 import com.bestduo_BE.workitem.domain.model.WorkItemStatus;
 import com.bestduo_BE.workitem.infra.persistence.entity.WorkItem;
 import com.bestduo_BE.workitem.infra.persistence.repository.WorkItemJpaRepository;
-import java.util.Comparator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -15,9 +14,7 @@ public class WorkItemPoller {
   private final WorkItemWorker workItemWorker;
 
   public WorkItemWorker.WorkerResult pollOnce() {
-    WorkItem next = workItemJpaRepository.findAll().stream()
-        .filter(item -> item.getStatus() == WorkItemStatus.READY)
-        .min(Comparator.comparingInt(WorkItem::getPriority).thenComparing(WorkItem::getCreatedAt))
+    WorkItem next = workItemJpaRepository.findFirstByStatusOrderByPriorityAscCreatedAtAsc(WorkItemStatus.READY)
         .orElse(null);
 
     if (next == null) {

--- a/src/main/java/com/bestduo_BE/workitem/application/WorkItemPoller.java
+++ b/src/main/java/com/bestduo_BE/workitem/application/WorkItemPoller.java
@@ -1,0 +1,29 @@
+package com.bestduo_BE.workitem.application;
+
+import com.bestduo_BE.workitem.domain.model.WorkItemStatus;
+import com.bestduo_BE.workitem.infra.persistence.entity.WorkItem;
+import com.bestduo_BE.workitem.infra.persistence.repository.WorkItemJpaRepository;
+import java.util.Comparator;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class WorkItemPoller {
+
+  private final WorkItemJpaRepository workItemJpaRepository;
+  private final WorkItemWorker workItemWorker;
+
+  public WorkItemWorker.WorkerResult pollOnce() {
+    WorkItem next = workItemJpaRepository.findAll().stream()
+        .filter(item -> item.getStatus() == WorkItemStatus.READY)
+        .min(Comparator.comparingInt(WorkItem::getPriority).thenComparing(WorkItem::getCreatedAt))
+        .orElse(null);
+
+    if (next == null) {
+      return null;
+    }
+
+    return workItemWorker.execute(next.getId());
+  }
+}

--- a/src/main/java/com/bestduo_BE/workitem/application/WorkItemWorker.java
+++ b/src/main/java/com/bestduo_BE/workitem/application/WorkItemWorker.java
@@ -1,0 +1,61 @@
+package com.bestduo_BE.workitem.application;
+
+import com.bestduo_BE.common.domain.model.SeedBootstrapCommand;
+import com.bestduo_BE.common.domain.model.Tier;
+import com.bestduo_BE.common.infra.riot.KeyLease;
+import com.bestduo_BE.common.infra.riot.RiotKeyPool;
+import com.bestduo_BE.coverage.infra.persistence.repository.CoverageBucketJpaRepository;
+import com.bestduo_BE.ingest.application.MatchIngestWorker;
+import com.bestduo_BE.refresh.application.RefreshBatchExecutor;
+import com.bestduo_BE.seed.application.SeedBootstrapExecutor;
+import com.bestduo_BE.workitem.domain.model.WorkItemType;
+import com.bestduo_BE.workitem.infra.persistence.entity.WorkItem;
+import com.bestduo_BE.workitem.infra.persistence.repository.WorkItemJpaRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class WorkItemWorker {
+
+  private final WorkItemJpaRepository workItemJpaRepository;
+  private final CoverageBucketJpaRepository coverageBucketJpaRepository;
+  private final SeedBootstrapExecutor seedBootstrapExecutor;
+  private final RefreshBatchExecutor refreshBatchExecutor;
+  private final MatchIngestWorker matchIngestWorker;
+  private final RiotKeyPool riotKeyPool;
+
+  @Transactional
+  public WorkerResult execute(Long workItemId) {
+    WorkItem item = workItemJpaRepository.findById(workItemId).orElseThrow();
+    item.markRunning();
+
+    try (KeyLease ignored = riotKeyPool.leaseForWorker()) {
+      switch (item.getType()) {
+        case VERIFY_SUMMONERS, REFRESH_SUMMONERS -> refreshBatchExecutor.execute(item.getBatchLimit(), item.getTier());
+        case INGEST_MATCH_DETAIL -> matchIngestWorker.execute(item.getBatchLimit(), item.getTier());
+        case SEED_SUMMONERS -> seedBootstrapExecutor.execute(new SeedBootstrapCommand(
+            "RANKED_SOLO_5x5",
+            item.getTier().name(),
+            "I",
+            item.getTier(),
+            1,
+            1,
+            20,
+            item.getBatchLimit() == null ? 0 : item.getBatchLimit()
+        ));
+      }
+      item.markDone();
+      return new WorkerResult(workItemId, item.getType(), "DONE");
+    } catch (Exception e) {
+      item.markError();
+      return new WorkerResult(workItemId, item.getType(), "ERROR");
+    } finally {
+      riotKeyPool.clearWorkerLease();
+    }
+  }
+
+  public record WorkerResult(Long workItemId, WorkItemType type, String status) {
+  }
+}

--- a/src/main/java/com/bestduo_BE/workitem/application/WorkItemWorker.java
+++ b/src/main/java/com/bestduo_BE/workitem/application/WorkItemWorker.java
@@ -4,10 +4,10 @@ import com.bestduo_BE.common.domain.model.SeedBootstrapCommand;
 import com.bestduo_BE.common.domain.model.Tier;
 import com.bestduo_BE.common.infra.riot.KeyLease;
 import com.bestduo_BE.common.infra.riot.RiotKeyPool;
-import com.bestduo_BE.coverage.infra.persistence.repository.CoverageBucketJpaRepository;
 import com.bestduo_BE.ingest.application.MatchIngestWorker;
 import com.bestduo_BE.refresh.application.RefreshBatchExecutor;
 import com.bestduo_BE.seed.application.SeedBootstrapExecutor;
+import com.bestduo_BE.workitem.domain.model.WorkItemStatus;
 import com.bestduo_BE.workitem.domain.model.WorkItemType;
 import com.bestduo_BE.workitem.infra.persistence.entity.WorkItem;
 import com.bestduo_BE.workitem.infra.persistence.repository.WorkItemJpaRepository;
@@ -20,7 +20,6 @@ import org.springframework.transaction.annotation.Transactional;
 public class WorkItemWorker {
 
   private final WorkItemJpaRepository workItemJpaRepository;
-  private final CoverageBucketJpaRepository coverageBucketJpaRepository;
   private final SeedBootstrapExecutor seedBootstrapExecutor;
   private final RefreshBatchExecutor refreshBatchExecutor;
   private final MatchIngestWorker matchIngestWorker;
@@ -47,15 +46,15 @@ public class WorkItemWorker {
         ));
       }
       item.markDone();
-      return new WorkerResult(workItemId, item.getType(), "DONE");
+      return new WorkerResult(workItemId, item.getType(), WorkItemStatus.DONE);
     } catch (Exception e) {
       item.markError();
-      return new WorkerResult(workItemId, item.getType(), "ERROR");
+      return new WorkerResult(workItemId, item.getType(), WorkItemStatus.ERROR);
     } finally {
       riotKeyPool.clearWorkerLease();
     }
   }
 
-  public record WorkerResult(Long workItemId, WorkItemType type, String status) {
+  public record WorkerResult(Long workItemId, WorkItemType type, WorkItemStatus status) {
   }
 }

--- a/src/main/java/com/bestduo_BE/workitem/application/WorkItemWorker.java
+++ b/src/main/java/com/bestduo_BE/workitem/application/WorkItemWorker.java
@@ -2,6 +2,8 @@ package com.bestduo_BE.workitem.application;
 
 import com.bestduo_BE.common.infra.riot.KeyLease;
 import com.bestduo_BE.common.infra.riot.RiotKeyPool;
+import com.bestduo_BE.common.infra.riot.budget.BudgetExhaustedException;
+import com.bestduo_BE.common.infra.riot.exception.RiotRateLimitedException;
 import com.bestduo_BE.workitem.application.port.WorkItemDispatcher;
 import com.bestduo_BE.workitem.application.worker.WorkerContract;
 import com.bestduo_BE.workitem.domain.model.WorkItemStatus;
@@ -42,6 +44,10 @@ public class WorkItemWorker {
       worker.execute(item, ignored);
       workItemDispatcher.markDone(item.getId());
       return new WorkerResult(item.getId(), item.getType(), WorkItemStatus.DONE);
+    } catch (BudgetExhaustedException | RiotRateLimitedException e) {
+      // key 소진/rate limit — 실패가 아니라 세션 일시 중단. PENDING으로 복구해 다음 주기에 재시도.
+      workItemDispatcher.markPending(item.getId());
+      throw e;
     } catch (Exception e) {
       workItemDispatcher.markError(item.getId(), e.getMessage());
       return new WorkerResult(item.getId(), item.getType(), WorkItemStatus.ERROR);

--- a/src/main/java/com/bestduo_BE/workitem/application/WorkItemWorker.java
+++ b/src/main/java/com/bestduo_BE/workitem/application/WorkItemWorker.java
@@ -1,55 +1,50 @@
 package com.bestduo_BE.workitem.application;
 
-import com.bestduo_BE.common.domain.model.SeedBootstrapCommand;
-import com.bestduo_BE.common.domain.model.Tier;
 import com.bestduo_BE.common.infra.riot.KeyLease;
 import com.bestduo_BE.common.infra.riot.RiotKeyPool;
-import com.bestduo_BE.ingest.application.MatchIngestWorker;
-import com.bestduo_BE.refresh.application.RefreshBatchExecutor;
-import com.bestduo_BE.seed.application.SeedBootstrapExecutor;
+import com.bestduo_BE.workitem.application.port.WorkItemDispatcher;
+import com.bestduo_BE.workitem.application.worker.WorkerContract;
 import com.bestduo_BE.workitem.domain.model.WorkItemStatus;
 import com.bestduo_BE.workitem.domain.model.WorkItemType;
 import com.bestduo_BE.workitem.infra.persistence.entity.WorkItem;
-import com.bestduo_BE.workitem.infra.persistence.repository.WorkItemJpaRepository;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
-@RequiredArgsConstructor
 public class WorkItemWorker {
 
-  private final WorkItemJpaRepository workItemJpaRepository;
-  private final SeedBootstrapExecutor seedBootstrapExecutor;
-  private final RefreshBatchExecutor refreshBatchExecutor;
-  private final MatchIngestWorker matchIngestWorker;
+  private final WorkItemDispatcher workItemDispatcher;
   private final RiotKeyPool riotKeyPool;
+  private final Map<WorkItemType, WorkerContract> workers;
 
-  @Transactional
-  public WorkerResult execute(Long workItemId) {
-    WorkItem item = workItemJpaRepository.findById(workItemId).orElseThrow();
-    item.markRunning();
+  public WorkItemWorker(
+      WorkItemDispatcher workItemDispatcher,
+      RiotKeyPool riotKeyPool,
+      List<WorkerContract> workers
+  ) {
+    this.workItemDispatcher = workItemDispatcher;
+    this.riotKeyPool = riotKeyPool;
+    this.workers = new EnumMap<>(WorkItemType.class);
+    workers.forEach(worker -> this.workers.put(worker.type(), worker));
+  }
+
+  public WorkerResult execute(WorkItem item) {
+    WorkerContract worker = workers.get(item.getType());
+    if (worker == null) {
+      workItemDispatcher.markError(item.getId(), "No worker registered for type=" + item.getType());
+      return new WorkerResult(item.getId(), item.getType(), WorkItemStatus.ERROR);
+    }
 
     try (KeyLease ignored = riotKeyPool.leaseForWorker()) {
-      switch (item.getType()) {
-        case VERIFY_SUMMONERS, REFRESH_SUMMONERS -> refreshBatchExecutor.execute(item.getBatchLimit(), item.getTier());
-        case INGEST_MATCH_DETAIL -> matchIngestWorker.execute(item.getBatchLimit(), item.getTier());
-        case SEED_SUMMONERS -> seedBootstrapExecutor.execute(new SeedBootstrapCommand(
-            "RANKED_SOLO_5x5",
-            item.getTier().name(),
-            "I",
-            item.getTier(),
-            1,
-            1,
-            20,
-            item.getBatchLimit() == null ? 0 : item.getBatchLimit()
-        ));
-      }
-      item.markDone();
-      return new WorkerResult(workItemId, item.getType(), WorkItemStatus.DONE);
+      worker.execute(item, ignored);
+      workItemDispatcher.markDone(item.getId());
+      return new WorkerResult(item.getId(), item.getType(), WorkItemStatus.DONE);
     } catch (Exception e) {
-      item.markError();
-      return new WorkerResult(workItemId, item.getType(), WorkItemStatus.ERROR);
+      workItemDispatcher.markError(item.getId(), e.getMessage());
+      return new WorkerResult(item.getId(), item.getType(), WorkItemStatus.ERROR);
     } finally {
       riotKeyPool.clearWorkerLease();
     }

--- a/src/main/java/com/bestduo_BE/workitem/application/WorkerPool.java
+++ b/src/main/java/com/bestduo_BE/workitem/application/WorkerPool.java
@@ -1,0 +1,61 @@
+package com.bestduo_BE.workitem.application;
+
+import com.bestduo_BE.config.WorkItemProperties;
+import com.bestduo_BE.workitem.application.port.WorkItemDispatcher;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import java.time.Duration;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+@ConditionalOnProperty(prefix = "work-item", name = "worker-enabled", havingValue = "true")
+public class WorkerPool {
+
+  private final WorkItemProperties workItemProperties;
+  private final WorkItemDispatcher workItemDispatcher;
+  private final WorkItemWorker workItemWorker;
+
+  private ExecutorService executorService;
+
+  @PostConstruct
+  void start() {
+    executorService = Executors.newVirtualThreadPerTaskExecutor();
+    for (int i = 0; i < workItemProperties.getPoolSize(); i++) {
+      executorService.submit(this::runLoop);
+    }
+  }
+
+  private void runLoop() {
+    while (!Thread.currentThread().isInterrupted()) {
+      try {
+        workItemDispatcher.recoverStaleRunning(workItemProperties.getStaleMinutes());
+        var picked = workItemDispatcher.pickAndLock(1);
+        if (picked.isEmpty()) {
+          Thread.sleep(workItemProperties.getPollingIntervalMs());
+          continue;
+        }
+        workItemWorker.execute(picked.getFirst());
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      } catch (Exception e) {
+        try {
+          Thread.sleep(Duration.ofMillis(workItemProperties.getPollingIntervalMs()).toMillis());
+        } catch (InterruptedException interruptedException) {
+          Thread.currentThread().interrupt();
+        }
+      }
+    }
+  }
+
+  @PreDestroy
+  void stop() {
+    if (executorService != null) {
+      executorService.shutdownNow();
+    }
+  }
+}

--- a/src/main/java/com/bestduo_BE/workitem/application/WorkerPool.java
+++ b/src/main/java/com/bestduo_BE/workitem/application/WorkerPool.java
@@ -24,6 +24,8 @@ public class WorkerPool {
 
   @PostConstruct
   void start() {
+    // 서버 재시작 시 이전 RUNNING 아이템을 PENDING으로 복구
+    workItemDispatcher.recoverStaleRunning(workItemProperties.getStaleMinutes());
     executorService = Executors.newVirtualThreadPerTaskExecutor();
     for (int i = 0; i < workItemProperties.getPoolSize(); i++) {
       executorService.submit(this::runLoop);
@@ -33,7 +35,6 @@ public class WorkerPool {
   private void runLoop() {
     while (!Thread.currentThread().isInterrupted()) {
       try {
-        workItemDispatcher.recoverStaleRunning(workItemProperties.getStaleMinutes());
         var picked = workItemDispatcher.pickAndLock(1);
         if (picked.isEmpty()) {
           Thread.sleep(workItemProperties.getPollingIntervalMs());

--- a/src/main/java/com/bestduo_BE/workitem/application/port/WorkItemDispatcher.java
+++ b/src/main/java/com/bestduo_BE/workitem/application/port/WorkItemDispatcher.java
@@ -1,0 +1,24 @@
+package com.bestduo_BE.workitem.application.port;
+
+import com.bestduo_BE.common.domain.model.Tier;
+import com.bestduo_BE.workitem.domain.model.WorkItemStatus;
+import com.bestduo_BE.workitem.domain.model.WorkItemType;
+import com.bestduo_BE.workitem.infra.persistence.entity.WorkItem;
+import java.util.List;
+
+public interface WorkItemDispatcher {
+
+  WorkItem emit(WorkItem workItem);
+
+  List<WorkItem> pickAndLock(int limit);
+
+  int recoverStaleRunning(int staleMinutes);
+
+  void markDone(Long workItemId);
+
+  void markError(Long workItemId, String message);
+
+  long countByTypePatchTierStatus(WorkItemType type, String patch, Tier tier, WorkItemStatus status);
+
+  long countByTypePatchTierStatuses(WorkItemType type, String patch, Tier tier, List<WorkItemStatus> statuses);
+}

--- a/src/main/java/com/bestduo_BE/workitem/application/port/WorkItemDispatcher.java
+++ b/src/main/java/com/bestduo_BE/workitem/application/port/WorkItemDispatcher.java
@@ -18,6 +18,8 @@ public interface WorkItemDispatcher {
 
   void markError(Long workItemId, String message);
 
+  void markPending(Long workItemId);
+
   long countByTypePatchTierStatus(WorkItemType type, String patch, Tier tier, WorkItemStatus status);
 
   long countByTypePatchTierStatuses(WorkItemType type, String patch, Tier tier, List<WorkItemStatus> statuses);

--- a/src/main/java/com/bestduo_BE/workitem/application/worker/IngestMatchDetailWorker.java
+++ b/src/main/java/com/bestduo_BE/workitem/application/worker/IngestMatchDetailWorker.java
@@ -1,0 +1,25 @@
+package com.bestduo_BE.workitem.application.worker;
+
+import com.bestduo_BE.common.infra.riot.KeyLease;
+import com.bestduo_BE.ingest.application.MatchIngestWorker;
+import com.bestduo_BE.workitem.domain.model.WorkItemType;
+import com.bestduo_BE.workitem.infra.persistence.entity.WorkItem;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class IngestMatchDetailWorker implements WorkerContract {
+
+  private final MatchIngestWorker matchIngestWorker;
+
+  @Override
+  public WorkItemType type() {
+    return WorkItemType.INGEST_MATCH_DETAIL;
+  }
+
+  @Override
+  public void execute(WorkItem workItem, KeyLease keyLease) {
+    matchIngestWorker.execute(workItem.getBatchLimit(), workItem.getTier());
+  }
+}

--- a/src/main/java/com/bestduo_BE/workitem/application/worker/RefreshSummonerWorker.java
+++ b/src/main/java/com/bestduo_BE/workitem/application/worker/RefreshSummonerWorker.java
@@ -1,0 +1,25 @@
+package com.bestduo_BE.workitem.application.worker;
+
+import com.bestduo_BE.common.infra.riot.KeyLease;
+import com.bestduo_BE.refresh.application.RefreshBatchExecutor;
+import com.bestduo_BE.workitem.domain.model.WorkItemType;
+import com.bestduo_BE.workitem.infra.persistence.entity.WorkItem;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class RefreshSummonerWorker implements WorkerContract {
+
+  private final RefreshBatchExecutor refreshBatchExecutor;
+
+  @Override
+  public WorkItemType type() {
+    return WorkItemType.REFRESH_SUMMONERS;
+  }
+
+  @Override
+  public void execute(WorkItem workItem, KeyLease keyLease) {
+    refreshBatchExecutor.execute(workItem.getBatchLimit(), workItem.getTier());
+  }
+}

--- a/src/main/java/com/bestduo_BE/workitem/application/worker/SeedPageWorker.java
+++ b/src/main/java/com/bestduo_BE/workitem/application/worker/SeedPageWorker.java
@@ -1,0 +1,63 @@
+package com.bestduo_BE.workitem.application.worker;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.bestduo_BE.common.domain.model.SeedBootstrapCommand;
+import com.bestduo_BE.common.infra.riot.KeyLease;
+import com.bestduo_BE.seed.application.SeedBootstrapExecutor;
+import com.bestduo_BE.workitem.domain.model.WorkItemType;
+import com.bestduo_BE.workitem.infra.persistence.entity.WorkItem;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class SeedPageWorker implements WorkerContract {
+
+  private final SeedBootstrapExecutor seedBootstrapExecutor;
+  private final ObjectMapper objectMapper;
+
+  @Override
+  public WorkItemType type() {
+    return WorkItemType.SEED_SUMMONERS;
+  }
+
+  @Override
+  public void execute(WorkItem workItem, KeyLease keyLease) {
+    SeedPayload payload = parsePayload(workItem.getPayload());
+    seedBootstrapExecutor.execute(new SeedBootstrapCommand(
+        payload.queue(),
+        payload.tier(),
+        payload.division(),
+        workItem.getTier(),
+        payload.page(),
+        payload.page(),
+        20,
+        workItem.getBatchLimit() == null ? 0 : workItem.getBatchLimit()
+    ));
+  }
+
+  private SeedPayload parsePayload(String rawPayload) {
+    if (rawPayload == null || rawPayload.isBlank()) {
+      return new SeedPayload("RANKED_SOLO_5x5", "I", 1, null);
+    }
+    try {
+      JsonNode node = objectMapper.readTree(rawPayload);
+      return new SeedPayload(
+          text(node, "queue", "RANKED_SOLO_5x5"),
+          text(node, "division", "I"),
+          node.path("page").asInt(1),
+          text(node, "tier", null)
+      );
+    } catch (Exception e) {
+      return new SeedPayload("RANKED_SOLO_5x5", "I", 1, null);
+    }
+  }
+
+  private String text(JsonNode node, String field, String fallback) {
+    return node.hasNonNull(field) ? node.get(field).asText() : fallback;
+  }
+
+  private record SeedPayload(String queue, String division, int page, String tier) {
+  }
+}

--- a/src/main/java/com/bestduo_BE/workitem/application/worker/VerifySummonerWorker.java
+++ b/src/main/java/com/bestduo_BE/workitem/application/worker/VerifySummonerWorker.java
@@ -1,0 +1,25 @@
+package com.bestduo_BE.workitem.application.worker;
+
+import com.bestduo_BE.common.infra.riot.KeyLease;
+import com.bestduo_BE.refresh.application.RefreshBatchExecutor;
+import com.bestduo_BE.workitem.domain.model.WorkItemType;
+import com.bestduo_BE.workitem.infra.persistence.entity.WorkItem;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class VerifySummonerWorker implements WorkerContract {
+
+  private final RefreshBatchExecutor refreshBatchExecutor;
+
+  @Override
+  public WorkItemType type() {
+    return WorkItemType.VERIFY_SUMMONERS;
+  }
+
+  @Override
+  public void execute(WorkItem workItem, KeyLease keyLease) {
+    refreshBatchExecutor.execute(workItem.getBatchLimit(), workItem.getTier());
+  }
+}

--- a/src/main/java/com/bestduo_BE/workitem/application/worker/VerifySummonerWorker.java
+++ b/src/main/java/com/bestduo_BE/workitem/application/worker/VerifySummonerWorker.java
@@ -20,6 +20,9 @@ public class VerifySummonerWorker implements WorkerContract {
 
   @Override
   public void execute(WorkItem workItem, KeyLease keyLease) {
+    // RefreshBatchExecutor는 findRefreshTargets를 tier_observed_at IS NULL 우선으로 정렬하므로,
+    // 미검증 소환사(tier_observed_at = null)가 자동으로 먼저 처리된다.
+    // tier 갱신 전용 executor가 별도로 생기면 그쪽으로 교체 예정.
     refreshBatchExecutor.execute(workItem.getBatchLimit(), workItem.getTier());
   }
 }

--- a/src/main/java/com/bestduo_BE/workitem/application/worker/WorkerContract.java
+++ b/src/main/java/com/bestduo_BE/workitem/application/worker/WorkerContract.java
@@ -1,0 +1,12 @@
+package com.bestduo_BE.workitem.application.worker;
+
+import com.bestduo_BE.common.infra.riot.KeyLease;
+import com.bestduo_BE.workitem.domain.model.WorkItemType;
+import com.bestduo_BE.workitem.infra.persistence.entity.WorkItem;
+
+public interface WorkerContract {
+
+  WorkItemType type();
+
+  void execute(WorkItem workItem, KeyLease keyLease);
+}

--- a/src/main/java/com/bestduo_BE/workitem/domain/model/WorkItemStatus.java
+++ b/src/main/java/com/bestduo_BE/workitem/domain/model/WorkItemStatus.java
@@ -1,0 +1,8 @@
+package com.bestduo_BE.workitem.domain.model;
+
+public enum WorkItemStatus {
+  READY,
+  RUNNING,
+  DONE,
+  ERROR
+}

--- a/src/main/java/com/bestduo_BE/workitem/domain/model/WorkItemStatus.java
+++ b/src/main/java/com/bestduo_BE/workitem/domain/model/WorkItemStatus.java
@@ -1,7 +1,7 @@
 package com.bestduo_BE.workitem.domain.model;
 
 public enum WorkItemStatus {
-  READY,
+  PENDING,
   RUNNING,
   DONE,
   ERROR

--- a/src/main/java/com/bestduo_BE/workitem/domain/model/WorkItemType.java
+++ b/src/main/java/com/bestduo_BE/workitem/domain/model/WorkItemType.java
@@ -1,0 +1,8 @@
+package com.bestduo_BE.workitem.domain.model;
+
+public enum WorkItemType {
+  SEED_SUMMONERS,
+  VERIFY_SUMMONERS,
+  REFRESH_SUMMONERS,
+  INGEST_MATCH_DETAIL
+}

--- a/src/main/java/com/bestduo_BE/workitem/infra/persistence/WorkItemDispatcherImpl.java
+++ b/src/main/java/com/bestduo_BE/workitem/infra/persistence/WorkItemDispatcherImpl.java
@@ -1,0 +1,63 @@
+package com.bestduo_BE.workitem.infra.persistence;
+
+import com.bestduo_BE.common.domain.model.Tier;
+import com.bestduo_BE.workitem.application.port.WorkItemDispatcher;
+import com.bestduo_BE.workitem.domain.model.WorkItemStatus;
+import com.bestduo_BE.workitem.domain.model.WorkItemType;
+import com.bestduo_BE.workitem.infra.persistence.entity.WorkItem;
+import com.bestduo_BE.workitem.infra.persistence.repository.WorkItemJpaRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class WorkItemDispatcherImpl implements WorkItemDispatcher {
+
+  private final WorkItemJpaRepository repository;
+
+  @Override
+  @Transactional
+  public WorkItem emit(WorkItem workItem) {
+    return repository.save(workItem);
+  }
+
+  @Override
+  @Transactional
+  public List<WorkItem> pickAndLock(int limit) {
+    List<WorkItem> items = repository.pickPendingForUpdate(limit);
+    items.forEach(WorkItem::markRunning);
+    return items;
+  }
+
+  @Override
+  @Transactional
+  public int recoverStaleRunning(int staleMinutes) {
+    return repository.recoverStaleRunning(staleMinutes);
+  }
+
+  @Override
+  @Transactional
+  public void markDone(Long workItemId) {
+    WorkItem item = repository.findById(workItemId).orElseThrow();
+    item.markDone();
+  }
+
+  @Override
+  @Transactional
+  public void markError(Long workItemId, String message) {
+    WorkItem item = repository.findById(workItemId).orElseThrow();
+    item.markError(message);
+  }
+
+  @Override
+  public long countByTypePatchTierStatus(WorkItemType type, String patch, Tier tier, WorkItemStatus status) {
+    return repository.countByTypeAndPatchAndTierAndStatus(type, patch, tier, status);
+  }
+
+  @Override
+  public long countByTypePatchTierStatuses(WorkItemType type, String patch, Tier tier, List<WorkItemStatus> statuses) {
+    return repository.countByTypeAndPatchAndTierAndStatusIn(type, patch, tier, statuses);
+  }
+}

--- a/src/main/java/com/bestduo_BE/workitem/infra/persistence/WorkItemDispatcherImpl.java
+++ b/src/main/java/com/bestduo_BE/workitem/infra/persistence/WorkItemDispatcherImpl.java
@@ -52,6 +52,13 @@ public class WorkItemDispatcherImpl implements WorkItemDispatcher {
   }
 
   @Override
+  @Transactional
+  public void markPending(Long workItemId) {
+    WorkItem item = repository.findById(workItemId).orElseThrow();
+    item.markPending();
+  }
+
+  @Override
   public long countByTypePatchTierStatus(WorkItemType type, String patch, Tier tier, WorkItemStatus status) {
     return repository.countByTypeAndPatchAndTierAndStatus(type, patch, tier, status);
   }

--- a/src/main/java/com/bestduo_BE/workitem/infra/persistence/entity/WorkItem.java
+++ b/src/main/java/com/bestduo_BE/workitem/infra/persistence/entity/WorkItem.java
@@ -1,0 +1,95 @@
+package com.bestduo_BE.workitem.infra.persistence.entity;
+
+import com.bestduo_BE.common.domain.model.Tier;
+import com.bestduo_BE.workitem.domain.model.WorkItemStatus;
+import com.bestduo_BE.workitem.domain.model.WorkItemType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Index;
+import jakarta.persistence.Table;
+import java.time.OffsetDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "work_item", indexes = {
+    @Index(name = "idx_work_item_status_priority", columnList = "status, priority, created_at")
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class WorkItem {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  private WorkItemType type;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  private WorkItemStatus status;
+
+  @Column(name = "coverage_bucket_id", nullable = false)
+  private Long coverageBucketId;
+
+  @Column(nullable = false)
+  private String patch;
+
+  @Enumerated(EnumType.STRING)
+  @Column(nullable = false)
+  private Tier tier;
+
+  @Column(nullable = false)
+  private int priority;
+
+  @Column(name = "batch_limit")
+  private Integer batchLimit;
+
+  @Column(name = "created_at", nullable = false)
+  private OffsetDateTime createdAt;
+
+  @Column(name = "updated_at", nullable = false)
+  private OffsetDateTime updatedAt;
+
+  public static WorkItem ready(Long coverageBucketId, String patch, Tier tier, WorkItemType type, int priority, Integer batchLimit) {
+    OffsetDateTime now = OffsetDateTime.now();
+    return WorkItem.builder()
+        .coverageBucketId(coverageBucketId)
+        .patch(patch)
+        .tier(tier)
+        .type(type)
+        .status(WorkItemStatus.READY)
+        .priority(priority)
+        .batchLimit(batchLimit)
+        .createdAt(now)
+        .updatedAt(now)
+        .build();
+  }
+
+  public void markRunning() {
+    this.status = WorkItemStatus.RUNNING;
+    this.updatedAt = OffsetDateTime.now();
+  }
+
+  public void markDone() {
+    this.status = WorkItemStatus.DONE;
+    this.updatedAt = OffsetDateTime.now();
+  }
+
+  public void markError() {
+    this.status = WorkItemStatus.ERROR;
+    this.updatedAt = OffsetDateTime.now();
+  }
+}

--- a/src/main/java/com/bestduo_BE/workitem/infra/persistence/entity/WorkItem.java
+++ b/src/main/java/com/bestduo_BE/workitem/infra/persistence/entity/WorkItem.java
@@ -44,6 +44,9 @@ public class WorkItem {
   @Column(name = "coverage_bucket_id", nullable = false)
   private Long coverageBucketId;
 
+  @Column(length = 2000)
+  private String payload;
+
   @Column(nullable = false)
   private String patch;
 
@@ -57,22 +60,43 @@ public class WorkItem {
   @Column(name = "batch_limit")
   private Integer batchLimit;
 
+  @Column(name = "retry_count", nullable = false)
+  private int retryCount;
+
+  @Column(name = "last_error", length = 512)
+  private String lastError;
+
+  @Column(name = "locked_at")
+  private OffsetDateTime lockedAt;
+
   @Column(name = "created_at", nullable = false)
   private OffsetDateTime createdAt;
 
   @Column(name = "updated_at", nullable = false)
   private OffsetDateTime updatedAt;
 
-  public static WorkItem ready(Long coverageBucketId, String patch, Tier tier, WorkItemType type, int priority, Integer batchLimit) {
+  public static WorkItem pending(
+      Long coverageBucketId,
+      String patch,
+      Tier tier,
+      WorkItemType type,
+      int priority,
+      Integer batchLimit,
+      String payload
+  ) {
     OffsetDateTime now = OffsetDateTime.now();
     return WorkItem.builder()
         .coverageBucketId(coverageBucketId)
         .patch(patch)
         .tier(tier)
         .type(type)
-        .status(WorkItemStatus.READY)
+        .status(WorkItemStatus.PENDING)
         .priority(priority)
         .batchLimit(batchLimit)
+        .payload(payload)
+        .retryCount(0)
+        .lastError(null)
+        .lockedAt(null)
         .createdAt(now)
         .updatedAt(now)
         .build();
@@ -80,16 +104,28 @@ public class WorkItem {
 
   public void markRunning() {
     this.status = WorkItemStatus.RUNNING;
+    this.lockedAt = OffsetDateTime.now();
     this.updatedAt = OffsetDateTime.now();
   }
 
   public void markDone() {
     this.status = WorkItemStatus.DONE;
+    this.lockedAt = null;
+    this.lastError = null;
     this.updatedAt = OffsetDateTime.now();
   }
 
-  public void markError() {
+  public void markError(String errorMessage) {
     this.status = WorkItemStatus.ERROR;
+    this.lockedAt = null;
+    this.retryCount += 1;
+    this.lastError = errorMessage == null ? null : errorMessage.substring(0, Math.min(errorMessage.length(), 512));
+    this.updatedAt = OffsetDateTime.now();
+  }
+
+  public void markPending() {
+    this.status = WorkItemStatus.PENDING;
+    this.lockedAt = null;
     this.updatedAt = OffsetDateTime.now();
   }
 }

--- a/src/main/java/com/bestduo_BE/workitem/infra/persistence/repository/WorkItemJpaRepository.java
+++ b/src/main/java/com/bestduo_BE/workitem/infra/persistence/repository/WorkItemJpaRepository.java
@@ -5,6 +5,7 @@ import com.bestduo_BE.workitem.domain.model.WorkItemStatus;
 import com.bestduo_BE.workitem.domain.model.WorkItemType;
 import com.bestduo_BE.workitem.infra.persistence.entity.WorkItem;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface WorkItemJpaRepository extends JpaRepository<WorkItem, Long> {
@@ -12,4 +13,6 @@ public interface WorkItemJpaRepository extends JpaRepository<WorkItem, Long> {
   boolean existsByCoverageBucketIdAndTypeAndStatusIn(Long coverageBucketId, WorkItemType type, List<WorkItemStatus> statuses);
 
   long countByPatchAndTierAndStatus(String patch, Tier tier, WorkItemStatus status);
+
+  Optional<WorkItem> findFirstByStatusOrderByPriorityAscCreatedAtAsc(WorkItemStatus status);
 }

--- a/src/main/java/com/bestduo_BE/workitem/infra/persistence/repository/WorkItemJpaRepository.java
+++ b/src/main/java/com/bestduo_BE/workitem/infra/persistence/repository/WorkItemJpaRepository.java
@@ -6,13 +6,42 @@ import com.bestduo_BE.workitem.domain.model.WorkItemType;
 import com.bestduo_BE.workitem.infra.persistence.entity.WorkItem;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.query.Param;
 
 public interface WorkItemJpaRepository extends JpaRepository<WorkItem, Long> {
 
   boolean existsByCoverageBucketIdAndTypeAndStatusIn(Long coverageBucketId, WorkItemType type, List<WorkItemStatus> statuses);
 
   long countByPatchAndTierAndStatus(String patch, Tier tier, WorkItemStatus status);
+
+  long countByTypeAndPatchAndTierAndStatus(WorkItemType type, String patch, Tier tier, WorkItemStatus status);
+
+  long countByTypeAndPatchAndTierAndStatusIn(WorkItemType type, String patch, Tier tier, List<WorkItemStatus> statuses);
+
+  @Query(value = """
+      select *
+      from work_item wi
+      where wi.status = 'PENDING'
+      order by wi.priority asc, wi.created_at asc
+      limit :limit
+      for update skip locked
+      """, nativeQuery = true)
+  List<WorkItem> pickPendingForUpdate(@Param("limit") int limit);
+
+  @Modifying(clearAutomatically = true, flushAutomatically = true)
+  @Query(value = """
+      update work_item
+      set status = 'PENDING',
+          locked_at = null,
+          updated_at = now()
+      where status = 'RUNNING'
+        and locked_at is not null
+        and locked_at <= now() - (:staleMinutes || ' minutes')::interval
+      """, nativeQuery = true)
+  int recoverStaleRunning(@Param("staleMinutes") int staleMinutes);
 
   Optional<WorkItem> findFirstByStatusOrderByPriorityAscCreatedAtAsc(WorkItemStatus status);
 }

--- a/src/main/java/com/bestduo_BE/workitem/infra/persistence/repository/WorkItemJpaRepository.java
+++ b/src/main/java/com/bestduo_BE/workitem/infra/persistence/repository/WorkItemJpaRepository.java
@@ -1,0 +1,15 @@
+package com.bestduo_BE.workitem.infra.persistence.repository;
+
+import com.bestduo_BE.common.domain.model.Tier;
+import com.bestduo_BE.workitem.domain.model.WorkItemStatus;
+import com.bestduo_BE.workitem.domain.model.WorkItemType;
+import com.bestduo_BE.workitem.infra.persistence.entity.WorkItem;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface WorkItemJpaRepository extends JpaRepository<WorkItem, Long> {
+
+  boolean existsByCoverageBucketIdAndTypeAndStatusIn(Long coverageBucketId, WorkItemType type, List<WorkItemStatus> statuses);
+
+  long countByPatchAndTierAndStatus(String patch, Tier tier, WorkItemStatus status);
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -54,6 +54,26 @@ execution-request:
   worker:
     enabled: ${EXECUTION_REQUEST_WORKER_ENABLED:false}
 
+work-item:
+  worker-enabled: ${WORK_ITEM_WORKER_ENABLED:false}
+  pool-size: ${WORK_ITEM_POOL_SIZE:4}
+  polling-interval-ms: ${WORK_ITEM_POLLING_INTERVAL_MS:500}
+  scheduler-fixed-delay-ms: ${WORK_ITEM_SCHEDULER_FIXED_DELAY_MS:30000}
+  stale-minutes: ${WORK_ITEM_STALE_MINUTES:10}
+  duplicate-pending-limit: ${WORK_ITEM_DUPLICATE_PENDING_LIMIT:1}
+  threshold:
+    verified-pool: ${WORK_ITEM_THRESHOLD_VERIFIED_POOL:10}
+    ready-match-queue: ${WORK_ITEM_THRESHOLD_READY_MATCH_QUEUE:20}
+    recent-ingest: ${WORK_ITEM_THRESHOLD_RECENT_INGEST:5}
+    unverified-backlog: ${WORK_ITEM_THRESHOLD_UNVERIFIED_BACKLOG:5}
+    min-seed-trigger: ${WORK_ITEM_THRESHOLD_MIN_SEED_TRIGGER:3}
+    ingest-window-minutes: ${WORK_ITEM_THRESHOLD_INGEST_WINDOW_MINUTES:30}
+  batch:
+    verify: ${WORK_ITEM_BATCH_VERIFY:10}
+    refresh: ${WORK_ITEM_BATCH_REFRESH:10}
+    ingest: ${WORK_ITEM_BATCH_INGEST:20}
+    seed: ${WORK_ITEM_BATCH_SEED:1}
+
 management:
   endpoints:
     web:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -26,6 +26,8 @@ external:
     platform-base-url: https://kr.api.riotgames.com
     regional-base-url: https://asia.api.riotgames.com
     api-key: ${EXTERNAL_RIOT_API_KEY:}
+    api-keys: ${EXTERNAL_RIOT_API_KEYS:}
+    multi-key-enabled: ${EXTERNAL_RIOT_MULTI_KEY_ENABLED:false}
 
 collector:
   seed-puuids: [] # TODO populate with seed accounts to crawl

--- a/src/test/java/com/bestduo_BE/common/infra/persistence/entity/SummonerTest.java
+++ b/src/test/java/com/bestduo_BE/common/infra/persistence/entity/SummonerTest.java
@@ -2,6 +2,8 @@ package com.bestduo_BE.common.infra.persistence.entity;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.bestduo_BE.common.domain.model.Tier;
+import java.time.OffsetDateTime;
 import org.junit.jupiter.api.Test;
 
 class SummonerTest {
@@ -12,8 +14,22 @@ class SummonerTest {
 
     assertThat(summoner.getPuuid()).isEqualTo("p-1");
     assertThat(summoner.getLastMatchStartTime()).isNull();
+    assertThat(summoner.getLastKnownTier()).isNull();
+    assertThat(summoner.getTierObservedAt()).isNull();
+    assertThat(summoner.getLastSeenPatch()).isNull();
     assertThat(summoner.getCreatedAt()).isNotNull();
     assertThat(summoner.getUpdatedAt()).isNotNull();
+  }
+
+  @Test
+  void observeTierStoresLatestTierMetadata() {
+    Summoner summoner = Summoner.create("p-tier");
+    OffsetDateTime observedAt = OffsetDateTime.now().minusMinutes(1);
+
+    summoner.observeTier(Tier.MASTER, observedAt);
+
+    assertThat(summoner.getLastKnownTier()).isEqualTo(Tier.MASTER);
+    assertThat(summoner.getTierObservedAt()).isEqualTo(observedAt);
   }
 
   @Test

--- a/src/test/java/com/bestduo_BE/common/infra/persistence/repository/SummonerJpaRepositoryTest.java
+++ b/src/test/java/com/bestduo_BE/common/infra/persistence/repository/SummonerJpaRepositoryTest.java
@@ -1,0 +1,63 @@
+package com.bestduo_BE.common.infra.persistence.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.bestduo_BE.common.domain.model.Tier;
+import com.bestduo_BE.common.infra.persistence.entity.Summoner;
+import java.time.OffsetDateTime;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.test.context.TestPropertySource;
+
+@DataJpaTest
+@TestPropertySource(properties = {
+    "spring.datasource.url=jdbc:h2:mem:summoner-repo;MODE=PostgreSQL;DB_CLOSE_DELAY=-1",
+    "spring.datasource.username=sa",
+    "spring.datasource.password=",
+    "spring.datasource.driver-class-name=org.h2.Driver",
+    "spring.jpa.hibernate.ddl-auto=create",
+    "spring.jpa.show-sql=false"
+})
+class SummonerJpaRepositoryTest {
+
+  @Autowired
+  private SummonerJpaRepository repository;
+
+  @Test
+  void findRefreshTargetsPrefersRequestedTierThenUnknownTier() {
+    Summoner gold = repository.save(summoner("gold", Tier.GOLD, OffsetDateTime.now().minusHours(2), OffsetDateTime.now().minusHours(2)));
+    repository.save(summoner("unknown", null, null, OffsetDateTime.now().minusHours(3)));
+    repository.save(summoner("silver", Tier.SILVER, OffsetDateTime.now().minusHours(4), OffsetDateTime.now().minusHours(4)));
+
+    List<Summoner> targets = repository.findRefreshTargets(2, Tier.GOLD.name());
+
+    assertThat(targets).extracting(Summoner::getPuuid).containsExactly(gold.getPuuid(), "unknown");
+  }
+
+  @Test
+  void updateTierMetadataStoresObservedTier() {
+    repository.save(Summoner.create("p-1"));
+    OffsetDateTime observedAt = OffsetDateTime.now().minusMinutes(5);
+
+    repository.updateTierMetadata("p-1", Tier.MASTER.name(), observedAt);
+
+    Summoner updated = repository.findById("p-1").orElseThrow();
+    assertThat(updated.getLastKnownTier()).isEqualTo(Tier.MASTER);
+    assertThat(updated.getTierObservedAt()).isEqualTo(observedAt);
+  }
+
+  private Summoner summoner(String puuid, Tier tier, OffsetDateTime observedAt, OffsetDateTime updatedAt) {
+    OffsetDateTime createdAt = updatedAt != null ? updatedAt.minusHours(1) : OffsetDateTime.now().minusHours(1);
+    return Summoner.builder()
+        .puuid(puuid)
+        .lastMatchStartTime(null)
+        .lastKnownTier(tier)
+        .tierObservedAt(observedAt)
+        .lastSeenPatch(null)
+        .createdAt(createdAt)
+        .updatedAt(updatedAt != null ? updatedAt : OffsetDateTime.now())
+        .build();
+  }
+}

--- a/src/test/java/com/bestduo_BE/common/infra/riot/RiotApiConfigTest.java
+++ b/src/test/java/com/bestduo_BE/common/infra/riot/RiotApiConfigTest.java
@@ -21,8 +21,10 @@ class RiotApiConfigTest {
 
     RiotKeyPool keyPool = config.riotKeyPool(properties);
 
-    try (KeyLease first = keyPool.lease(); KeyLease second = keyPool.lease()) {
+    try (KeyLease first = keyPool.lease()) {
       assertThat(first.apiKey()).isEqualTo("single-key");
+    }
+    try (KeyLease second = keyPool.lease()) {
       assertThat(second.apiKey()).isEqualTo("single-key");
     }
   }
@@ -36,8 +38,10 @@ class RiotApiConfigTest {
 
     RiotKeyPool keyPool = config.riotKeyPool(properties);
 
-    try (KeyLease first = keyPool.lease(); KeyLease second = keyPool.lease()) {
+    try (KeyLease first = keyPool.lease()) {
       assertThat(first.apiKey()).isEqualTo("key-a");
+    }
+    try (KeyLease second = keyPool.lease()) {
       assertThat(second.apiKey()).isEqualTo("key-b");
     }
   }
@@ -51,8 +55,10 @@ class RiotApiConfigTest {
 
     RiotKeyPool keyPool = config.riotKeyPool(properties);
 
-    try (KeyLease first = keyPool.lease(); KeyLease second = keyPool.lease()) {
+    try (KeyLease first = keyPool.lease()) {
       assertThat(first.apiKey()).isEqualTo("single-key");
+    }
+    try (KeyLease second = keyPool.lease()) {
       assertThat(second.apiKey()).isEqualTo("single-key");
     }
   }

--- a/src/test/java/com/bestduo_BE/common/infra/riot/RiotApiConfigTest.java
+++ b/src/test/java/com/bestduo_BE/common/infra/riot/RiotApiConfigTest.java
@@ -1,0 +1,74 @@
+package com.bestduo_BE.common.infra.riot;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.bestduo_BE.config.RiotApiProperties;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.restclient.RestTemplateBuilder;
+import org.springframework.web.client.RestTemplate;
+
+class RiotApiConfigTest {
+
+  private final RiotApiConfig config = new RiotApiConfig();
+
+  @Test
+  void riotKeyPoolFallsBackToSingleKeyWhenMultiKeyDisabled() {
+    RiotApiProperties properties = new RiotApiProperties();
+    properties.setApiKey("single-key");
+    properties.setApiKeys(List.of("key-a", "key-b"));
+    properties.setMultiKeyEnabled(false);
+
+    RiotKeyPool keyPool = config.riotKeyPool(properties);
+
+    try (KeyLease first = keyPool.lease(); KeyLease second = keyPool.lease()) {
+      assertThat(first.apiKey()).isEqualTo("single-key");
+      assertThat(second.apiKey()).isEqualTo("single-key");
+    }
+  }
+
+  @Test
+  void riotKeyPoolUsesDistinctMultiKeysWhenEnabled() {
+    RiotApiProperties properties = new RiotApiProperties();
+    properties.setApiKey("single-key");
+    properties.setApiKeys(List.of("key-a", "key-a", "key-b"));
+    properties.setMultiKeyEnabled(true);
+
+    RiotKeyPool keyPool = config.riotKeyPool(properties);
+
+    try (KeyLease first = keyPool.lease(); KeyLease second = keyPool.lease()) {
+      assertThat(first.apiKey()).isEqualTo("key-a");
+      assertThat(second.apiKey()).isEqualTo("key-b");
+    }
+  }
+
+  @Test
+  void riotKeyPoolFallsBackToSingleKeyWhenMultiKeyListIsBlank() {
+    RiotApiProperties properties = new RiotApiProperties();
+    properties.setApiKey("single-key");
+    properties.setApiKeys(List.of(" ", ""));
+    properties.setMultiKeyEnabled(true);
+
+    RiotKeyPool keyPool = config.riotKeyPool(properties);
+
+    try (KeyLease first = keyPool.lease(); KeyLease second = keyPool.lease()) {
+      assertThat(first.apiKey()).isEqualTo("single-key");
+      assertThat(second.apiKey()).isEqualTo("single-key");
+    }
+  }
+
+  @Test
+  void restTemplateBeansAreStillCreatedWithExistingNames() {
+    RiotApiProperties properties = new RiotApiProperties();
+    properties.setPlatformBaseUrl("https://kr.api.riotgames.com");
+    properties.setRegionalBaseUrl("https://asia.api.riotgames.com");
+    properties.setApiKey("single-key");
+    RiotRateLimitInterceptor interceptor = new RiotRateLimitInterceptor(config.riotKeyPool(properties));
+
+    RestTemplate platform = config.riotPlatformRestTemplate(new RestTemplateBuilder(), interceptor, properties);
+    RestTemplate regional = config.riotRegionalRestTemplate(new RestTemplateBuilder(), interceptor, properties);
+
+    assertThat(platform).isNotNull();
+    assertThat(regional).isNotNull();
+  }
+}

--- a/src/test/java/com/bestduo_BE/common/infra/riot/RiotKeyPoolTest.java
+++ b/src/test/java/com/bestduo_BE/common/infra/riot/RiotKeyPoolTest.java
@@ -1,0 +1,74 @@
+package com.bestduo_BE.common.infra.riot;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class RiotKeyPoolTest {
+
+  @Test
+  void leaseRotatesAcrossAvailableKeys() {
+    Clock clock = Clock.fixed(Instant.parse("2026-03-30T00:00:00Z"), ZoneOffset.UTC);
+    RiotKeyPool keyPool = RiotKeyPool.fromKeys(List.of("key-a", "key-b"), clock);
+
+    try (KeyLease first = keyPool.lease(); KeyLease second = keyPool.lease()) {
+      assertThat(first.apiKey()).isEqualTo("key-a");
+      assertThat(second.apiKey()).isEqualTo("key-b");
+    }
+  }
+
+  @Test
+  void leaseSkipsRateLimitedKey() {
+    MutableClock clock = new MutableClock(Instant.parse("2026-03-30T00:00:00Z"));
+    RiotKeyState first = new RiotKeyState("key-a", new DualWindowRateLimiter(10, Duration.ofMillis(1), 60, Duration.ofMinutes(2)), clock);
+    RiotKeyState second = new RiotKeyState("key-b", new DualWindowRateLimiter(10, Duration.ofMillis(1), 60, Duration.ofMinutes(2)), clock);
+    RiotKeyPool keyPool = new RiotKeyPool(List.of(first, second));
+
+    first.markRateLimited(Duration.ofSeconds(30));
+
+    try (KeyLease lease = keyPool.lease()) {
+      assertThat(lease.apiKey()).isEqualTo("key-b");
+    }
+  }
+
+  @Test
+  void leaseFailsWhenAllKeysCoolingDown() {
+    MutableClock clock = new MutableClock(Instant.parse("2026-03-30T00:00:00Z"));
+    RiotKeyState first = new RiotKeyState("key-a", new DualWindowRateLimiter(10, Duration.ofMillis(1), 60, Duration.ofMinutes(2)), clock);
+    RiotKeyPool keyPool = new RiotKeyPool(List.of(first));
+    first.markRateLimited(Duration.ofSeconds(30));
+
+    assertThatThrownBy(keyPool::lease)
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("All Riot API keys are cooling down");
+  }
+
+  private static final class MutableClock extends Clock {
+    private Instant instant;
+
+    private MutableClock(Instant instant) {
+      this.instant = instant;
+    }
+
+    @Override
+    public ZoneOffset getZone() {
+      return ZoneOffset.UTC;
+    }
+
+    @Override
+    public Clock withZone(java.time.ZoneId zone) {
+      return this;
+    }
+
+    @Override
+    public Instant instant() {
+      return instant;
+    }
+  }
+}

--- a/src/test/java/com/bestduo_BE/common/infra/riot/RiotKeyPoolTest.java
+++ b/src/test/java/com/bestduo_BE/common/infra/riot/RiotKeyPoolTest.java
@@ -49,6 +49,21 @@ class RiotKeyPoolTest {
         .hasMessageContaining("All Riot API keys are cooling down");
   }
 
+  @Test
+  void longerCooldownIsNotShortenedByLaterShorterRetryAfter() {
+    MutableClock clock = new MutableClock(Instant.parse("2026-03-30T00:00:00Z"));
+    RiotKeyState state = new RiotKeyState("key-a", new DualWindowRateLimiter(10, Duration.ofMillis(1), 60, Duration.ofMinutes(2)), clock);
+
+    state.markRateLimited(Duration.ofSeconds(30));
+    clock.advance(Duration.ofSeconds(5));
+    state.markRateLimited(Duration.ofSeconds(1));
+    clock.advance(Duration.ofSeconds(20));
+
+    assertThat(state.isAvailable()).isFalse();
+    clock.advance(Duration.ofSeconds(5));
+    assertThat(state.isAvailable()).isTrue();
+  }
+
   private static final class MutableClock extends Clock {
     private Instant instant;
 
@@ -69,6 +84,10 @@ class RiotKeyPoolTest {
     @Override
     public Instant instant() {
       return instant;
+    }
+
+    private void advance(Duration duration) {
+      this.instant = this.instant.plus(duration);
     }
   }
 }

--- a/src/test/java/com/bestduo_BE/common/infra/riot/RiotKeyPoolTest.java
+++ b/src/test/java/com/bestduo_BE/common/infra/riot/RiotKeyPoolTest.java
@@ -64,6 +64,20 @@ class RiotKeyPoolTest {
     assertThat(state.isAvailable()).isTrue();
   }
 
+  @Test
+  void leaseForWorkerReleasesKeyOnClose() {
+    RiotKeyPool keyPool = RiotKeyPool.fromKeys(List.of("key-a"), Clock.systemUTC());
+
+    try (KeyLease ignored = keyPool.leaseForWorker()) {
+      assertThatThrownBy(keyPool::leaseForWorker)
+          .isInstanceOf(IllegalStateException.class);
+    }
+
+    try (KeyLease ignored = keyPool.leaseForWorker()) {
+      assertThat(ignored.apiKey()).isEqualTo("key-a");
+    }
+  }
+
   private static final class MutableClock extends Clock {
     private Instant instant;
 

--- a/src/test/java/com/bestduo_BE/common/infra/riot/RiotRateLimitInterceptorTest.java
+++ b/src/test/java/com/bestduo_BE/common/infra/riot/RiotRateLimitInterceptorTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -52,7 +53,11 @@ class RiotRateLimitInterceptorTest {
   @Test
   void throwsRiotRateLimitedExceptionOnTooManyRequests() throws Exception {
     ClientHttpRequestExecution execution = mock(ClientHttpRequestExecution.class);
-    MockClientHttpResponse tooMany = new MockClientHttpResponse(new byte[0], HttpStatus.TOO_MANY_REQUESTS);
+    ClientHttpResponse tooMany = mock(ClientHttpResponse.class);
+    var headers = new org.springframework.http.HttpHeaders();
+    headers.set("Retry-After", "10");
+    when(tooMany.getStatusCode()).thenReturn(HttpStatus.TOO_MANY_REQUESTS);
+    when(tooMany.getHeaders()).thenReturn(headers);
     tooMany.getHeaders().set("Retry-After", "10");
     when(keyPool.lease()).thenReturn(keyLease);
     when(keyLease.apiKey()).thenReturn("key-a");
@@ -65,5 +70,19 @@ class RiotRateLimitInterceptorTest {
 
     verify(keyLease).acquire();
     verify(keyLease).markRateLimited(Duration.ofSeconds(10));
+    verify(tooMany).close();
+  }
+
+  @Test
+  void doesNotMarkRateLimitedWhenRequestSucceeds() throws Exception {
+    ClientHttpRequestExecution execution = mock(ClientHttpRequestExecution.class);
+    ClientHttpResponse ok = new MockClientHttpResponse(new byte[0], HttpStatus.OK);
+    when(keyPool.lease()).thenReturn(keyLease);
+    when(keyLease.apiKey()).thenReturn("key-a");
+    when(execution.execute(any(), any())).thenReturn(ok);
+
+    interceptor.intercept(request, new byte[0], execution);
+
+    verify(keyLease, never()).markRateLimited(any());
   }
 }

--- a/src/test/java/com/bestduo_BE/common/infra/riot/RiotRateLimitInterceptorTest.java
+++ b/src/test/java/com/bestduo_BE/common/infra/riot/RiotRateLimitInterceptorTest.java
@@ -39,7 +39,7 @@ class RiotRateLimitInterceptorTest {
   void acquireCalledAndResponseReturnedWhenRequestSucceeds() throws Exception {
     ClientHttpRequestExecution execution = mock(ClientHttpRequestExecution.class);
     ClientHttpResponse ok = new MockClientHttpResponse(new byte[0], HttpStatus.OK);
-    when(keyPool.lease()).thenReturn(keyLease);
+    when(keyPool.leaseForRequest()).thenReturn(keyLease);
     when(keyLease.apiKey()).thenReturn("key-a");
     when(execution.execute(any(), any())).thenReturn(ok);
 
@@ -58,8 +58,7 @@ class RiotRateLimitInterceptorTest {
     headers.set("Retry-After", "10");
     when(tooMany.getStatusCode()).thenReturn(HttpStatus.TOO_MANY_REQUESTS);
     when(tooMany.getHeaders()).thenReturn(headers);
-    tooMany.getHeaders().set("Retry-After", "10");
-    when(keyPool.lease()).thenReturn(keyLease);
+    when(keyPool.leaseForRequest()).thenReturn(keyLease);
     when(keyLease.apiKey()).thenReturn("key-a");
     when(execution.execute(any(), any())).thenReturn(tooMany);
 
@@ -77,7 +76,7 @@ class RiotRateLimitInterceptorTest {
   void doesNotMarkRateLimitedWhenRequestSucceeds() throws Exception {
     ClientHttpRequestExecution execution = mock(ClientHttpRequestExecution.class);
     ClientHttpResponse ok = new MockClientHttpResponse(new byte[0], HttpStatus.OK);
-    when(keyPool.lease()).thenReturn(keyLease);
+    when(keyPool.leaseForRequest()).thenReturn(keyLease);
     when(keyLease.apiKey()).thenReturn("key-a");
     when(execution.execute(any(), any())).thenReturn(ok);
 

--- a/src/test/java/com/bestduo_BE/common/infra/riot/RiotRateLimitInterceptorTest.java
+++ b/src/test/java/com/bestduo_BE/common/infra/riot/RiotRateLimitInterceptorTest.java
@@ -7,10 +7,9 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.bestduo_BE.common.infra.riot.DualWindowRateLimiter;
-import com.bestduo_BE.common.infra.riot.RiotRateLimitInterceptor;
 import com.bestduo_BE.common.infra.riot.exception.RiotRateLimitedException;
 import java.net.URI;
+import java.time.Duration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
@@ -21,14 +20,16 @@ import org.springframework.mock.http.client.MockClientHttpResponse;
 
 class RiotRateLimitInterceptorTest {
 
-  private DualWindowRateLimiter rateLimiter;
+  private RiotKeyPool keyPool;
+  private KeyLease keyLease;
   private RiotRateLimitInterceptor interceptor;
   private MockClientHttpRequest request;
 
   @BeforeEach
   void setUp() {
-    rateLimiter = mock(DualWindowRateLimiter.class);
-    interceptor = new RiotRateLimitInterceptor(rateLimiter);
+    keyPool = mock(RiotKeyPool.class);
+    keyLease = mock(KeyLease.class);
+    interceptor = new RiotRateLimitInterceptor(keyPool);
     request = new MockClientHttpRequest();
     request.setURI(URI.create("https://riot.api/test"));
   }
@@ -37,12 +38,15 @@ class RiotRateLimitInterceptorTest {
   void acquireCalledAndResponseReturnedWhenRequestSucceeds() throws Exception {
     ClientHttpRequestExecution execution = mock(ClientHttpRequestExecution.class);
     ClientHttpResponse ok = new MockClientHttpResponse(new byte[0], HttpStatus.OK);
+    when(keyPool.lease()).thenReturn(keyLease);
+    when(keyLease.apiKey()).thenReturn("key-a");
     when(execution.execute(any(), any())).thenReturn(ok);
 
     ClientHttpResponse result = interceptor.intercept(request, new byte[0], execution);
 
     assertThat(result).isSameAs(ok);
-    verify(rateLimiter).acquire();
+    assertThat(request.getHeaders().getFirst("X-Riot-Token")).isEqualTo("key-a");
+    verify(keyLease).acquire();
   }
 
   @Test
@@ -50,6 +54,8 @@ class RiotRateLimitInterceptorTest {
     ClientHttpRequestExecution execution = mock(ClientHttpRequestExecution.class);
     MockClientHttpResponse tooMany = new MockClientHttpResponse(new byte[0], HttpStatus.TOO_MANY_REQUESTS);
     tooMany.getHeaders().set("Retry-After", "10");
+    when(keyPool.lease()).thenReturn(keyLease);
+    when(keyLease.apiKey()).thenReturn("key-a");
     when(execution.execute(any(), any())).thenReturn(tooMany);
 
     assertThatThrownBy(() -> interceptor.intercept(request, new byte[0], execution))
@@ -57,6 +63,7 @@ class RiotRateLimitInterceptorTest {
         .hasMessageContaining("retry-after=10")
         .hasMessageContaining("uri=" + request.getURI());
 
-    verify(rateLimiter).acquire();
+    verify(keyLease).acquire();
+    verify(keyLease).markRateLimited(Duration.ofSeconds(10));
   }
 }

--- a/src/test/java/com/bestduo_BE/config/RiotApiPropertiesTest.java
+++ b/src/test/java/com/bestduo_BE/config/RiotApiPropertiesTest.java
@@ -1,0 +1,29 @@
+package com.bestduo_BE.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class RiotApiPropertiesTest {
+
+  @Test
+  void resolvedApiKeysFallsBackToSingleKeyWhenMultiKeyDisabled() {
+    RiotApiProperties properties = new RiotApiProperties();
+    properties.setApiKey("single-key");
+    properties.setApiKeys(List.of("key-a", "key-b"));
+    properties.setMultiKeyEnabled(false);
+
+    assertThat(properties.resolvedApiKeys()).containsExactly("single-key");
+  }
+
+  @Test
+  void resolvedApiKeysUsesConfiguredMultiKeysWhenEnabled() {
+    RiotApiProperties properties = new RiotApiProperties();
+    properties.setApiKey("single-key");
+    properties.setApiKeys(List.of("key-a", "key-b"));
+    properties.setMultiKeyEnabled(true);
+
+    assertThat(properties.resolvedApiKeys()).containsExactly("key-a", "key-b");
+  }
+}

--- a/src/test/java/com/bestduo_BE/config/RiotApiPropertiesTest.java
+++ b/src/test/java/com/bestduo_BE/config/RiotApiPropertiesTest.java
@@ -26,4 +26,24 @@ class RiotApiPropertiesTest {
 
     assertThat(properties.resolvedApiKeys()).containsExactly("key-a", "key-b");
   }
+
+  @Test
+  void resolvedApiKeysTrimsAndDeduplicatesConfiguredKeys() {
+    RiotApiProperties properties = new RiotApiProperties();
+    properties.setApiKey("  single-key  ");
+    properties.setApiKeys(List.of(" key-a ", "key-a", " key-b "));
+    properties.setMultiKeyEnabled(true);
+
+    assertThat(properties.resolvedApiKeys()).containsExactly("key-a", "key-b");
+  }
+
+  @Test
+  void resolvedApiKeysTrimsSingleKeyFallback() {
+    RiotApiProperties properties = new RiotApiProperties();
+    properties.setApiKey("  single-key  ");
+    properties.setApiKeys(List.of(" ", ""));
+    properties.setMultiKeyEnabled(true);
+
+    assertThat(properties.resolvedApiKeys()).containsExactly("single-key");
+  }
 }

--- a/src/test/java/com/bestduo_BE/coverage/application/CoverageBucketServiceTest.java
+++ b/src/test/java/com/bestduo_BE/coverage/application/CoverageBucketServiceTest.java
@@ -1,0 +1,131 @@
+package com.bestduo_BE.coverage.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import com.bestduo_BE.common.domain.model.Tier;
+import com.bestduo_BE.coverage.application.exception.CoverageBucketAlreadyExistsException;
+import com.bestduo_BE.coverage.application.exception.CoverageBucketNotFoundException;
+import com.bestduo_BE.coverage.domain.model.CoverageBucketStatus;
+import com.bestduo_BE.coverage.infra.persistence.entity.CoverageBucket;
+import com.bestduo_BE.coverage.infra.persistence.repository.CoverageBucketCountJpaRepository;
+import com.bestduo_BE.coverage.infra.persistence.repository.CoverageBucketJpaRepository;
+import com.bestduo_BE.coverage.presentation.api.dto.CoverageBucketCreateRequest;
+import com.bestduo_BE.coverage.presentation.api.dto.CoverageBucketResponse;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
+
+@ExtendWith(MockitoExtension.class)
+class CoverageBucketServiceTest {
+
+  @Mock
+  private CoverageBucketJpaRepository coverageBucketRepository;
+
+  @Mock
+  private CoverageBucketCountJpaRepository coverageBucketCountRepository;
+
+  private CoverageBucketService service;
+
+  @BeforeEach
+  void setUp() {
+    service = new CoverageBucketService(coverageBucketRepository, coverageBucketCountRepository);
+  }
+
+  @Test
+  void createUsesCurrentCoverageCountAndDefaultPriority() {
+    CoverageBucketCreateRequest request = new CoverageBucketCreateRequest("15.7", Tier.MASTER, 20_000L, null);
+    given(coverageBucketRepository.existsByPatchAndTier("15.7", Tier.MASTER)).willReturn(false);
+    given(coverageBucketCountRepository.countDistinctMatches("15.7", "MASTER")).willReturn(3_400L);
+    given(coverageBucketRepository.save(org.mockito.ArgumentMatchers.any(CoverageBucket.class)))
+        .willAnswer(invocation -> invocation.getArgument(0));
+
+    CoverageBucketResponse response = service.create(request);
+
+    ArgumentCaptor<CoverageBucket> captor = ArgumentCaptor.forClass(CoverageBucket.class);
+    verify(coverageBucketRepository).save(captor.capture());
+    CoverageBucket saved = captor.getValue();
+    assertThat(saved.getPatch()).isEqualTo("15.7");
+    assertThat(saved.getTier()).isEqualTo(Tier.MASTER);
+    assertThat(saved.getTargetMatchCount()).isEqualTo(20_000L);
+    assertThat(saved.getCurrentMatchCount()).isEqualTo(3_400L);
+    assertThat(saved.getStatus()).isEqualTo(CoverageBucketStatus.COLLECTING);
+    assertThat(saved.getPriority()).isEqualTo(CoverageBucketService.DEFAULT_PRIORITY);
+
+    assertThat(response.patch()).isEqualTo("15.7");
+    assertThat(response.currentMatchCount()).isEqualTo(3_400L);
+    assertThat(response.deficitMatchCount()).isEqualTo(16_600L);
+    assertThat(response.status()).isEqualTo("COLLECTING");
+    assertThat(response.lastEvaluatedAt()).isNotNull();
+  }
+
+  @Test
+  void createRejectsDuplicatePatchTierBucket() {
+    CoverageBucketCreateRequest request = new CoverageBucketCreateRequest("15.7", Tier.MASTER, 20_000L, 1);
+    given(coverageBucketRepository.existsByPatchAndTier("15.7", Tier.MASTER)).willReturn(true);
+
+    assertThatThrownBy(() -> service.create(request))
+        .isInstanceOf(CoverageBucketAlreadyExistsException.class)
+        .hasMessageContaining("Coverage bucket already exists");
+  }
+
+  @Test
+  void createTranslatesUniqueConstraintViolationToConflictStyleException() {
+    CoverageBucketCreateRequest request = new CoverageBucketCreateRequest("15.7", Tier.MASTER, 20_000L, 1);
+    given(coverageBucketRepository.existsByPatchAndTier("15.7", Tier.MASTER)).willReturn(false);
+    given(coverageBucketCountRepository.countDistinctMatches("15.7", "MASTER")).willReturn(0L);
+    given(coverageBucketRepository.save(org.mockito.ArgumentMatchers.any(CoverageBucket.class)))
+        .willThrow(new DataIntegrityViolationException("duplicate key"));
+
+    assertThatThrownBy(() -> service.create(request))
+        .isInstanceOf(CoverageBucketAlreadyExistsException.class)
+        .hasMessageContaining("Coverage bucket already exists");
+  }
+
+  @Test
+  void getThrowsCoverageBucketNotFoundExceptionWhenMissing() {
+    given(coverageBucketRepository.findById(99L)).willReturn(Optional.empty());
+
+    assertThatThrownBy(() -> service.get(99L))
+        .isInstanceOf(CoverageBucketNotFoundException.class)
+        .hasMessageContaining("Coverage bucket not found");
+  }
+
+  @Test
+  void getReevaluatesCurrentCountAndMarksBucketSufficient() {
+    CoverageBucket bucket = CoverageBucket.create("15.7", Tier.MASTER, 2_000L, 5);
+    given(coverageBucketRepository.findById(7L)).willReturn(Optional.of(bucket));
+    given(coverageBucketCountRepository.countDistinctMatches("15.7", "MASTER")).willReturn(2_500L);
+
+    CoverageBucketResponse response = service.get(7L);
+
+    assertThat(response.currentMatchCount()).isEqualTo(2_500L);
+    assertThat(response.deficitMatchCount()).isZero();
+    assertThat(response.status()).isEqualTo("SUFFICIENT");
+  }
+
+  @Test
+  void getAllReturnsBucketsOrderedByPriorityAndId() {
+    CoverageBucket first = CoverageBucket.create("15.7", Tier.MASTER, 100L, 1);
+    CoverageBucket second = CoverageBucket.create("15.7", Tier.DIAMOND, 100L, 2);
+    given(coverageBucketRepository.findAllByOrderByPriorityAscIdAsc()).willReturn(List.of(first, second));
+    given(coverageBucketCountRepository.countDistinctMatches("15.7", "MASTER")).willReturn(10L);
+    given(coverageBucketCountRepository.countDistinctMatches("15.7", "DIAMOND")).willReturn(20L);
+
+    List<CoverageBucketResponse> responses = service.getAll();
+
+    assertThat(responses).hasSize(2);
+    assertThat(responses.get(0).tier()).isEqualTo(Tier.MASTER);
+    assertThat(responses.get(0).currentMatchCount()).isEqualTo(10L);
+    assertThat(responses.get(1).tier()).isEqualTo(Tier.DIAMOND);
+    assertThat(responses.get(1).currentMatchCount()).isEqualTo(20L);
+  }
+}

--- a/src/test/java/com/bestduo_BE/coverage/application/CoverageSchedulerTest.java
+++ b/src/test/java/com/bestduo_BE/coverage/application/CoverageSchedulerTest.java
@@ -1,0 +1,99 @@
+package com.bestduo_BE.coverage.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import com.bestduo_BE.common.domain.model.Tier;
+import com.bestduo_BE.common.infra.persistence.repository.IngestQueueStatsJpaRepository;
+import com.bestduo_BE.common.infra.persistence.repository.SummonerJpaRepository;
+import com.bestduo_BE.coverage.infra.persistence.entity.CoverageBucket;
+import com.bestduo_BE.coverage.infra.persistence.repository.CoverageBucketCountJpaRepository;
+import com.bestduo_BE.coverage.infra.persistence.repository.CoverageBucketJpaRepository;
+import com.bestduo_BE.workitem.domain.model.WorkItemStatus;
+import com.bestduo_BE.workitem.domain.model.WorkItemType;
+import com.bestduo_BE.workitem.infra.persistence.entity.WorkItem;
+import com.bestduo_BE.workitem.infra.persistence.repository.WorkItemJpaRepository;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class CoverageSchedulerTest {
+
+  @Mock private CoverageBucketJpaRepository coverageBucketJpaRepository;
+  @Mock private CoverageBucketCountJpaRepository coverageBucketCountJpaRepository;
+  @Mock private SummonerJpaRepository summonerJpaRepository;
+  @Mock private IngestQueueStatsJpaRepository ingestQueueStatsJpaRepository;
+  @Mock private WorkItemJpaRepository workItemJpaRepository;
+
+  private CoverageScheduler scheduler;
+
+  @BeforeEach
+  void setUp() {
+    scheduler = new CoverageScheduler(
+        coverageBucketJpaRepository,
+        coverageBucketCountJpaRepository,
+        summonerJpaRepository,
+        ingestQueueStatsJpaRepository,
+        workItemJpaRepository
+    );
+  }
+
+  @Test
+  void scheduleCreatesVerifyWorkItemWhenVerifiedPoolIsLow() {
+    CoverageBucket bucket = CoverageBucket.create("15.7", Tier.MASTER, 20000L, 1);
+    given(coverageBucketJpaRepository.findAllByOrderByPriorityAscIdAsc()).willReturn(List.of(bucket));
+    given(coverageBucketCountJpaRepository.countDistinctMatches("15.7", "MASTER")).willReturn(100L);
+    given(summonerJpaRepository.countByLastKnownTier(Tier.MASTER)).willReturn(3L);
+    given(workItemJpaRepository.existsByCoverageBucketIdAndTypeAndStatusIn(
+        bucket.getId(), WorkItemType.VERIFY_SUMMONERS, List.of(WorkItemStatus.READY, WorkItemStatus.RUNNING)
+    )).willReturn(false);
+    given(workItemJpaRepository.save(org.mockito.ArgumentMatchers.any(WorkItem.class)))
+        .willAnswer(invocation -> invocation.getArgument(0));
+
+    CoverageScheduler.ScheduleResult result = scheduler.schedule();
+
+    ArgumentCaptor<WorkItem> captor = ArgumentCaptor.forClass(WorkItem.class);
+    org.mockito.Mockito.verify(workItemJpaRepository).save(captor.capture());
+    assertThat(result.createdCount()).isEqualTo(1);
+    assertThat(captor.getValue().getType()).isEqualTo(WorkItemType.VERIFY_SUMMONERS);
+  }
+
+  @Test
+  void scheduleCreatesRefreshThenIngestThenSeedBasedOnBacklogSignals() {
+    CoverageBucket bucket = CoverageBucket.create("15.7", Tier.DIAMOND, 20000L, 1);
+    given(coverageBucketJpaRepository.findAllByOrderByPriorityAscIdAsc()).willReturn(List.of(bucket));
+    given(coverageBucketCountJpaRepository.countDistinctMatches("15.7", "DIAMOND")).willReturn(100L);
+    given(summonerJpaRepository.countByLastKnownTier(Tier.DIAMOND)).willReturn(100L);
+    given(ingestQueueStatsJpaRepository.countReadyByTier("DIAMOND")).willReturn(0L);
+    given(workItemJpaRepository.existsByCoverageBucketIdAndTypeAndStatusIn(
+        bucket.getId(), WorkItemType.REFRESH_SUMMONERS, List.of(WorkItemStatus.READY, WorkItemStatus.RUNNING)
+    )).willReturn(false);
+    given(workItemJpaRepository.save(org.mockito.ArgumentMatchers.any(WorkItem.class)))
+        .willAnswer(invocation -> invocation.getArgument(0));
+
+    CoverageScheduler.ScheduleResult result = scheduler.schedule();
+
+    assertThat(result.workItems()).singleElement().extracting(WorkItem::getType).isEqualTo(WorkItemType.REFRESH_SUMMONERS);
+  }
+
+  @Test
+  void scheduleSkipsWhenSamePendingWorkItemAlreadyExists() {
+    CoverageBucket bucket = CoverageBucket.create("15.7", Tier.MASTER, 20000L, 1);
+    given(coverageBucketJpaRepository.findAllByOrderByPriorityAscIdAsc()).willReturn(List.of(bucket));
+    given(coverageBucketCountJpaRepository.countDistinctMatches("15.7", "MASTER")).willReturn(100L);
+    given(summonerJpaRepository.countByLastKnownTier(Tier.MASTER)).willReturn(3L);
+    given(workItemJpaRepository.existsByCoverageBucketIdAndTypeAndStatusIn(
+        bucket.getId(), WorkItemType.VERIFY_SUMMONERS, List.of(WorkItemStatus.READY, WorkItemStatus.RUNNING)
+    )).willReturn(true);
+
+    CoverageScheduler.ScheduleResult result = scheduler.schedule();
+
+    assertThat(result.createdCount()).isZero();
+    org.mockito.Mockito.verify(workItemJpaRepository, org.mockito.Mockito.never()).save(org.mockito.ArgumentMatchers.any());
+  }
+}

--- a/src/test/java/com/bestduo_BE/coverage/application/CoverageSchedulerTest.java
+++ b/src/test/java/com/bestduo_BE/coverage/application/CoverageSchedulerTest.java
@@ -6,13 +6,14 @@ import static org.mockito.BDDMockito.given;
 import com.bestduo_BE.common.domain.model.Tier;
 import com.bestduo_BE.common.infra.persistence.repository.IngestQueueStatsJpaRepository;
 import com.bestduo_BE.common.infra.persistence.repository.SummonerJpaRepository;
+import com.bestduo_BE.config.WorkItemProperties;
 import com.bestduo_BE.coverage.infra.persistence.entity.CoverageBucket;
 import com.bestduo_BE.coverage.infra.persistence.repository.CoverageBucketCountJpaRepository;
 import com.bestduo_BE.coverage.infra.persistence.repository.CoverageBucketJpaRepository;
+import com.bestduo_BE.workitem.application.port.WorkItemDispatcher;
 import com.bestduo_BE.workitem.domain.model.WorkItemStatus;
 import com.bestduo_BE.workitem.domain.model.WorkItemType;
 import com.bestduo_BE.workitem.infra.persistence.entity.WorkItem;
-import com.bestduo_BE.workitem.infra.persistence.repository.WorkItemJpaRepository;
 import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -25,10 +26,10 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class CoverageSchedulerTest {
 
   @Mock private CoverageBucketJpaRepository coverageBucketJpaRepository;
-  @Mock private CoverageBucketCountJpaRepository coverageBucketCountJpaRepository;
+  @Mock private CoverageBucketCountJpaRepository coverageBucketCountRepository;
   @Mock private SummonerJpaRepository summonerJpaRepository;
   @Mock private IngestQueueStatsJpaRepository ingestQueueStatsJpaRepository;
-  @Mock private WorkItemJpaRepository workItemJpaRepository;
+  @Mock private WorkItemDispatcher workItemDispatcher;
 
   private CoverageScheduler scheduler;
 
@@ -36,44 +37,46 @@ class CoverageSchedulerTest {
   void setUp() {
     scheduler = new CoverageScheduler(
         coverageBucketJpaRepository,
-        coverageBucketCountJpaRepository,
+        coverageBucketCountRepository,
         summonerJpaRepository,
         ingestQueueStatsJpaRepository,
-        workItemJpaRepository
+        workItemDispatcher,
+        new WorkItemProperties()
     );
   }
 
   @Test
   void scheduleCreatesVerifyWorkItemWhenVerifiedPoolIsLow() {
-    CoverageBucket bucket = CoverageBucket.create("15.7", Tier.MASTER, 20000L, 1);
+    CoverageBucket bucket = CoverageBucket.create("15.7", Tier.MASTER, 20_000L, 1);
     given(coverageBucketJpaRepository.findAllByOrderByPriorityAscIdAsc()).willReturn(List.of(bucket));
-    given(coverageBucketCountJpaRepository.countDistinctMatches("15.7", "MASTER")).willReturn(100L);
+    given(coverageBucketCountRepository.countDistinctMatches("15.7", "MASTER")).willReturn(100L);
     given(summonerJpaRepository.countByLastKnownTier(Tier.MASTER)).willReturn(3L);
-    given(workItemJpaRepository.existsByCoverageBucketIdAndTypeAndStatusIn(
-        bucket.getId(), WorkItemType.VERIFY_SUMMONERS, List.of(WorkItemStatus.READY, WorkItemStatus.RUNNING)
-    )).willReturn(false);
-    given(workItemJpaRepository.save(org.mockito.ArgumentMatchers.any(WorkItem.class)))
+    given(workItemDispatcher.countByTypePatchTierStatuses(WorkItemType.VERIFY_SUMMONERS, "15.7", Tier.MASTER,
+        List.of(WorkItemStatus.PENDING, WorkItemStatus.RUNNING)))
+        .willReturn(0L);
+    given(workItemDispatcher.emit(org.mockito.ArgumentMatchers.any(WorkItem.class)))
         .willAnswer(invocation -> invocation.getArgument(0));
 
     CoverageScheduler.ScheduleResult result = scheduler.schedule();
 
     ArgumentCaptor<WorkItem> captor = ArgumentCaptor.forClass(WorkItem.class);
-    org.mockito.Mockito.verify(workItemJpaRepository).save(captor.capture());
+    org.mockito.Mockito.verify(workItemDispatcher).emit(captor.capture());
     assertThat(result.createdCount()).isEqualTo(1);
     assertThat(captor.getValue().getType()).isEqualTo(WorkItemType.VERIFY_SUMMONERS);
+    assertThat(captor.getValue().getStatus()).isEqualTo(WorkItemStatus.PENDING);
   }
 
   @Test
-  void scheduleCreatesRefreshThenIngestThenSeedBasedOnBacklogSignals() {
-    CoverageBucket bucket = CoverageBucket.create("15.7", Tier.DIAMOND, 20000L, 1);
+  void scheduleCreatesRefreshWhenReadyQueueIsLow() {
+    CoverageBucket bucket = CoverageBucket.create("15.7", Tier.DIAMOND, 20_000L, 1);
     given(coverageBucketJpaRepository.findAllByOrderByPriorityAscIdAsc()).willReturn(List.of(bucket));
-    given(coverageBucketCountJpaRepository.countDistinctMatches("15.7", "DIAMOND")).willReturn(100L);
+    given(coverageBucketCountRepository.countDistinctMatches("15.7", "DIAMOND")).willReturn(100L);
     given(summonerJpaRepository.countByLastKnownTier(Tier.DIAMOND)).willReturn(100L);
     given(ingestQueueStatsJpaRepository.countReadyByTier("DIAMOND")).willReturn(0L);
-    given(workItemJpaRepository.existsByCoverageBucketIdAndTypeAndStatusIn(
-        bucket.getId(), WorkItemType.REFRESH_SUMMONERS, List.of(WorkItemStatus.READY, WorkItemStatus.RUNNING)
-    )).willReturn(false);
-    given(workItemJpaRepository.save(org.mockito.ArgumentMatchers.any(WorkItem.class)))
+    given(workItemDispatcher.countByTypePatchTierStatuses(WorkItemType.REFRESH_SUMMONERS, "15.7", Tier.DIAMOND,
+        List.of(WorkItemStatus.PENDING, WorkItemStatus.RUNNING)))
+        .willReturn(0L);
+    given(workItemDispatcher.emit(org.mockito.ArgumentMatchers.any(WorkItem.class)))
         .willAnswer(invocation -> invocation.getArgument(0));
 
     CoverageScheduler.ScheduleResult result = scheduler.schedule();
@@ -83,17 +86,32 @@ class CoverageSchedulerTest {
 
   @Test
   void scheduleSkipsWhenSamePendingWorkItemAlreadyExists() {
-    CoverageBucket bucket = CoverageBucket.create("15.7", Tier.MASTER, 20000L, 1);
+    CoverageBucket bucket = CoverageBucket.create("15.7", Tier.MASTER, 20_000L, 1);
     given(coverageBucketJpaRepository.findAllByOrderByPriorityAscIdAsc()).willReturn(List.of(bucket));
-    given(coverageBucketCountJpaRepository.countDistinctMatches("15.7", "MASTER")).willReturn(100L);
+    given(coverageBucketCountRepository.countDistinctMatches("15.7", "MASTER")).willReturn(100L);
     given(summonerJpaRepository.countByLastKnownTier(Tier.MASTER)).willReturn(3L);
-    given(workItemJpaRepository.existsByCoverageBucketIdAndTypeAndStatusIn(
-        bucket.getId(), WorkItemType.VERIFY_SUMMONERS, List.of(WorkItemStatus.READY, WorkItemStatus.RUNNING)
-    )).willReturn(true);
+    given(workItemDispatcher.countByTypePatchTierStatuses(WorkItemType.VERIFY_SUMMONERS, "15.7", Tier.MASTER,
+        List.of(WorkItemStatus.PENDING, WorkItemStatus.RUNNING)))
+        .willReturn(1L);
 
     CoverageScheduler.ScheduleResult result = scheduler.schedule();
 
     assertThat(result.createdCount()).isZero();
-    org.mockito.Mockito.verify(workItemJpaRepository, org.mockito.Mockito.never()).save(org.mockito.ArgumentMatchers.any());
+    org.mockito.Mockito.verify(workItemDispatcher, org.mockito.Mockito.never()).emit(org.mockito.ArgumentMatchers.any());
+  }
+
+  @Test
+  void scheduleSkipsWhenSameRunningWorkItemAlreadyExists() {
+    CoverageBucket bucket = CoverageBucket.create("15.7", Tier.MASTER, 20_000L, 1);
+    given(coverageBucketJpaRepository.findAllByOrderByPriorityAscIdAsc()).willReturn(List.of(bucket));
+    given(coverageBucketCountRepository.countDistinctMatches("15.7", "MASTER")).willReturn(100L);
+    given(summonerJpaRepository.countByLastKnownTier(Tier.MASTER)).willReturn(3L);
+    given(workItemDispatcher.countByTypePatchTierStatuses(WorkItemType.VERIFY_SUMMONERS, "15.7", Tier.MASTER,
+        List.of(WorkItemStatus.PENDING, WorkItemStatus.RUNNING))).willReturn(1L);
+
+    CoverageScheduler.ScheduleResult result = scheduler.schedule();
+
+    assertThat(result.createdCount()).isZero();
+    org.mockito.Mockito.verify(workItemDispatcher, org.mockito.Mockito.never()).emit(org.mockito.ArgumentMatchers.any());
   }
 }

--- a/src/test/java/com/bestduo_BE/coverage/infra/persistence/repository/CoverageBucketCountJpaRepositoryTest.java
+++ b/src/test/java/com/bestduo_BE/coverage/infra/persistence/repository/CoverageBucketCountJpaRepositoryTest.java
@@ -1,0 +1,49 @@
+package com.bestduo_BE.coverage.infra.persistence.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.bestduo_BE.common.domain.model.BottomDuoRaw;
+import com.bestduo_BE.common.domain.model.Tier;
+import com.bestduo_BE.common.infra.persistence.entity.BottomDuoRawEntity;
+import com.bestduo_BE.common.infra.persistence.repository.BottomDuoRawJpaRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.test.context.TestPropertySource;
+
+@DataJpaTest
+@TestPropertySource(properties = {
+    "spring.datasource.url=jdbc:h2:mem:coverage;MODE=PostgreSQL;DB_CLOSE_DELAY=-1",
+    "spring.datasource.username=sa",
+    "spring.datasource.password=",
+    "spring.datasource.driver-class-name=org.h2.Driver",
+    "spring.jpa.hibernate.ddl-auto=create",
+    "spring.jpa.show-sql=false",
+    "spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect"
+})
+class CoverageBucketCountJpaRepositoryTest {
+
+  @Autowired
+  private BottomDuoRawJpaRepository bottomDuoRawRepository;
+
+  @Autowired
+  private CoverageBucketCountJpaRepository coverageBucketCountRepository;
+
+  @AfterEach
+  void cleanUp() {
+    bottomDuoRawRepository.deleteAll();
+  }
+
+  @Test
+  void countDistinctMatchesCountsOneMatchForTwoTeamRowsAndFiltersByPatchAndTier() {
+    bottomDuoRawRepository.save(BottomDuoRawEntity.fromDomain(new BottomDuoRaw("KR_1", 100, 1, 2, true, "15.7", Tier.MASTER)));
+    bottomDuoRawRepository.save(BottomDuoRawEntity.fromDomain(new BottomDuoRaw("KR_1", 200, 3, 4, false, "15.7", Tier.MASTER)));
+    bottomDuoRawRepository.save(BottomDuoRawEntity.fromDomain(new BottomDuoRaw("KR_2", 100, 5, 6, true, "15.6", Tier.MASTER)));
+    bottomDuoRawRepository.save(BottomDuoRawEntity.fromDomain(new BottomDuoRaw("KR_3", 100, 7, 8, true, "15.7", Tier.DIAMOND)));
+
+    long count = coverageBucketCountRepository.countDistinctMatches("15.7", "MASTER");
+
+    assertThat(count).isEqualTo(1L);
+  }
+}

--- a/src/test/java/com/bestduo_BE/coverage/presentation/api/AdminCoverageControllerTest.java
+++ b/src/test/java/com/bestduo_BE/coverage/presentation/api/AdminCoverageControllerTest.java
@@ -1,0 +1,108 @@
+package com.bestduo_BE.coverage.presentation.api;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.bestduo_BE.common.domain.model.Tier;
+import com.bestduo_BE.coverage.application.CoverageBucketService;
+import com.bestduo_BE.coverage.application.exception.CoverageBucketAlreadyExistsException;
+import com.bestduo_BE.coverage.application.exception.CoverageBucketNotFoundException;
+import com.bestduo_BE.coverage.presentation.api.dto.CoverageBucketResponse;
+import java.time.OffsetDateTime;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(AdminCoverageController.class)
+class AdminCoverageControllerTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @MockitoBean
+  private CoverageBucketService coverageBucketService;
+
+  @Test
+  void createDelegatesToServiceAndReturnsCreatedBucket() throws Exception {
+    CoverageBucketResponse response = new CoverageBucketResponse(
+        1L,
+        "15.7",
+        Tier.MASTER,
+        20_000L,
+        3_400L,
+        16_600L,
+        "COLLECTING",
+        7,
+        OffsetDateTime.parse("2026-03-30T10:15:30+09:00")
+    );
+    given(coverageBucketService.create(any())).willReturn(response);
+
+    mockMvc.perform(post("/admin/coverage")
+            .param("patch", "15.7")
+            .param("tier", "MASTER")
+            .param("targetMatchCount", "20000")
+            .param("priority", "7"))
+        .andExpect(status().isCreated())
+        .andExpect(jsonPath("$.patch").value("15.7"))
+        .andExpect(jsonPath("$.tier").value("MASTER"))
+        .andExpect(jsonPath("$.currentMatchCount").value(3400))
+        .andExpect(jsonPath("$.deficitMatchCount").value(16600))
+        .andExpect(jsonPath("$.status").value("COLLECTING"));
+
+    then(coverageBucketService).should().create(any());
+  }
+
+  @Test
+  void createReturnsConflictWhenDuplicateBucketExists() throws Exception {
+    given(coverageBucketService.create(any())).willThrow(new CoverageBucketAlreadyExistsException("15.7", "MASTER"));
+
+    mockMvc.perform(post("/admin/coverage")
+            .param("patch", "15.7")
+            .param("tier", "MASTER")
+            .param("targetMatchCount", "20000"))
+        .andExpect(status().isConflict());
+  }
+
+  @Test
+  void getAllReturnsBuckets() throws Exception {
+    given(coverageBucketService.getAll()).willReturn(List.of(
+        new CoverageBucketResponse(1L, "15.7", Tier.MASTER, 20_000L, 3_400L, 16_600L, "COLLECTING", 1,
+            OffsetDateTime.parse("2026-03-30T10:15:30+09:00"))
+    ));
+
+    mockMvc.perform(get("/admin/coverage"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$[0].tier").value("MASTER"))
+        .andExpect(jsonPath("$[0].currentMatchCount").value(3400));
+  }
+
+  @Test
+  void getReturnsBucket() throws Exception {
+    given(coverageBucketService.get(1L)).willReturn(
+        new CoverageBucketResponse(1L, "15.7", Tier.MASTER, 20_000L, 3_400L, 16_600L, "COLLECTING", 1,
+            OffsetDateTime.parse("2026-03-30T10:15:30+09:00"))
+    );
+
+    mockMvc.perform(get("/admin/coverage/1"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.id").value(1))
+        .andExpect(jsonPath("$.tier").value("MASTER"))
+        .andExpect(jsonPath("$.deficitMatchCount").value(16600));
+  }
+
+  @Test
+  void getReturnsNotFoundWhenBucketIsMissing() throws Exception {
+    given(coverageBucketService.get(99L)).willThrow(new CoverageBucketNotFoundException(99L));
+
+    mockMvc.perform(get("/admin/coverage/99"))
+        .andExpect(status().isNotFound());
+  }
+}

--- a/src/test/java/com/bestduo_BE/refresh/application/RefreshBatchExecutorTest.java
+++ b/src/test/java/com/bestduo_BE/refresh/application/RefreshBatchExecutorTest.java
@@ -34,7 +34,7 @@ class RefreshBatchExecutorTest {
   @Test
   void aggregateSuccessAndFailureCounts() {
     List<Summoner> targets = List.of(summoner("p1"), summoner("p2"), summoner("p3"));
-    given(summonerJpaRepository.findRefreshTargets(3)).willReturn(targets);
+    given(summonerJpaRepository.findRefreshTargets(3, Tier.GOLD.name())).willReturn(targets);
     given(refreshSummonerMatches.execute("p1", Tier.GOLD))
         .willReturn(new RefreshSummonerMatches.Result("p1", 2, Tier.GOLD, 1L));
     given(refreshSummonerMatches.execute("p2", Tier.GOLD))
@@ -44,7 +44,7 @@ class RefreshBatchExecutorTest {
 
     RefreshBatchExecutor.Result result = useCase.execute(3, Tier.GOLD);
 
-    verify(summonerJpaRepository).findRefreshTargets(3);
+    verify(summonerJpaRepository).findRefreshTargets(3, Tier.GOLD.name());
     assertThat(result.processed()).isEqualTo(3);
     assertThat(result.success()).isEqualTo(2);
     assertThat(result.failed()).isEqualTo(1);
@@ -53,7 +53,7 @@ class RefreshBatchExecutorTest {
 
   @Test
   void returnZerosWhenNoTargetsFound() {
-    given(summonerJpaRepository.findRefreshTargets(5)).willReturn(List.of());
+    given(summonerJpaRepository.findRefreshTargets(5, Tier.ALL_TIERS.name())).willReturn(List.of());
 
     RefreshBatchExecutor.Result result = useCase.execute(5, Tier.ALL_TIERS);
 
@@ -65,7 +65,7 @@ class RefreshBatchExecutorTest {
 
   @Test
   void defaultExecuteUsesAllTiers() {
-    given(summonerJpaRepository.findRefreshTargets(1)).willReturn(List.of(summoner("p1")));
+    given(summonerJpaRepository.findRefreshTargets(1, Tier.ALL_TIERS.name())).willReturn(List.of(summoner("p1")));
     given(refreshSummonerMatches.execute("p1", Tier.ALL_TIERS))
         .willReturn(new RefreshSummonerMatches.Result("p1", 1, Tier.GOLD, 1L));
 
@@ -77,13 +77,13 @@ class RefreshBatchExecutorTest {
 
   @Test
   void stillForwardsRequestedTierToRefreshWorker() {
-    given(summonerJpaRepository.findRefreshTargets(2)).willReturn(List.of(summoner("p1")));
+    given(summonerJpaRepository.findRefreshTargets(2, Tier.EMERALD.name())).willReturn(List.of(summoner("p1")));
     given(refreshSummonerMatches.execute("p1", Tier.EMERALD))
         .willReturn(new RefreshSummonerMatches.Result("p1", 1, Tier.EMERALD, 1L));
 
     RefreshBatchExecutor.Result result = useCase.execute(2, Tier.EMERALD);
 
-    verify(summonerJpaRepository).findRefreshTargets(2);
+    verify(summonerJpaRepository).findRefreshTargets(2, Tier.EMERALD.name());
     verify(refreshSummonerMatches).execute("p1", Tier.EMERALD);
     assertThat(result.success()).isEqualTo(1);
   }

--- a/src/test/java/com/bestduo_BE/refresh/application/RefreshSummonerMatchesTest.java
+++ b/src/test/java/com/bestduo_BE/refresh/application/RefreshSummonerMatchesTest.java
@@ -77,6 +77,7 @@ class RefreshSummonerMatchesTest {
     RefreshSummonerMatches.Result result = useCase.execute("p-new", Tier.EMERALD);
     long after = Instant.now().getEpochSecond();
 
+    verify(summonerRefreshStatusUpdater).syncResolvedTier(org.mockito.ArgumentMatchers.eq("p-new"), org.mockito.ArgumentMatchers.eq(Tier.EMERALD), org.mockito.ArgumentMatchers.any(OffsetDateTime.class));
     verify(matchQueueEnqueuer).enqueueAllIdempotent(List.of("m-1", "m-2"), Tier.EMERALD, 10);
     assertThat(result.matchIdsEnqueued()).isEqualTo(2);
     assertThat(result.collectionTier()).isEqualTo(Tier.EMERALD);
@@ -125,6 +126,7 @@ class RefreshSummonerMatchesTest {
 
     RefreshSummonerMatches.Result result = useCase.execute("p-miss", Tier.GOLD);
 
+    verify(summonerRefreshStatusUpdater).syncResolvedTier(org.mockito.ArgumentMatchers.eq("p-miss"), org.mockito.ArgumentMatchers.eq(Tier.EMERALD), org.mockito.ArgumentMatchers.any(OffsetDateTime.class));
     verify(summonerRefreshStatusUpdater).syncRefreshCursor("p-miss", 777L);
     verifyNoInteractions(matchIdsFinder, matchQueueEnqueuer);
     assertThat(result.matchIdsEnqueued()).isZero();

--- a/src/test/java/com/bestduo_BE/workitem/application/WorkItemPollerTest.java
+++ b/src/test/java/com/bestduo_BE/workitem/application/WorkItemPollerTest.java
@@ -5,10 +5,11 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
 import com.bestduo_BE.common.domain.model.Tier;
+import com.bestduo_BE.workitem.domain.model.WorkItemStatus;
 import com.bestduo_BE.workitem.domain.model.WorkItemType;
 import com.bestduo_BE.workitem.infra.persistence.entity.WorkItem;
 import com.bestduo_BE.workitem.infra.persistence.repository.WorkItemJpaRepository;
-import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -31,12 +32,12 @@ class WorkItemPollerTest {
   @Test
   void pollOncePicksReadyWorkItemAndDelegatesToWorker() {
     WorkItem item = WorkItem.ready(1L, "15.7", Tier.MASTER, WorkItemType.VERIFY_SUMMONERS, 1, 10);
-    given(workItemJpaRepository.findAll()).willReturn(List.of(item));
-    given(workItemWorker.execute(item.getId())).willReturn(new WorkItemWorker.WorkerResult(item.getId(), item.getType(), "DONE"));
+    given(workItemJpaRepository.findFirstByStatusOrderByPriorityAscCreatedAtAsc(WorkItemStatus.READY)).willReturn(Optional.of(item));
+    given(workItemWorker.execute(item.getId())).willReturn(new WorkItemWorker.WorkerResult(item.getId(), item.getType(), WorkItemStatus.DONE));
 
     WorkItemWorker.WorkerResult result = poller.pollOnce();
 
     verify(workItemWorker).execute(item.getId());
-    assertThat(result.status()).isEqualTo("DONE");
+    assertThat(result.status()).isEqualTo(WorkItemStatus.DONE);
   }
 }

--- a/src/test/java/com/bestduo_BE/workitem/application/WorkItemPollerTest.java
+++ b/src/test/java/com/bestduo_BE/workitem/application/WorkItemPollerTest.java
@@ -1,0 +1,42 @@
+package com.bestduo_BE.workitem.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import com.bestduo_BE.common.domain.model.Tier;
+import com.bestduo_BE.workitem.domain.model.WorkItemType;
+import com.bestduo_BE.workitem.infra.persistence.entity.WorkItem;
+import com.bestduo_BE.workitem.infra.persistence.repository.WorkItemJpaRepository;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class WorkItemPollerTest {
+
+  @Mock private WorkItemJpaRepository workItemJpaRepository;
+  @Mock private WorkItemWorker workItemWorker;
+
+  private WorkItemPoller poller;
+
+  @BeforeEach
+  void setUp() {
+    poller = new WorkItemPoller(workItemJpaRepository, workItemWorker);
+  }
+
+  @Test
+  void pollOncePicksReadyWorkItemAndDelegatesToWorker() {
+    WorkItem item = WorkItem.ready(1L, "15.7", Tier.MASTER, WorkItemType.VERIFY_SUMMONERS, 1, 10);
+    given(workItemJpaRepository.findAll()).willReturn(List.of(item));
+    given(workItemWorker.execute(item.getId())).willReturn(new WorkItemWorker.WorkerResult(item.getId(), item.getType(), "DONE"));
+
+    WorkItemWorker.WorkerResult result = poller.pollOnce();
+
+    verify(workItemWorker).execute(item.getId());
+    assertThat(result.status()).isEqualTo("DONE");
+  }
+}

--- a/src/test/java/com/bestduo_BE/workitem/application/WorkItemPollerTest.java
+++ b/src/test/java/com/bestduo_BE/workitem/application/WorkItemPollerTest.java
@@ -5,11 +5,11 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
 import com.bestduo_BE.common.domain.model.Tier;
+import com.bestduo_BE.workitem.application.port.WorkItemDispatcher;
 import com.bestduo_BE.workitem.domain.model.WorkItemStatus;
 import com.bestduo_BE.workitem.domain.model.WorkItemType;
 import com.bestduo_BE.workitem.infra.persistence.entity.WorkItem;
-import com.bestduo_BE.workitem.infra.persistence.repository.WorkItemJpaRepository;
-import java.util.Optional;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -19,25 +19,26 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class WorkItemPollerTest {
 
-  @Mock private WorkItemJpaRepository workItemJpaRepository;
+  @Mock private WorkItemDispatcher workItemDispatcher;
   @Mock private WorkItemWorker workItemWorker;
 
   private WorkItemPoller poller;
 
   @BeforeEach
   void setUp() {
-    poller = new WorkItemPoller(workItemJpaRepository, workItemWorker);
+    poller = new WorkItemPoller(workItemDispatcher, workItemWorker);
   }
 
   @Test
-  void pollOncePicksReadyWorkItemAndDelegatesToWorker() {
-    WorkItem item = WorkItem.ready(1L, "15.7", Tier.MASTER, WorkItemType.VERIFY_SUMMONERS, 1, 10);
-    given(workItemJpaRepository.findFirstByStatusOrderByPriorityAscCreatedAtAsc(WorkItemStatus.READY)).willReturn(Optional.of(item));
-    given(workItemWorker.execute(item.getId())).willReturn(new WorkItemWorker.WorkerResult(item.getId(), item.getType(), WorkItemStatus.DONE));
+  void pollOncePicksPendingWorkItemAndDelegatesToWorker() {
+    WorkItem item = WorkItem.pending(1L, "15.7", Tier.MASTER, WorkItemType.VERIFY_SUMMONERS, 1, 10, null);
+    item.markRunning();
+    given(workItemDispatcher.pickAndLock(1)).willReturn(List.of(item));
+    given(workItemWorker.execute(item)).willReturn(new WorkItemWorker.WorkerResult(item.getId(), item.getType(), WorkItemStatus.DONE));
 
     WorkItemWorker.WorkerResult result = poller.pollOnce();
 
-    verify(workItemWorker).execute(item.getId());
+    verify(workItemWorker).execute(item);
     assertThat(result.status()).isEqualTo(WorkItemStatus.DONE);
   }
 }

--- a/src/test/java/com/bestduo_BE/workitem/application/WorkItemWorkerTest.java
+++ b/src/test/java/com/bestduo_BE/workitem/application/WorkItemWorkerTest.java
@@ -1,0 +1,63 @@
+package com.bestduo_BE.workitem.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import com.bestduo_BE.common.domain.model.Tier;
+import com.bestduo_BE.common.infra.riot.KeyLease;
+import com.bestduo_BE.common.infra.riot.RiotKeyPool;
+import com.bestduo_BE.coverage.infra.persistence.repository.CoverageBucketJpaRepository;
+import com.bestduo_BE.ingest.application.MatchIngestWorker;
+import com.bestduo_BE.refresh.application.RefreshBatchExecutor;
+import com.bestduo_BE.seed.application.SeedBootstrapExecutor;
+import com.bestduo_BE.workitem.domain.model.WorkItemType;
+import com.bestduo_BE.workitem.infra.persistence.entity.WorkItem;
+import com.bestduo_BE.workitem.infra.persistence.repository.WorkItemJpaRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class WorkItemWorkerTest {
+
+  @Mock private WorkItemJpaRepository workItemJpaRepository;
+  @Mock private CoverageBucketJpaRepository coverageBucketJpaRepository;
+  @Mock private SeedBootstrapExecutor seedBootstrapExecutor;
+  @Mock private RefreshBatchExecutor refreshBatchExecutor;
+  @Mock private MatchIngestWorker matchIngestWorker;
+  @Mock private RiotKeyPool riotKeyPool;
+  @Mock private KeyLease keyLease;
+
+  private WorkItemWorker worker;
+
+  @BeforeEach
+  void setUp() {
+    worker = new WorkItemWorker(
+        workItemJpaRepository,
+        coverageBucketJpaRepository,
+        seedBootstrapExecutor,
+        refreshBatchExecutor,
+        matchIngestWorker,
+        riotKeyPool
+    );
+  }
+
+  @Test
+  void executeRefreshWorkItemUsesWorkerLeaseAndMarksDone() {
+    WorkItem item = WorkItem.ready(1L, "15.7", Tier.MASTER, WorkItemType.REFRESH_SUMMONERS, 1, 10);
+    given(workItemJpaRepository.findById(1L)).willReturn(Optional.of(item));
+    given(riotKeyPool.leaseForWorker()).willReturn(keyLease);
+    given(refreshBatchExecutor.execute(10, Tier.MASTER)).willReturn(new RefreshBatchExecutor.Result(1, 1, 0, 3));
+
+    WorkItemWorker.WorkerResult result = worker.execute(1L);
+
+    verify(refreshBatchExecutor).execute(10, Tier.MASTER);
+    verify(riotKeyPool).clearWorkerLease();
+    assertThat(result.status()).isEqualTo("DONE");
+    assertThat(item.getStatus().name()).isEqualTo("DONE");
+  }
+}

--- a/src/test/java/com/bestduo_BE/workitem/application/WorkItemWorkerTest.java
+++ b/src/test/java/com/bestduo_BE/workitem/application/WorkItemWorkerTest.java
@@ -7,14 +7,12 @@ import static org.mockito.Mockito.verify;
 import com.bestduo_BE.common.domain.model.Tier;
 import com.bestduo_BE.common.infra.riot.KeyLease;
 import com.bestduo_BE.common.infra.riot.RiotKeyPool;
-import com.bestduo_BE.ingest.application.MatchIngestWorker;
-import com.bestduo_BE.refresh.application.RefreshBatchExecutor;
-import com.bestduo_BE.seed.application.SeedBootstrapExecutor;
+import com.bestduo_BE.workitem.application.port.WorkItemDispatcher;
+import com.bestduo_BE.workitem.application.worker.WorkerContract;
 import com.bestduo_BE.workitem.domain.model.WorkItemStatus;
 import com.bestduo_BE.workitem.domain.model.WorkItemType;
 import com.bestduo_BE.workitem.infra.persistence.entity.WorkItem;
-import com.bestduo_BE.workitem.infra.persistence.repository.WorkItemJpaRepository;
-import java.util.Optional;
+import java.util.List;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -24,38 +22,29 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class WorkItemWorkerTest {
 
-  @Mock private WorkItemJpaRepository workItemJpaRepository;
-  @Mock private SeedBootstrapExecutor seedBootstrapExecutor;
-  @Mock private RefreshBatchExecutor refreshBatchExecutor;
-  @Mock private MatchIngestWorker matchIngestWorker;
+  @Mock private WorkItemDispatcher workItemDispatcher;
   @Mock private RiotKeyPool riotKeyPool;
   @Mock private KeyLease keyLease;
+  @Mock private WorkerContract workerContract;
 
   private WorkItemWorker worker;
 
   @BeforeEach
   void setUp() {
-    worker = new WorkItemWorker(
-        workItemJpaRepository,
-        seedBootstrapExecutor,
-        refreshBatchExecutor,
-        matchIngestWorker,
-        riotKeyPool
-    );
+    given(workerContract.type()).willReturn(WorkItemType.REFRESH_SUMMONERS);
+    worker = new WorkItemWorker(workItemDispatcher, riotKeyPool, List.of(workerContract));
   }
 
   @Test
   void executeRefreshWorkItemUsesWorkerLeaseAndMarksDone() {
-    WorkItem item = WorkItem.ready(1L, "15.7", Tier.MASTER, WorkItemType.REFRESH_SUMMONERS, 1, 10);
-    given(workItemJpaRepository.findById(1L)).willReturn(Optional.of(item));
+    WorkItem item = WorkItem.pending(1L, "15.7", Tier.MASTER, WorkItemType.REFRESH_SUMMONERS, 1, 10, null);
     given(riotKeyPool.leaseForWorker()).willReturn(keyLease);
-    given(refreshBatchExecutor.execute(10, Tier.MASTER)).willReturn(new RefreshBatchExecutor.Result(1, 1, 0, 3));
 
-    WorkItemWorker.WorkerResult result = worker.execute(1L);
+    WorkItemWorker.WorkerResult result = worker.execute(item);
 
-    verify(refreshBatchExecutor).execute(10, Tier.MASTER);
+    verify(workerContract).execute(item, keyLease);
+    verify(workItemDispatcher).markDone(item.getId());
     verify(riotKeyPool).clearWorkerLease();
     assertThat(result.status()).isEqualTo(WorkItemStatus.DONE);
-    assertThat(item.getStatus()).isEqualTo(WorkItemStatus.DONE);
   }
 }

--- a/src/test/java/com/bestduo_BE/workitem/application/WorkItemWorkerTest.java
+++ b/src/test/java/com/bestduo_BE/workitem/application/WorkItemWorkerTest.java
@@ -7,10 +7,10 @@ import static org.mockito.Mockito.verify;
 import com.bestduo_BE.common.domain.model.Tier;
 import com.bestduo_BE.common.infra.riot.KeyLease;
 import com.bestduo_BE.common.infra.riot.RiotKeyPool;
-import com.bestduo_BE.coverage.infra.persistence.repository.CoverageBucketJpaRepository;
 import com.bestduo_BE.ingest.application.MatchIngestWorker;
 import com.bestduo_BE.refresh.application.RefreshBatchExecutor;
 import com.bestduo_BE.seed.application.SeedBootstrapExecutor;
+import com.bestduo_BE.workitem.domain.model.WorkItemStatus;
 import com.bestduo_BE.workitem.domain.model.WorkItemType;
 import com.bestduo_BE.workitem.infra.persistence.entity.WorkItem;
 import com.bestduo_BE.workitem.infra.persistence.repository.WorkItemJpaRepository;
@@ -25,7 +25,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class WorkItemWorkerTest {
 
   @Mock private WorkItemJpaRepository workItemJpaRepository;
-  @Mock private CoverageBucketJpaRepository coverageBucketJpaRepository;
   @Mock private SeedBootstrapExecutor seedBootstrapExecutor;
   @Mock private RefreshBatchExecutor refreshBatchExecutor;
   @Mock private MatchIngestWorker matchIngestWorker;
@@ -38,7 +37,6 @@ class WorkItemWorkerTest {
   void setUp() {
     worker = new WorkItemWorker(
         workItemJpaRepository,
-        coverageBucketJpaRepository,
         seedBootstrapExecutor,
         refreshBatchExecutor,
         matchIngestWorker,
@@ -57,7 +55,7 @@ class WorkItemWorkerTest {
 
     verify(refreshBatchExecutor).execute(10, Tier.MASTER);
     verify(riotKeyPool).clearWorkerLease();
-    assertThat(result.status()).isEqualTo("DONE");
-    assertThat(item.getStatus().name()).isEqualTo("DONE");
+    assertThat(result.status()).isEqualTo(WorkItemStatus.DONE);
+    assertThat(item.getStatus()).isEqualTo(WorkItemStatus.DONE);
   }
 }

--- a/src/test/java/com/bestduo_BE/workitem/application/worker/SeedPageWorkerTest.java
+++ b/src/test/java/com/bestduo_BE/workitem/application/worker/SeedPageWorkerTest.java
@@ -1,0 +1,54 @@
+package com.bestduo_BE.workitem.application.worker;
+
+import static org.mockito.Mockito.verify;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.bestduo_BE.common.domain.model.SeedBootstrapCommand;
+import com.bestduo_BE.common.domain.model.Tier;
+import com.bestduo_BE.common.infra.riot.KeyLease;
+import com.bestduo_BE.seed.application.SeedBootstrapExecutor;
+import com.bestduo_BE.workitem.domain.model.WorkItemType;
+import com.bestduo_BE.workitem.infra.persistence.entity.WorkItem;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class SeedPageWorkerTest {
+
+  @Mock private SeedBootstrapExecutor seedBootstrapExecutor;
+  @Mock private KeyLease keyLease;
+
+  private SeedPageWorker worker;
+
+  @BeforeEach
+  void setUp() {
+    worker = new SeedPageWorker(seedBootstrapExecutor, new ObjectMapper());
+  }
+
+  @Test
+  void executeUsesPayloadPageQueueAndDivision() {
+    WorkItem item = WorkItem.pending(
+        1L,
+        "15.7",
+        Tier.MASTER,
+        WorkItemType.SEED_SUMMONERS,
+        1,
+        2,
+        "{\"queue\":\"RANKED_SOLO_5x5\",\"division\":\"II\",\"page\":3,\"tier\":\"MASTER\"}"
+    );
+
+    worker.execute(item, keyLease);
+
+    ArgumentCaptor<SeedBootstrapCommand> captor = ArgumentCaptor.forClass(SeedBootstrapCommand.class);
+    verify(seedBootstrapExecutor).execute(captor.capture());
+    SeedBootstrapCommand command = captor.getValue();
+    org.assertj.core.api.Assertions.assertThat(command.startPage()).isEqualTo(3);
+    org.assertj.core.api.Assertions.assertThat(command.endPage()).isEqualTo(3);
+    org.assertj.core.api.Assertions.assertThat(command.division()).isEqualTo("II");
+    org.assertj.core.api.Assertions.assertThat(command.maxEntries()).isEqualTo(2);
+  }
+}

--- a/src/test/java/com/bestduo_BE/workitem/infra/persistence/WorkItemDispatcherImplTest.java
+++ b/src/test/java/com/bestduo_BE/workitem/infra/persistence/WorkItemDispatcherImplTest.java
@@ -1,0 +1,65 @@
+package com.bestduo_BE.workitem.infra.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import com.bestduo_BE.common.domain.model.Tier;
+import com.bestduo_BE.workitem.domain.model.WorkItemStatus;
+import com.bestduo_BE.workitem.domain.model.WorkItemType;
+import com.bestduo_BE.workitem.infra.persistence.entity.WorkItem;
+import com.bestduo_BE.workitem.infra.persistence.repository.WorkItemJpaRepository;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class WorkItemDispatcherImplTest {
+
+  @Mock private WorkItemJpaRepository repository;
+
+  private WorkItemDispatcherImpl dispatcher;
+
+  @BeforeEach
+  void setUp() {
+    dispatcher = new WorkItemDispatcherImpl(repository);
+  }
+
+  @Test
+  void pickAndLockMarksPendingItemsRunning() {
+    WorkItem item = WorkItem.pending(1L, "15.7", Tier.MASTER, WorkItemType.VERIFY_SUMMONERS, 1, 10, null);
+    given(repository.pickPendingForUpdate(1)).willReturn(List.of(item));
+
+    List<WorkItem> picked = dispatcher.pickAndLock(1);
+
+    assertThat(picked).singleElement().extracting(WorkItem::getStatus).isEqualTo(WorkItemStatus.RUNNING);
+  }
+
+  @Test
+  void markDoneTransitionsItemToDone() {
+    WorkItem item = WorkItem.pending(1L, "15.7", Tier.MASTER, WorkItemType.VERIFY_SUMMONERS, 1, 10, null);
+    item.markRunning();
+    given(repository.findById(1L)).willReturn(Optional.of(item));
+
+    dispatcher.markDone(1L);
+
+    assertThat(item.getStatus()).isEqualTo(WorkItemStatus.DONE);
+  }
+
+  @Test
+  void markErrorTransitionsItemToErrorAndStoresMessage() {
+    WorkItem item = WorkItem.pending(1L, "15.7", Tier.MASTER, WorkItemType.VERIFY_SUMMONERS, 1, 10, null);
+    item.markRunning();
+    given(repository.findById(1L)).willReturn(Optional.of(item));
+
+    dispatcher.markError(1L, "boom");
+
+    assertThat(item.getStatus()).isEqualTo(WorkItemStatus.ERROR);
+    assertThat(item.getLastError()).isEqualTo("boom");
+    verify(repository).findById(1L);
+  }
+}

--- a/src/test/java/com/bestduo_BE/workitem/infra/persistence/repository/WorkItemJpaRepositoryTest.java
+++ b/src/test/java/com/bestduo_BE/workitem/infra/persistence/repository/WorkItemJpaRepositoryTest.java
@@ -48,4 +48,14 @@ class WorkItemJpaRepositoryTest {
     assertThat(count).isEqualTo(2L);
   }
 
+  @Test
+  void findFirstByStatusOrderByPriorityAscCreatedAtAscReturnsHighestPriorityReadyItem() {
+    repository.save(WorkItem.ready(1L, "15.7", Tier.MASTER, WorkItemType.VERIFY_SUMMONERS, 5, 10));
+    WorkItem expected = repository.save(WorkItem.ready(1L, "15.7", Tier.MASTER, WorkItemType.REFRESH_SUMMONERS, 1, 10));
+
+    WorkItem next = repository.findFirstByStatusOrderByPriorityAscCreatedAtAsc(WorkItemStatus.READY).orElseThrow();
+
+    assertThat(next.getId()).isEqualTo(expected.getId());
+  }
+
 }

--- a/src/test/java/com/bestduo_BE/workitem/infra/persistence/repository/WorkItemJpaRepositoryTest.java
+++ b/src/test/java/com/bestduo_BE/workitem/infra/persistence/repository/WorkItemJpaRepositoryTest.java
@@ -1,0 +1,51 @@
+package com.bestduo_BE.workitem.infra.persistence.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.bestduo_BE.common.domain.model.Tier;
+import com.bestduo_BE.workitem.domain.model.WorkItemStatus;
+import com.bestduo_BE.workitem.domain.model.WorkItemType;
+import com.bestduo_BE.workitem.infra.persistence.entity.WorkItem;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.test.context.TestPropertySource;
+
+@DataJpaTest
+@TestPropertySource(properties = {
+    "spring.datasource.url=jdbc:h2:mem:work-item-repo;MODE=PostgreSQL;DB_CLOSE_DELAY=-1",
+    "spring.datasource.username=sa",
+    "spring.datasource.password=",
+    "spring.datasource.driver-class-name=org.h2.Driver",
+    "spring.jpa.hibernate.ddl-auto=create",
+    "spring.jpa.show-sql=false"
+})
+class WorkItemJpaRepositoryTest {
+
+  @Autowired private WorkItemJpaRepository repository;
+
+  @Test
+  void existsByCoverageBucketIdAndTypeAndStatusInDetectsPendingWork() {
+    repository.save(WorkItem.ready(1L, "15.7", Tier.MASTER, WorkItemType.VERIFY_SUMMONERS, 1, 10));
+
+    boolean exists = repository.existsByCoverageBucketIdAndTypeAndStatusIn(
+        1L,
+        WorkItemType.VERIFY_SUMMONERS,
+        List.of(WorkItemStatus.READY, WorkItemStatus.RUNNING)
+    );
+
+    assertThat(exists).isTrue();
+  }
+
+  @Test
+  void countByPatchAndTierAndStatusCountsMatchingRows() {
+    repository.save(WorkItem.ready(1L, "15.7", Tier.MASTER, WorkItemType.VERIFY_SUMMONERS, 1, 10));
+    repository.save(WorkItem.ready(1L, "15.7", Tier.MASTER, WorkItemType.REFRESH_SUMMONERS, 1, 10));
+
+    long count = repository.countByPatchAndTierAndStatus("15.7", Tier.MASTER, WorkItemStatus.READY);
+
+    assertThat(count).isEqualTo(2L);
+  }
+
+}

--- a/src/test/java/com/bestduo_BE/workitem/infra/persistence/repository/WorkItemJpaRepositoryTest.java
+++ b/src/test/java/com/bestduo_BE/workitem/infra/persistence/repository/WorkItemJpaRepositoryTest.java
@@ -27,12 +27,12 @@ class WorkItemJpaRepositoryTest {
 
   @Test
   void existsByCoverageBucketIdAndTypeAndStatusInDetectsPendingWork() {
-    repository.save(WorkItem.ready(1L, "15.7", Tier.MASTER, WorkItemType.VERIFY_SUMMONERS, 1, 10));
+    repository.save(WorkItem.pending(1L, "15.7", Tier.MASTER, WorkItemType.VERIFY_SUMMONERS, 1, 10, null));
 
     boolean exists = repository.existsByCoverageBucketIdAndTypeAndStatusIn(
         1L,
         WorkItemType.VERIFY_SUMMONERS,
-        List.of(WorkItemStatus.READY, WorkItemStatus.RUNNING)
+        List.of(WorkItemStatus.PENDING, WorkItemStatus.RUNNING)
     );
 
     assertThat(exists).isTrue();
@@ -40,20 +40,20 @@ class WorkItemJpaRepositoryTest {
 
   @Test
   void countByPatchAndTierAndStatusCountsMatchingRows() {
-    repository.save(WorkItem.ready(1L, "15.7", Tier.MASTER, WorkItemType.VERIFY_SUMMONERS, 1, 10));
-    repository.save(WorkItem.ready(1L, "15.7", Tier.MASTER, WorkItemType.REFRESH_SUMMONERS, 1, 10));
+    repository.save(WorkItem.pending(1L, "15.7", Tier.MASTER, WorkItemType.VERIFY_SUMMONERS, 1, 10, null));
+    repository.save(WorkItem.pending(1L, "15.7", Tier.MASTER, WorkItemType.REFRESH_SUMMONERS, 1, 10, null));
 
-    long count = repository.countByPatchAndTierAndStatus("15.7", Tier.MASTER, WorkItemStatus.READY);
+    long count = repository.countByPatchAndTierAndStatus("15.7", Tier.MASTER, WorkItemStatus.PENDING);
 
     assertThat(count).isEqualTo(2L);
   }
 
   @Test
-  void findFirstByStatusOrderByPriorityAscCreatedAtAscReturnsHighestPriorityReadyItem() {
-    repository.save(WorkItem.ready(1L, "15.7", Tier.MASTER, WorkItemType.VERIFY_SUMMONERS, 5, 10));
-    WorkItem expected = repository.save(WorkItem.ready(1L, "15.7", Tier.MASTER, WorkItemType.REFRESH_SUMMONERS, 1, 10));
+  void findFirstByStatusOrderByPriorityAscCreatedAtAscReturnsHighestPriorityPendingItem() {
+    repository.save(WorkItem.pending(1L, "15.7", Tier.MASTER, WorkItemType.VERIFY_SUMMONERS, 5, 10, null));
+    WorkItem expected = repository.save(WorkItem.pending(1L, "15.7", Tier.MASTER, WorkItemType.REFRESH_SUMMONERS, 1, 10, null));
 
-    WorkItem next = repository.findFirstByStatusOrderByPriorityAscCreatedAtAsc(WorkItemStatus.READY).orElseThrow();
+    WorkItem next = repository.findFirstByStatusOrderByPriorityAscCreatedAtAsc(WorkItemStatus.PENDING).orElseThrow();
 
     assertThat(next.getId()).isEqualTo(expected.getId());
   }


### PR DESCRIPTION
## Summary

- `work_item` DB 테이블 기반 분산 큐 + Virtual Thread Worker Pool 구현 (방식 A)
- `CoverageScheduler`가 30초 주기로 버킷 부족 상태를 평가해 WorkItem 발행
- 4가지 Worker(`SeedPage`, `VerifySummoner`, `RefreshSummoner`, `IngestMatchDetail`)가 `SKIP LOCKED` 패턴으로 병렬 처리
- `work-item.worker-enabled=true` feature flag로 기존 ExecutionPipeline 경로와 독립 공존

## Bug fixes (이번 PR 추가 수정)

- `BudgetExhaustedException` / `RiotRateLimitedException` 발생 시 `markError` → `markPending`으로 변경 (retryCount 오염 방지, 다음 주기 재시도)
- `WorkItemDispatcher`에 `markPending` 포트 추가
- `WorkerPool`에서 `recoverStaleRunning`을 매 루프(N스레드 × 2/초)가 아닌 `@PostConstruct` 1회로 축소
- `VerifySummonerWorker`에 `findRefreshTargets` 정렬 우선순위 근거 주석 추가

## Test plan

- [ ] `work-item.worker-enabled=true` 설정 후 서버 기동 — Hibernate DDL로 `work_item` 테이블 생성 확인
- [ ] COLLECTING 버킷 생성 → `CoverageScheduler` 30초 주기로 WorkItem 발행 로그 확인
- [ ] Riot API key 소진 시 work item이 PENDING으로 복구되는지 확인 (ERROR로 남지 않음)
- [ ] 서버 재시작 후 이전 RUNNING 아이템이 PENDING으로 복구되는지 확인
- [ ] 기존 `/admin/run` 경로 정상 동작 유지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)