### PR TITLE
FEAT : PatchVersion 기반 현재 패치 match 수집 필터링

### DIFF
--- a/src/main/java/com/bestduo_BE/common/application/PatchVersionService.java
+++ b/src/main/java/com/bestduo_BE/common/application/PatchVersionService.java
@@ -1,0 +1,36 @@
+package com.bestduo_BE.common.application;
+
+import com.bestduo_BE.common.infra.persistence.entity.PatchVersion;
+import com.bestduo_BE.common.infra.persistence.repository.PatchVersionJpaRepository;
+import java.time.OffsetDateTime;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class PatchVersionService {
+
+  private final PatchVersionJpaRepository patchVersionRepository;
+
+  /** 최신 패치의 릴리스 시점 (epoch seconds). 데이터 없으면 Optional.empty() */
+  public Optional<Long> currentPatchStartTimeEpochSeconds() {
+    return patchVersionRepository.findTopByOrderByReleasedAtDesc()
+        .map(PatchVersion::releasedAtEpochSeconds);
+  }
+
+  /** 최신 패치 문자열 (e.g., "15.23"). 데이터 없으면 Optional.empty() */
+  public Optional<String> currentPatchVersion() {
+    return patchVersionRepository.findTopByOrderByReleasedAtDesc()
+        .map(PatchVersion::getPatch);
+  }
+
+  /** 새 패치 등록 (멱등: 이미 존재하면 false 반환) */
+  public boolean registerIfAbsent(String patch, OffsetDateTime releasedAt) {
+    if (patchVersionRepository.existsByPatch(patch)) {
+      return false;
+    }
+    patchVersionRepository.save(PatchVersion.of(patch, releasedAt));
+    return true;
+  }
+}

--- a/src/main/java/com/bestduo_BE/common/application/port/MatchQueueEnqueuer.java
+++ b/src/main/java/com/bestduo_BE/common/application/port/MatchQueueEnqueuer.java
@@ -4,5 +4,5 @@ import com.bestduo_BE.common.domain.model.Tier;
 import java.util.List;
 
 public interface MatchQueueEnqueuer {
-  void enqueueAllIdempotent(List<String> matchIds, Tier tier, int priority);
+  void enqueueAllIdempotent(List<String> matchIds, Tier tier, int priority, String patch);
 }

--- a/src/main/java/com/bestduo_BE/common/infra/persistence/MatchQueueEnqueuerImpl.java
+++ b/src/main/java/com/bestduo_BE/common/infra/persistence/MatchQueueEnqueuerImpl.java
@@ -16,10 +16,10 @@ public class MatchQueueEnqueuerImpl implements MatchQueueEnqueuer {
 
   @Override
   @Transactional
-  public void enqueueAllIdempotent(List<String> matchIds, Tier tier, int priority) {
+  public void enqueueAllIdempotent(List<String> matchIds, Tier tier, int priority, String patch) {
     for (String matchId : matchIds) {
       if (repo.existsById(matchId)) continue; // ✅ 멱등
-      repo.save(MatchQueue.newReady(matchId, tier.name(), priority));
+      repo.save(MatchQueue.newReady(matchId, tier.name(), priority, patch));
     }
   }
 

--- a/src/main/java/com/bestduo_BE/common/infra/persistence/entity/MatchQueue.java
+++ b/src/main/java/com/bestduo_BE/common/infra/persistence/entity/MatchQueue.java
@@ -33,6 +33,9 @@ public class MatchQueue {
   @Column(name = "collection_tier", nullable = false)
   private String collectionTier; // Tier enum name
 
+  @Column(name = "patch")
+  private String patch;
+
   @Column(name = "retry_count", nullable = false)
   private int retryCount;
 
@@ -48,13 +51,14 @@ public class MatchQueue {
   @Column(name = "updated_at", nullable = false)
   private OffsetDateTime updatedAt;
 
-  public static MatchQueue newReady(String matchId, String collectionTier, int priority) {
+  public static MatchQueue newReady(String matchId, String collectionTier, int priority, String patch) {
     OffsetDateTime now = OffsetDateTime.now();
     return MatchQueue.builder()
         .matchId(matchId)
         .status("READY")
         .priority(priority)
         .collectionTier(collectionTier)
+        .patch(patch)
         .retryCount(0)
         .lastError(null)
         .lockedAt(null)

--- a/src/main/java/com/bestduo_BE/common/infra/persistence/entity/PatchVersion.java
+++ b/src/main/java/com/bestduo_BE/common/infra/persistence/entity/PatchVersion.java
@@ -1,0 +1,49 @@
+package com.bestduo_BE.common.infra.persistence.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.OffsetDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "patch_version")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class PatchVersion {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(nullable = false, unique = true)
+  private String patch; // "15.23" (major.minor만)
+
+  @Column(name = "released_at", nullable = false)
+  private OffsetDateTime releasedAt; // 최초 감지 시점 (근사값)
+
+  @Column(name = "created_at", nullable = false)
+  private OffsetDateTime createdAt;
+
+  /** Riot API startTime 파라미터용 epoch seconds */
+  public long releasedAtEpochSeconds() {
+    return releasedAt.toEpochSecond();
+  }
+
+  public static PatchVersion of(String patch, OffsetDateTime releasedAt) {
+    return PatchVersion.builder()
+        .patch(patch)
+        .releasedAt(releasedAt)
+        .createdAt(OffsetDateTime.now())
+        .build();
+  }
+}

--- a/src/main/java/com/bestduo_BE/common/infra/persistence/repository/IngestQueueStatsJpaRepository.java
+++ b/src/main/java/com/bestduo_BE/common/infra/persistence/repository/IngestQueueStatsJpaRepository.java
@@ -23,7 +23,7 @@ public interface IngestQueueStatsJpaRepository extends Repository<MatchQueue, St
     from match_queue mq
     where mq.status = 'RUNNING'
       and mq.locked_at is not null
-      and mq.locked_at <= now() - (:staleMinutes || ' minutes')::interval
+      and mq.locked_at <= now() - (:staleMinutes * interval '1 minute')
     """, nativeQuery = true)
   long countStaleRunning(@Param("staleMinutes") int staleMinutes);
 
@@ -58,7 +58,7 @@ public interface IngestQueueStatsJpaRepository extends Repository<MatchQueue, St
     select count(*)
     from match_queue mq
     where mq.status = 'DONE'
-      and mq.updated_at >= now() - (:minutes || ' minutes')::interval
+      and mq.updated_at >= now() - (:minutes * interval '1 minute')
     """, nativeQuery = true)
   long countDoneInLastMinutes(@Param("minutes") int minutes);
 
@@ -74,7 +74,7 @@ public interface IngestQueueStatsJpaRepository extends Repository<MatchQueue, St
     select count(*)
     from match_queue mq
     where mq.status = 'DONE'
-      and mq.updated_at >= now() - (:minutes || ' minutes')::interval
+      and mq.updated_at >= now() - (:minutes * interval '1 minute')
       and (:collectionTier is null or mq.collection_tier = :collectionTier)
     """, nativeQuery = true)
   long countDoneInLastMinutesByTier(@Param("minutes") int minutes, @Param("collectionTier") String collectionTier);

--- a/src/main/java/com/bestduo_BE/common/infra/persistence/repository/MatchQueueJpaRepository.java
+++ b/src/main/java/com/bestduo_BE/common/infra/persistence/repository/MatchQueueJpaRepository.java
@@ -31,7 +31,7 @@ public interface MatchQueueJpaRepository extends JpaRepository<MatchQueue, Strin
         updated_at = now()
     where status = 'RUNNING'
       and locked_at is not null
-      and locked_at <= now() - (:staleMinutes || ' minutes')::interval
+      and locked_at <= now() - (:staleMinutes * interval '1 minute')
     """, nativeQuery = true)
   int recoverStaleRunning(@Param("staleMinutes") int staleMinutes);
 
@@ -65,7 +65,7 @@ public interface MatchQueueJpaRepository extends JpaRepository<MatchQueue, Strin
       from match_queue mq
       where mq.status = 'ERROR'
         and mq.retry_count < :maxRetry
-        and mq.updated_at <= now() - (:cooldownMinutes || ' minutes')::interval
+        and mq.updated_at <= now() - (:cooldownMinutes * interval '1 minute')
         and (:collectionTier is null or mq.collection_tier = :collectionTier)
       order by mq.priority asc, mq.updated_at asc
       limit :limit

--- a/src/main/java/com/bestduo_BE/common/infra/persistence/repository/PatchVersionJpaRepository.java
+++ b/src/main/java/com/bestduo_BE/common/infra/persistence/repository/PatchVersionJpaRepository.java
@@ -1,0 +1,14 @@
+package com.bestduo_BE.common.infra.persistence.repository;
+
+import com.bestduo_BE.common.infra.persistence.entity.PatchVersion;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PatchVersionJpaRepository extends JpaRepository<PatchVersion, Long> {
+
+  boolean existsByPatch(String patch);
+
+  Optional<PatchVersion> findByPatch(String patch);
+
+  Optional<PatchVersion> findTopByOrderByReleasedAtDesc();
+}

--- a/src/main/java/com/bestduo_BE/ingest/application/port/MatchQueueDispatcher.java
+++ b/src/main/java/com/bestduo_BE/ingest/application/port/MatchQueueDispatcher.java
@@ -29,5 +29,5 @@ public interface MatchQueueDispatcher {
    */
   void unlockToReady(String matchId);
 
-  record Item(String matchId, Tier tier, int priority) {}
+  record Item(String matchId, Tier tier, int priority, String patch) {}
 }

--- a/src/main/java/com/bestduo_BE/ingest/infra/persistence/MatchQueueDispatcherImpl.java
+++ b/src/main/java/com/bestduo_BE/ingest/infra/persistence/MatchQueueDispatcherImpl.java
@@ -70,7 +70,7 @@ public class MatchQueueDispatcherImpl implements MatchQueueDispatcher {
     List<Item> out = new ArrayList<>();
     for (MatchQueue mq : list) {
       Tier tier = Tier.valueOf(mq.getCollectionTier());
-      out.add(new Item(mq.getMatchId(), tier, mq.getPriority()));
+      out.add(new Item(mq.getMatchId(), tier, mq.getPriority(), mq.getPatch()));
     }
     return out;
   }

--- a/src/main/java/com/bestduo_BE/refresh/application/RefreshSummonerMatches.java
+++ b/src/main/java/com/bestduo_BE/refresh/application/RefreshSummonerMatches.java
@@ -2,6 +2,7 @@ package com.bestduo_BE.refresh.application;
 
 import com.bestduo_BE.config.WorkItemProperties;
 import com.bestduo_BE.refresh.application.port.LeagueEntriesRefreshLoader;
+import com.bestduo_BE.common.application.PatchVersionService;
 import com.bestduo_BE.common.application.port.MatchIdsFinder;
 import com.bestduo_BE.common.application.port.MatchQueueEnqueuer;
 import com.bestduo_BE.refresh.application.port.SummonerRefreshStatusUpdater;
@@ -28,6 +29,7 @@ public class RefreshSummonerMatches {
   private final MatchIdsFinder matchIdsFinder;
   private final MatchQueueEnqueuer matchQueueEnqueuer;
   private final SummonerRefreshStatusUpdater summonerRefreshStatusUpdater;
+  private final PatchVersionService patchVersionService;
   private final WorkItemProperties workItemProperties;
 
   public Result execute(String puuid) {
@@ -58,7 +60,8 @@ public class RefreshSummonerMatches {
         return new Result(puuid, 0, collectionTier, summoner.getLastMatchStartTime());
       }
 
-      matchQueueEnqueuer.enqueueAllIdempotent(matchIds, collectionTier, PRIORITY_REFRESH);
+      String currentPatch = patchVersionService.currentPatchVersion().orElse(null);
+      matchQueueEnqueuer.enqueueAllIdempotent(matchIds, collectionTier, PRIORITY_REFRESH, currentPatch);
 
       long newCursor = Instant.now().getEpochSecond();
       summonerRefreshStatusUpdater.syncRefreshCursor(puuid, newCursor);
@@ -97,10 +100,17 @@ public class RefreshSummonerMatches {
   }
 
   private List<String> loadMatchIds(String puuid, Long lastMatchStartTimeSecOrNull) {
-    if (lastMatchStartTimeSecOrNull == null) {
-      return matchIdsFinder.findRecentMatchIds(puuid, FETCH_COUNT);
+    long effectiveStartTime = patchVersionService.currentPatchStartTimeEpochSeconds().orElse(0L);
+
+    if (lastMatchStartTimeSecOrNull != null && lastMatchStartTimeSecOrNull > effectiveStartTime) {
+      effectiveStartTime = lastMatchStartTimeSecOrNull;
     }
-    return matchIdsFinder.findMatchIdsSince(puuid, lastMatchStartTimeSecOrNull, FETCH_COUNT);
+
+    if (effectiveStartTime > 0) {
+      return matchIdsFinder.findMatchIdsSince(puuid, effectiveStartTime, FETCH_COUNT);
+    }
+
+    return matchIdsFinder.findRecentMatchIds(puuid, FETCH_COUNT);
   }
 
   private Tier resolveCollectionTierBySolo(String puuid) {

--- a/src/main/java/com/bestduo_BE/seed/application/SeedBootstrapExecutor.java
+++ b/src/main/java/com/bestduo_BE/seed/application/SeedBootstrapExecutor.java
@@ -1,6 +1,7 @@
 package com.bestduo_BE.seed.application;
 
 import com.bestduo_BE.seed.application.port.LeagueEntriesSeedLoader;
+import com.bestduo_BE.common.application.PatchVersionService;
 import com.bestduo_BE.common.application.port.MatchIdsFinder;
 import com.bestduo_BE.common.application.port.MatchQueueEnqueuer;
 import com.bestduo_BE.seed.application.port.SummonerSeedRegistry;
@@ -22,6 +23,7 @@ public class SeedBootstrapExecutor {
   private final MatchIdsFinder matchIdsFinder;
   private final MatchQueueEnqueuer matchQueueEnqueuer;
   private final SummonerSeedRegistry summonerSeedRegistry;
+  private final PatchVersionService patchVersionService;
 
   public record SeedBootstrapResult(
       int pagesProcessed,
@@ -121,14 +123,23 @@ public class SeedBootstrapExecutor {
   }
 
   private void enqueueRecentMatches(String puuid, SeedBootstrapCommand cmd, SeedBootstrapProgress progress) {
-    List<String> matchIds = matchIdsFinder.findRecentMatchIds(puuid, cmd.matchesPerPuuid());
+    var patchStartTime = patchVersionService.currentPatchStartTimeEpochSeconds();
+    String currentPatch = patchVersionService.currentPatchVersion().orElse(null);
+
+    List<String> matchIds;
+    if (patchStartTime.isPresent()) {
+      matchIds = matchIdsFinder.findMatchIdsSince(puuid, patchStartTime.get(), cmd.matchesPerPuuid());
+    } else {
+      matchIds = matchIdsFinder.findRecentMatchIds(puuid, cmd.matchesPerPuuid());
+    }
+
     if (matchIds == null || matchIds.isEmpty()) {
       return;
     }
 
     progress.addFetchedMatchIds(matchIds.size());
     Tier tierLabel = cmd.seedTier();
-    matchQueueEnqueuer.enqueueAllIdempotent(matchIds, tierLabel, PRIORITY_SEED);
+    matchQueueEnqueuer.enqueueAllIdempotent(matchIds, tierLabel, PRIORITY_SEED, currentPatch);
     progress.addEnqueuedMatchIds(matchIds.size());
   }
 

--- a/src/main/java/com/bestduo_BE/workitem/infra/persistence/repository/WorkItemJpaRepository.java
+++ b/src/main/java/com/bestduo_BE/workitem/infra/persistence/repository/WorkItemJpaRepository.java
@@ -39,7 +39,7 @@ public interface WorkItemJpaRepository extends JpaRepository<WorkItem, Long> {
           updated_at = now()
       where status = 'RUNNING'
         and locked_at is not null
-        and locked_at <= now() - (:staleMinutes || ' minutes')::interval
+        and locked_at <= now() - (:staleMinutes * interval '1 minute')
       """, nativeQuery = true)
   int recoverStaleRunning(@Param("staleMinutes") int staleMinutes);
 

--- a/src/test/java/com/bestduo_BE/common/application/PatchVersionServiceTest.java
+++ b/src/test/java/com/bestduo_BE/common/application/PatchVersionServiceTest.java
@@ -1,0 +1,108 @@
+package com.bestduo_BE.common.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.bestduo_BE.common.infra.persistence.entity.PatchVersion;
+import com.bestduo_BE.common.infra.persistence.repository.PatchVersionJpaRepository;
+import java.time.OffsetDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class PatchVersionServiceTest {
+
+  @Mock
+  private PatchVersionJpaRepository patchVersionRepository;
+
+  private PatchVersionService service;
+
+  @BeforeEach
+  void setUp() {
+    service = new PatchVersionService(patchVersionRepository);
+  }
+
+  @Test
+  @DisplayName("currentPatchStartTimeEpochSeconds — 패치 있으면 epoch seconds 반환")
+  void currentPatchStartTimeEpochSeconds_whenPatchExists_returnsEpochSeconds() {
+    OffsetDateTime releasedAt = OffsetDateTime.parse("2025-03-01T00:00:00+00:00");
+    PatchVersion patch = PatchVersion.of("15.5", releasedAt);
+    given(patchVersionRepository.findTopByOrderByReleasedAtDesc()).willReturn(Optional.of(patch));
+
+    Optional<Long> result = service.currentPatchStartTimeEpochSeconds();
+
+    assertThat(result).isPresent();
+    assertThat(result.get()).isEqualTo(releasedAt.toEpochSecond());
+  }
+
+  @Test
+  @DisplayName("currentPatchStartTimeEpochSeconds — 패치 없으면 empty 반환")
+  void currentPatchStartTimeEpochSeconds_whenNoPatch_returnsEmpty() {
+    given(patchVersionRepository.findTopByOrderByReleasedAtDesc()).willReturn(Optional.empty());
+
+    Optional<Long> result = service.currentPatchStartTimeEpochSeconds();
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  @DisplayName("currentPatchVersion — 최신 패치 문자열 반환")
+  void currentPatchVersion_whenPatchExists_returnsPatchString() {
+    OffsetDateTime releasedAt = OffsetDateTime.parse("2025-03-01T00:00:00+00:00");
+    PatchVersion patch = PatchVersion.of("15.5", releasedAt);
+    given(patchVersionRepository.findTopByOrderByReleasedAtDesc()).willReturn(Optional.of(patch));
+
+    Optional<String> result = service.currentPatchVersion();
+
+    assertThat(result).contains("15.5");
+  }
+
+  @Test
+  @DisplayName("currentPatchVersion — 패치 없으면 empty 반환")
+  void currentPatchVersion_whenNoPatch_returnsEmpty() {
+    given(patchVersionRepository.findTopByOrderByReleasedAtDesc()).willReturn(Optional.empty());
+
+    Optional<String> result = service.currentPatchVersion();
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  @DisplayName("registerIfAbsent — 신규 패치면 저장 후 true 반환")
+  void registerIfAbsent_newPatch_savesAndReturnsTrue() {
+    OffsetDateTime releasedAt = OffsetDateTime.parse("2025-04-01T00:00:00+00:00");
+    given(patchVersionRepository.existsByPatch("15.8")).willReturn(false);
+    given(patchVersionRepository.save(any(PatchVersion.class)))
+        .willAnswer(invocation -> invocation.getArgument(0));
+
+    boolean result = service.registerIfAbsent("15.8", releasedAt);
+
+    assertThat(result).isTrue();
+    ArgumentCaptor<PatchVersion> captor = ArgumentCaptor.forClass(PatchVersion.class);
+    verify(patchVersionRepository).save(captor.capture());
+    PatchVersion saved = captor.getValue();
+    assertThat(saved.getPatch()).isEqualTo("15.8");
+    assertThat(saved.getReleasedAt()).isEqualTo(releasedAt);
+  }
+
+  @Test
+  @DisplayName("registerIfAbsent — 이미 존재하면 저장 안하고 false 반환")
+  void registerIfAbsent_existingPatch_skipsAndReturnsFalse() {
+    OffsetDateTime releasedAt = OffsetDateTime.parse("2025-04-01T00:00:00+00:00");
+    given(patchVersionRepository.existsByPatch("15.8")).willReturn(true);
+
+    boolean result = service.registerIfAbsent("15.8", releasedAt);
+
+    assertThat(result).isFalse();
+    verify(patchVersionRepository, never()).save(any());
+  }
+}

--- a/src/test/java/com/bestduo_BE/common/infra/persistence/MatchQueueEnqueuerImplTest.java
+++ b/src/test/java/com/bestduo_BE/common/infra/persistence/MatchQueueEnqueuerImplTest.java
@@ -35,7 +35,7 @@ class MatchQueueEnqueuerImplTest {
     given(repository.existsById("m-1")).willReturn(false);
     given(repository.existsById("m-2")).willReturn(true);
 
-    enqueuer.enqueueAllIdempotent(List.of("m-1", "m-2"), Tier.EMERALD, 80);
+    enqueuer.enqueueAllIdempotent(List.of("m-1", "m-2"), Tier.EMERALD, 80, "15.23");
 
     ArgumentCaptor<MatchQueue> captor = ArgumentCaptor.forClass(MatchQueue.class);
     verify(repository).save(captor.capture());
@@ -43,6 +43,7 @@ class MatchQueueEnqueuerImplTest {
     assertThat(saved.getMatchId()).isEqualTo("m-1");
     assertThat(saved.getCollectionTier()).isEqualTo("EMERALD");
     assertThat(saved.getPriority()).isEqualTo(80);
+    assertThat(saved.getPatch()).isEqualTo("15.23");
     verify(repository).existsById("m-1");
     verify(repository).existsById("m-2");
   }
@@ -51,7 +52,7 @@ class MatchQueueEnqueuerImplTest {
   void skipSavingWhenAllIdsExist() {
     given(repository.existsById("m-3")).willReturn(true);
 
-    enqueuer.enqueueAllIdempotent(List.of("m-3"), Tier.GOLD, 5);
+    enqueuer.enqueueAllIdempotent(List.of("m-3"), Tier.GOLD, 5, "15.23");
 
     verify(repository, never()).save(any());
   }

--- a/src/test/java/com/bestduo_BE/common/infra/persistence/entity/MatchQueueTest.java
+++ b/src/test/java/com/bestduo_BE/common/infra/persistence/entity/MatchQueueTest.java
@@ -1,0 +1,19 @@
+package com.bestduo_BE.common.infra.persistence.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class MatchQueueTest {
+
+  @Test
+  void newReadyIncludesPatch() {
+    MatchQueue queue = MatchQueue.newReady("match-1", "EMERALD", 20, "15.23");
+
+    assertThat(queue.getMatchId()).isEqualTo("match-1");
+    assertThat(queue.getCollectionTier()).isEqualTo("EMERALD");
+    assertThat(queue.getPriority()).isEqualTo(20);
+    assertThat(queue.getPatch()).isEqualTo("15.23");
+    assertThat(queue.getStatus()).isEqualTo("READY");
+  }
+}

--- a/src/test/java/com/bestduo_BE/ingest/application/MatchIngestWorkerTest.java
+++ b/src/test/java/com/bestduo_BE/ingest/application/MatchIngestWorkerTest.java
@@ -32,7 +32,7 @@ class MatchIngestWorkerTest {
 
   @Test
   void executeForwardsRequestedTierToQueueLocking() {
-    MatchQueueDispatcher.Item item = new MatchQueueDispatcher.Item("match-1", Tier.GOLD, 1);
+    MatchQueueDispatcher.Item item = new MatchQueueDispatcher.Item("match-1", Tier.GOLD, 1, "15.23");
     given(queue.recoverStaleRunning(10)).willReturn(0);
     given(queue.pickAndLock(3, 2, 10, Tier.GOLD)).willReturn(List.of(item));
     given(ingestMatchDetail.execute("match-1", Tier.GOLD))

--- a/src/test/java/com/bestduo_BE/ingest/infra/persistence/MatchQueueDispatcherImplTest.java
+++ b/src/test/java/com/bestduo_BE/ingest/infra/persistence/MatchQueueDispatcherImplTest.java
@@ -44,9 +44,9 @@ class MatchQueueDispatcherImplTest {
 
   @Test
   void pickAndLockPrefersReadyBeforeRetryableErrors() {
-    MatchQueue ready1 = match("m-1", Tier.GOLD, 1);
-    MatchQueue ready2 = match("m-2", Tier.SILVER, 2);
-    MatchQueue error = match("m-3", Tier.BRONZE, 3);
+    MatchQueue ready1 = match("m-1", Tier.GOLD, 1, "15.23");
+    MatchQueue ready2 = match("m-2", Tier.SILVER, 2, "15.23");
+    MatchQueue error = match("m-3", Tier.BRONZE, 3, "15.23");
     given(repository.pickReadyAndLock(3, null)).willReturn(List.of(ready1, ready2));
     given(repository.pickRetryableErrorAndLock(1, 2, 5, null)).willReturn(List.of(error));
 
@@ -55,16 +55,16 @@ class MatchQueueDispatcherImplTest {
     verify(repository).pickReadyAndLock(3, null);
     verify(repository).pickRetryableErrorAndLock(1, 2, 5, null);
     assertThat(items).containsExactly(
-        new Item("m-1", Tier.GOLD, 1),
-        new Item("m-2", Tier.SILVER, 2),
-        new Item("m-3", Tier.BRONZE, 3)
+        new Item("m-1", Tier.GOLD, 1, "15.23"),
+        new Item("m-2", Tier.SILVER, 2, "15.23"),
+        new Item("m-3", Tier.BRONZE, 3, "15.23")
     );
   }
 
   @Test
   void skipsRetryableErrorsWhenReadyFillLimit() {
-    MatchQueue ready1 = match("m-1", Tier.EMERALD, 1);
-    MatchQueue ready2 = match("m-2", Tier.EMERALD, 2);
+    MatchQueue ready1 = match("m-1", Tier.EMERALD, 1, "15.23");
+    MatchQueue ready2 = match("m-2", Tier.EMERALD, 2, "15.23");
     given(repository.pickReadyAndLock(2, null)).willReturn(List.of(ready1, ready2));
 
     List<Item> items = coordinator.pickAndLock(2, 2, 5);
@@ -72,14 +72,14 @@ class MatchQueueDispatcherImplTest {
     verify(repository).pickReadyAndLock(2, null);
     verify(repository, never()).pickRetryableErrorAndLock(anyInt(), anyInt(), anyInt(), org.mockito.ArgumentMatchers.<String>any());
     assertThat(items).containsExactly(
-        new Item("m-1", Tier.EMERALD, 1),
-        new Item("m-2", Tier.EMERALD, 2)
+        new Item("m-1", Tier.EMERALD, 1, "15.23"),
+        new Item("m-2", Tier.EMERALD, 2, "15.23")
     );
   }
 
   @Test
   void pickAndLockFiltersByRequestedTier() {
-    MatchQueue ready = match("m-gold", Tier.GOLD, 1);
+    MatchQueue ready = match("m-gold", Tier.GOLD, 1, "15.23");
     given(repository.pickReadyAndLock(2, "GOLD")).willReturn(List.of(ready));
     given(repository.pickRetryableErrorAndLock(1, 2, 5, "GOLD")).willReturn(List.of());
 
@@ -87,12 +87,12 @@ class MatchQueueDispatcherImplTest {
 
     verify(repository).pickReadyAndLock(2, "GOLD");
     verify(repository).pickRetryableErrorAndLock(1, 2, 5, "GOLD");
-    assertThat(items).containsExactly(new Item("m-gold", Tier.GOLD, 1));
+    assertThat(items).containsExactly(new Item("m-gold", Tier.GOLD, 1, "15.23"));
   }
 
   @Test
   void markDoneUpdatesEntityStatus() {
-    MatchQueue mq = match("done", Tier.GOLD, 1);
+    MatchQueue mq = match("done", Tier.GOLD, 1, "15.23");
     given(repository.findById("done")).willReturn(Optional.of(mq));
 
     coordinator.markDone("done");
@@ -103,7 +103,7 @@ class MatchQueueDispatcherImplTest {
 
   @Test
   void markErrorRegistersFailureMessage() {
-    MatchQueue mq = match("err", Tier.GOLD, 1);
+    MatchQueue mq = match("err", Tier.GOLD, 1, "15.23");
     given(repository.findById("err")).willReturn(Optional.of(mq));
 
     coordinator.markError("err", "boom");
@@ -120,13 +120,14 @@ class MatchQueueDispatcherImplTest {
     verify(repository).unlockToReady("match");
   }
 
-  private MatchQueue match(String matchId, Tier tier, int priority) {
+  private MatchQueue match(String matchId, Tier tier, int priority, String patch) {
     OffsetDateTime now = OffsetDateTime.now();
     return MatchQueue.builder()
         .matchId(matchId)
         .status("READY")
         .priority(priority)
         .collectionTier(tier.name())
+        .patch(patch)
         .retryCount(0)
         .lastError(null)
         .lockedAt(null)

--- a/src/test/java/com/bestduo_BE/ingest/infra/persistence/MatchQueuePickerImplTest.java
+++ b/src/test/java/com/bestduo_BE/ingest/infra/persistence/MatchQueuePickerImplTest.java
@@ -32,8 +32,8 @@ class MatchQueuePickerImplTest {
 
   @Test
   void pickMapsEntitiesToItems() {
-    MatchQueue ready = MatchQueue.newReady("m-1", Tier.EMERALD.name(), 20);
-    MatchQueue retry = MatchQueue.newReady("m-2", Tier.SILVER.name(), 30);
+    MatchQueue ready = MatchQueue.newReady("m-1", Tier.EMERALD.name(), 20, null);
+    MatchQueue retry = MatchQueue.newReady("m-2", Tier.SILVER.name(), 30, null);
     given(repository.pickReadyOrRetry(2)).willReturn(List.of(ready, retry));
 
     List<MatchQueueItem> items = picker.pick(2);
@@ -47,7 +47,7 @@ class MatchQueuePickerImplTest {
 
   @Test
   void markRunningUpdatesStatus() {
-    MatchQueue mq = MatchQueue.newReady("running", Tier.GOLD.name(), 10);
+    MatchQueue mq = MatchQueue.newReady("running", Tier.GOLD.name(), 10, null);
     given(repository.findById("running")).willReturn(Optional.of(mq));
 
     picker.markRunning("running");
@@ -58,7 +58,7 @@ class MatchQueuePickerImplTest {
 
   @Test
   void markDoneClearsLock() {
-    MatchQueue mq = MatchQueue.newReady("done", Tier.BRONZE.name(), 5);
+    MatchQueue mq = MatchQueue.newReady("done", Tier.BRONZE.name(), 5, null);
     given(repository.findById("done")).willReturn(Optional.of(mq));
 
     picker.markDone("done");
@@ -68,7 +68,7 @@ class MatchQueuePickerImplTest {
 
   @Test
   void markErrorRecordsFailureMessage() {
-    MatchQueue mq = MatchQueue.newReady("err", Tier.PLATINUM.name(), 1);
+    MatchQueue mq = MatchQueue.newReady("err", Tier.PLATINUM.name(), 1, null);
     given(repository.findById("err")).willReturn(Optional.of(mq));
 
     picker.markError("err", "boom");

--- a/src/test/java/com/bestduo_BE/ingest/presentation/api/IngestControllerTest.java
+++ b/src/test/java/com/bestduo_BE/ingest/presentation/api/IngestControllerTest.java
@@ -33,9 +33,8 @@ import org.springframework.test.web.servlet.MockMvc;
     "spring.datasource.username=sa",
     "spring.datasource.password=",
     "spring.datasource.driver-class-name=org.h2.Driver",
-    "spring.jpa.hibernate.ddl-auto=create",
+    "spring.jpa.hibernate.ddl-auto=create-drop",
     "spring.jpa.show-sql=false",
-    "spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.PostgreSQLDialect",
     "external.riot.api-key=dummy"
 })
 class IngestControllerTest {

--- a/src/test/java/com/bestduo_BE/refresh/application/RefreshSummonerMatchesTest.java
+++ b/src/test/java/com/bestduo_BE/refresh/application/RefreshSummonerMatchesTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.verifyNoInteractions;
 
 import com.bestduo_BE.config.WorkItemProperties;
 import com.bestduo_BE.refresh.application.port.LeagueEntriesRefreshLoader;
+import com.bestduo_BE.common.application.PatchVersionService;
 import com.bestduo_BE.common.application.port.MatchIdsFinder;
 import com.bestduo_BE.common.application.port.MatchQueueEnqueuer;
 import com.bestduo_BE.refresh.application.port.SummonerRefreshStatusUpdater;
@@ -39,6 +40,9 @@ class RefreshSummonerMatchesTest {
   @Mock
   private SummonerRefreshStatusUpdater summonerRefreshStatusUpdater;
 
+  @Mock
+  private PatchVersionService patchVersionService;
+
   // 실제 인스턴스 사용 — 기본값(tierCacheTtlHours=12)으로 충분하며, 테스트 내 summoner는
   // 모두 tierObservedAt=null 이므로 캐시가 활성화되지 않아 기존 동작이 보존됨
   private final WorkItemProperties workItemProperties = new WorkItemProperties();
@@ -52,6 +56,7 @@ class RefreshSummonerMatchesTest {
         matchIdsFinder,
         matchQueueEnqueuer,
         summonerRefreshStatusUpdater,
+        patchVersionService,
         workItemProperties
     );
   }
@@ -77,6 +82,8 @@ class RefreshSummonerMatchesTest {
     given(summonerRefreshStatusUpdater.findOrCreate("p-new")).willReturn(summoner);
     given(leagueEntriesRefreshLoader.loadEntriesByPuuid("p-new"))
         .willReturn(List.of(new LeagueEntry("p-new", "EMERALD", "RANKED_SOLO_5x5", "I", 200L)));
+    given(patchVersionService.currentPatchStartTimeEpochSeconds()).willReturn(java.util.Optional.empty());
+    given(patchVersionService.currentPatchVersion()).willReturn(java.util.Optional.of("15.23"));
     given(matchIdsFinder.findRecentMatchIds("p-new", 50)).willReturn(List.of("m-1", "m-2"));
 
     long before = Instant.now().getEpochSecond();
@@ -84,7 +91,7 @@ class RefreshSummonerMatchesTest {
     long after = Instant.now().getEpochSecond();
 
     verify(summonerRefreshStatusUpdater).syncResolvedTier(org.mockito.ArgumentMatchers.eq("p-new"), org.mockito.ArgumentMatchers.eq(Tier.EMERALD), org.mockito.ArgumentMatchers.any(OffsetDateTime.class));
-    verify(matchQueueEnqueuer).enqueueAllIdempotent(List.of("m-1", "m-2"), Tier.EMERALD, 10);
+    verify(matchQueueEnqueuer).enqueueAllIdempotent(List.of("m-1", "m-2"), Tier.EMERALD, 10, "15.23");
     assertThat(result.matchIdsEnqueued()).isEqualTo(2);
     assertThat(result.collectionTier()).isEqualTo(Tier.EMERALD);
     assertThat(result.lastMatchStartTimeSec()).isBetween(before, after);
@@ -96,14 +103,32 @@ class RefreshSummonerMatchesTest {
     given(summonerRefreshStatusUpdater.findOrCreate("p-mid")).willReturn(summoner);
     given(leagueEntriesRefreshLoader.loadEntriesByPuuid("p-mid"))
         .willReturn(List.of(new LeagueEntry("p-mid", "DIAMOND", "RANKED_SOLO_5x5", "I", 30L)));
+    given(patchVersionService.currentPatchStartTimeEpochSeconds()).willReturn(java.util.Optional.of(1234L));
+    given(patchVersionService.currentPatchVersion()).willReturn(java.util.Optional.of("15.23"));
     given(matchIdsFinder.findMatchIdsSince("p-mid", 5678L, 50)).willReturn(List.of("m-42"));
 
     long before = Instant.now().getEpochSecond();
     RefreshSummonerMatches.Result result = useCase.execute("p-mid", Tier.DIAMOND);
     long after = Instant.now().getEpochSecond();
 
-    verify(matchQueueEnqueuer).enqueueAllIdempotent(List.of("m-42"), Tier.DIAMOND, 10);
+    verify(matchQueueEnqueuer).enqueueAllIdempotent(List.of("m-42"), Tier.DIAMOND, 10, "15.23");
     assertThat(result.lastMatchStartTimeSec()).isBetween(before, after);
+  }
+
+  @Test
+  void usePatchStartTimeWhenItIsNewerThanCursor() {
+    Summoner summoner = summoner("p-fresh", 1000L);
+    given(summonerRefreshStatusUpdater.findOrCreate("p-fresh")).willReturn(summoner);
+    given(leagueEntriesRefreshLoader.loadEntriesByPuuid("p-fresh"))
+        .willReturn(List.of(new LeagueEntry("p-fresh", "DIAMOND", "RANKED_SOLO_5x5", "I", 30L)));
+    given(patchVersionService.currentPatchStartTimeEpochSeconds()).willReturn(java.util.Optional.of(2000L));
+    given(patchVersionService.currentPatchVersion()).willReturn(java.util.Optional.of("15.23"));
+    given(matchIdsFinder.findMatchIdsSince("p-fresh", 2000L, 50)).willReturn(List.of("m-77"));
+
+    useCase.execute("p-fresh", Tier.DIAMOND);
+
+    verify(matchIdsFinder).findMatchIdsSince("p-fresh", 2000L, 50);
+    verify(matchQueueEnqueuer).enqueueAllIdempotent(List.of("m-77"), Tier.DIAMOND, 10, "15.23");
   }
 
   @Test
@@ -112,10 +137,12 @@ class RefreshSummonerMatchesTest {
     given(summonerRefreshStatusUpdater.findOrCreate("p-err")).willReturn(summoner);
     given(leagueEntriesRefreshLoader.loadEntriesByPuuid("p-err"))
         .willReturn(List.of(new LeagueEntry("p-err", "MASTER", "RANKED_SOLO_5x5", "I", 300L)));
+    given(patchVersionService.currentPatchStartTimeEpochSeconds()).willReturn(java.util.Optional.empty());
+    given(patchVersionService.currentPatchVersion()).willReturn(java.util.Optional.of("15.23"));
     given(matchIdsFinder.findRecentMatchIds("p-err", 50)).willReturn(List.of("m-err"));
     willThrow(new IllegalStateException("queue down"))
         .given(matchQueueEnqueuer)
-        .enqueueAllIdempotent(List.of("m-err"), Tier.MASTER, 10);
+        .enqueueAllIdempotent(List.of("m-err"), Tier.MASTER, 10, "15.23");
 
     IllegalStateException ex = assertThrows(IllegalStateException.class, () -> useCase.execute("p-err", Tier.MASTER));
     assertThat(ex).hasMessageContaining("queue down");

--- a/src/test/java/com/bestduo_BE/seed/application/SeedBootstrapExecutorTest.java
+++ b/src/test/java/com/bestduo_BE/seed/application/SeedBootstrapExecutorTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import com.bestduo_BE.seed.application.port.LeagueEntriesSeedLoader;
+import com.bestduo_BE.common.application.PatchVersionService;
 import com.bestduo_BE.common.application.port.MatchIdsFinder;
 import com.bestduo_BE.common.application.port.MatchQueueEnqueuer;
 import com.bestduo_BE.seed.application.port.SummonerSeedRegistry;
@@ -38,6 +39,9 @@ class SeedBootstrapExecutorTest {
   @Mock
   private SummonerSeedRegistry summonerSeedRegistry;
 
+  @Mock
+  private PatchVersionService patchVersionService;
+
   private SeedBootstrapExecutor useCase;
 
   private final SeedBootstrapCommand command = new SeedBootstrapCommand(
@@ -50,7 +54,8 @@ class SeedBootstrapExecutorTest {
         leagueEntriesSeedLoader,
         matchIdsFinder,
         matchQueueEnqueuer,
-        summonerSeedRegistry
+        summonerSeedRegistry,
+        patchVersionService
     );
   }
 
@@ -73,12 +78,14 @@ class SeedBootstrapExecutorTest {
     givenEntries(entries);
     given(summonerSeedRegistry.registerIfAbsent(eq("new-1"), any(Tier.class), any(OffsetDateTime.class))).willReturn(true);
     given(summonerSeedRegistry.registerIfAbsent(eq("existing"), any(Tier.class), any(OffsetDateTime.class))).willReturn(false);
-    given(matchIdsFinder.findRecentMatchIds("new-1", command.matchesPerPuuid()))
+    given(patchVersionService.currentPatchStartTimeEpochSeconds()).willReturn(java.util.Optional.of(1700000000L));
+    given(patchVersionService.currentPatchVersion()).willReturn(java.util.Optional.of("15.23"));
+    given(matchIdsFinder.findMatchIdsSince("new-1", 1700000000L, command.matchesPerPuuid()))
         .willReturn(List.of("m-1", "m-2"));
 
     SeedBootstrapExecutor.SeedBootstrapResult result = useCase.execute(command);
 
-    verify(matchQueueEnqueuer).enqueueAllIdempotent(List.of("m-1", "m-2"), Tier.MASTER, 50);
+    verify(matchQueueEnqueuer).enqueueAllIdempotent(List.of("m-1", "m-2"), Tier.MASTER, 50, "15.23");
     verify(matchIdsFinder, never()).findRecentMatchIds(eq("existing"), anyInt());
 
     assertThat(result.pagesProcessed()).isEqualTo(1);
@@ -92,7 +99,8 @@ class SeedBootstrapExecutorTest {
   void markSeedErrorWhenMatchLookupFails() {
     givenEntries(List.of(entry("p-error")));
     given(summonerSeedRegistry.registerIfAbsent(eq("p-error"), any(Tier.class), any(OffsetDateTime.class))).willReturn(true);
-    given(matchIdsFinder.findRecentMatchIds("p-error", command.matchesPerPuuid()))
+    given(patchVersionService.currentPatchStartTimeEpochSeconds()).willReturn(java.util.Optional.of(1700000000L));
+    given(matchIdsFinder.findMatchIdsSince("p-error", 1700000000L, command.matchesPerPuuid()))
         .willThrow(new IllegalStateException("boom"));
 
     SeedBootstrapExecutor.SeedBootstrapResult result = useCase.execute(command);
@@ -111,7 +119,8 @@ class SeedBootstrapExecutorTest {
         limited.queue(), limited.tier(), limited.division(), 1
     )).willReturn(entries);
     given(summonerSeedRegistry.registerIfAbsent(eq("new-1"), any(Tier.class), any(OffsetDateTime.class))).willReturn(true);
-    given(matchIdsFinder.findRecentMatchIds("new-1", limited.matchesPerPuuid()))
+    given(patchVersionService.currentPatchStartTimeEpochSeconds()).willReturn(java.util.Optional.of(1700000000L));
+    given(matchIdsFinder.findMatchIdsSince("new-1", 1700000000L, limited.matchesPerPuuid()))
         .willReturn(List.of("m-1"));
 
     SeedBootstrapExecutor.SeedBootstrapResult result = useCase.execute(limited);
@@ -120,6 +129,20 @@ class SeedBootstrapExecutorTest {
     verify(summonerSeedRegistry, never()).registerIfAbsent(eq("new-2"), any(Tier.class), any(OffsetDateTime.class));
     assertThat(result.entriesFetched()).isEqualTo(1);
     assertThat(result.puuidRegistered()).isEqualTo(1);
+  }
+
+  @Test
+  void fallBackToRecentMatchesWhenPatchStartTimeIsMissing() {
+    givenEntries(List.of(entry("new-1")));
+    given(summonerSeedRegistry.registerIfAbsent(eq("new-1"), any(Tier.class), any(OffsetDateTime.class))).willReturn(true);
+    given(patchVersionService.currentPatchStartTimeEpochSeconds()).willReturn(java.util.Optional.empty());
+    given(patchVersionService.currentPatchVersion()).willReturn(java.util.Optional.empty());
+    given(matchIdsFinder.findRecentMatchIds("new-1", command.matchesPerPuuid())).willReturn(List.of("m-9"));
+
+    useCase.execute(command);
+
+    verify(matchIdsFinder).findRecentMatchIds("new-1", command.matchesPerPuuid());
+    verify(matchQueueEnqueuer).enqueueAllIdempotent(List.of("m-9"), Tier.MASTER, 50, null);
   }
 
   private void givenEntries(List<LeagueEntry> entries) {

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,19 @@
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb;MODE=PostgreSQL;DB_CLOSE_DELAY=-1
+    username: sa
+    password:
+    driver-class-name: org.h2.Driver
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    show-sql: false
+
+external:
+  riot:
+    api-key: dummy
+    platform-base-url: https://kr.api.riotgames.com
+    regional-base-url: https://asia.api.riotgames.com
+
+work-item:
+  worker-enabled: false


### PR DESCRIPTION
## Summary

- **Phase 1**: PatchVersion 엔티티 인프라 신규 추가
  - `PatchVersion` JPA 엔티티 (`patch_version` 테이블)
  - `PatchVersionJpaRepository` (existsByPatch / findByPatch / findTopByOrderByReleasedAtDesc)
  - `PatchVersionService` (currentPatchStartTimeEpochSeconds / currentPatchVersion / registerIfAbsent)

- **Phase 2**: match_queue에 patch 컬럼 추가 + Match ID 조회 필터링
  - `MatchQueue.patch` 컬럼 추가 (nullable, 기존 행 호환)
  - `MatchQueueEnqueuer` / `MatchQueueEnqueuerImpl` — patch 파라미터 전달
  - `MatchQueueDispatcher.Item` — patch 필드 추가
  - `SeedBootstrapExecutor` — PatchVersionService 주입, startTime 필터링 + patch stamp
  - `RefreshSummonerMatches` — patchStart 하한 적용 + patch stamp

- **테스트 인프라 수정** (DB 호환성)
  - WorkItemJpaRepository / MatchQueueJpaRepository / IngestQueueStatsJpaRepository의 PostgreSQL 전용 `::interval` 캐스트를 H2/PG 공통 문법(`param * interval '1 minute'`)으로 교체
  - `src/test/resources/application.yml` 추가: H2 인메모리 기본 설정 + `work-item.worker-enabled=false`로 @PostConstruct 워커 기동 억제
  - `IngestControllerTest`: 불필요한 PostgreSQLDialect 강제 설정 제거

## Verification

```bash
./gradlew cleanTest test
# → BUILD SUCCESSFUL, 전체 테스트 통과
```

## Notes

- `application.yml` 로컬 수정분(Riot API key 등)과 `docs/` 파일은 의도적으로 미포함
- Phase 3~5는 후속 PR 예정