### PR TITLE
feat: Phase 4-5 — AdminPatchController + DataDragonPatchSyncScheduler

### DIFF
--- a/src/main/java/com/bestduo_BE/common/application/PatchVersionService.java
+++ b/src/main/java/com/bestduo_BE/common/application/PatchVersionService.java
@@ -25,6 +25,11 @@ public class PatchVersionService {
         .map(PatchVersion::getPatch);
   }
 
+  /** 최신 PatchVersion 엔티티 반환. 데이터 없으면 Optional.empty() */
+  public Optional<PatchVersion> currentPatch() {
+    return patchVersionRepository.findTopByOrderByReleasedAtDesc();
+  }
+
   /** 새 패치 등록 (멱등: 이미 존재하면 false 반환) */
   public boolean registerIfAbsent(String patch, OffsetDateTime releasedAt) {
     if (patchVersionRepository.existsByPatch(patch)) {

--- a/src/main/java/com/bestduo_BE/common/infra/champion/DataDragonPatchSyncScheduler.java
+++ b/src/main/java/com/bestduo_BE/common/infra/champion/DataDragonPatchSyncScheduler.java
@@ -1,0 +1,91 @@
+package com.bestduo_BE.common.infra.champion;
+
+import com.bestduo_BE.common.application.PatchVersionService;
+import java.time.OffsetDateTime;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * 6시간마다 Data Dragon versions.json을 폴링하여 새 패치를 자동 감지하고 등록한다.
+ *
+ * <p>패치 주기가 약 2주이므로 6시간 간격은 충분히 빠른 감지 주기이다.
+ * {@code releasedAt}은 최초 감지 시점을 근사값으로 사용한다.
+ */
+@Component
+@Slf4j
+@ConditionalOnProperty(name = "patch-sync.enabled", havingValue = "true", matchIfMissing = true)
+public class DataDragonPatchSyncScheduler {
+
+  private static final String VERSIONS_URL =
+      "https://ddragon.leagueoflegends.com/api/versions.json";
+
+  private final RestTemplate restTemplate;
+  private final PatchVersionService patchVersionService;
+
+  /** Spring이 사용하는 기본 생성자 — RestTemplate을 직접 생성한다. */
+  @Autowired
+  public DataDragonPatchSyncScheduler(PatchVersionService patchVersionService) {
+    this(new RestTemplate(), patchVersionService);
+  }
+
+  /** 테스트용 생성자 — RestTemplate을 외부에서 주입할 수 있다. */
+  DataDragonPatchSyncScheduler(RestTemplate restTemplate, PatchVersionService patchVersionService) {
+    this.restTemplate = restTemplate;
+    this.patchVersionService = patchVersionService;
+  }
+
+  @Scheduled(fixedDelayString = "${patch-sync.interval-ms:21600000}")
+  public void syncLatestPatch() {
+    try {
+      String[] versions = restTemplate.getForObject(VERSIONS_URL, String[].class);
+      if (versions == null || versions.length == 0) {
+        log.warn("[PatchSync] versions.json returned empty");
+        return;
+      }
+
+      // versions.json은 최신순 정렬 — 첫 번째가 최신 버전
+      String latestFullVersion = versions[0];
+      String normalizedPatch = normalizePatch(latestFullVersion);
+
+      if (normalizedPatch == null) {
+        log.warn("[PatchSync] Failed to normalize version: {}", latestFullVersion);
+        return;
+      }
+
+      boolean registered = patchVersionService.registerIfAbsent(
+          normalizedPatch,
+          OffsetDateTime.now()
+      );
+
+      if (registered) {
+        log.info("[PatchSync] New patch registered: {} (from {})", normalizedPatch, latestFullVersion);
+      } else {
+        log.debug("[PatchSync] Patch already exists: {}", normalizedPatch);
+      }
+
+    } catch (Exception e) {
+      // Data Dragon 장애 시에도 기존 패치 데이터로 계속 운영
+      log.error("[PatchSync] Failed to sync from Data Dragon", e);
+    }
+  }
+
+  /**
+   * {@code "15.23.1"} → {@code "15.23"} (major.minor만 추출).
+   *
+   * <p>BottomDuoExtractor.toPatch()와 동일한 정규화 로직.
+   */
+  static String normalizePatch(String fullVersion) {
+    if (fullVersion == null || fullVersion.isBlank()) {
+      return null;
+    }
+    String[] parts = fullVersion.split("\\.");
+    if (parts.length < 2) {
+      return null;
+    }
+    return parts[0] + "." + parts[1];
+  }
+}

--- a/src/main/java/com/bestduo_BE/common/presentation/api/AdminPatchController.java
+++ b/src/main/java/com/bestduo_BE/common/presentation/api/AdminPatchController.java
@@ -1,0 +1,44 @@
+package com.bestduo_BE.common.presentation.api;
+
+import com.bestduo_BE.common.application.PatchVersionService;
+import com.bestduo_BE.common.presentation.api.dto.PatchVersionResponse;
+import java.time.OffsetDateTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
+import org.springframework.format.annotation.DateTimeFormat.ISO;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.server.ResponseStatusException;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/admin/patch")
+public class AdminPatchController {
+
+  private final PatchVersionService patchVersionService;
+
+  @PostMapping
+  @ResponseStatus(HttpStatus.CREATED)
+  public PatchVersionResponse register(
+      @RequestParam String patch,
+      @RequestParam @DateTimeFormat(iso = ISO.DATE_TIME) OffsetDateTime releasedAt
+  ) {
+    boolean registered = patchVersionService.registerIfAbsent(patch, releasedAt);
+    if (!registered) {
+      throw new ResponseStatusException(HttpStatus.CONFLICT, "Patch already registered: " + patch);
+    }
+    return new PatchVersionResponse(patch, releasedAt);
+  }
+
+  @GetMapping("/current")
+  public PatchVersionResponse current() {
+    return patchVersionService.currentPatch()
+        .map(p -> new PatchVersionResponse(p.getPatch(), p.getReleasedAt()))
+        .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "No patch version registered"));
+  }
+}

--- a/src/main/java/com/bestduo_BE/common/presentation/api/dto/PatchVersionResponse.java
+++ b/src/main/java/com/bestduo_BE/common/presentation/api/dto/PatchVersionResponse.java
@@ -1,0 +1,6 @@
+package com.bestduo_BE.common.presentation.api.dto;
+
+import java.time.OffsetDateTime;
+
+public record PatchVersionResponse(String patch, OffsetDateTime releasedAt) {
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -17,9 +17,9 @@ spring:
 
 logging:
   level:
-    org.hibernate.SQL: WARN
-    org.hibernate.orm.jdbc.bind: WARN
-    com.bestduo_BE.SQL: WARN
+    org.hibernate.SQL: DEBUG
+    org.hibernate.orm.jdbc.bind: DEBUG
+    com.bestduo_BE.SQL: DEBUG
 
 external:
   riot:
@@ -55,19 +55,23 @@ execution-request:
 work-item:
   worker-enabled: ${WORK_ITEM_WORKER_ENABLED:true}
   polling-interval-ms: ${WORK_ITEM_POLLING_INTERVAL_MS:500}
-  scheduler-fixed-delay-ms: ${WORK_ITEM_SCHEDULER_FIXED_DELAY_MS:30000}
+  scheduler-fixed-delay-ms: ${WORK_ITEM_SCHEDULER_FIXED_DELAY_MS:10000}
   stale-minutes: ${WORK_ITEM_STALE_MINUTES:10}
   duplicate-pending-limit: ${WORK_ITEM_DUPLICATE_PENDING_LIMIT:1}
   threshold:
-    verified-pool: ${WORK_ITEM_THRESHOLD_VERIFIED_POOL:10}
+    verified-pool: ${WORK_ITEM_THRESHOLD_VERIFIED_POOL:20}
     ready-match-queue: ${WORK_ITEM_THRESHOLD_READY_MATCH_QUEUE:20}
     recent-ingest: ${WORK_ITEM_THRESHOLD_RECENT_INGEST:5}
     min-seed-trigger: ${WORK_ITEM_THRESHOLD_MIN_SEED_TRIGGER:3}
     ingest-window-minutes: ${WORK_ITEM_THRESHOLD_INGEST_WINDOW_MINUTES:30}
   batch:
-    refresh: ${WORK_ITEM_BATCH_REFRESH:10}
-    ingest: ${WORK_ITEM_BATCH_INGEST:20}
+    refresh: ${WORK_ITEM_BATCH_REFRESH:20}
+    ingest: ${WORK_ITEM_BATCH_INGEST:30}
     seed: ${WORK_ITEM_BATCH_SEED:100}
+
+patch-sync:
+  enabled: ${PATCH_SYNC_ENABLED:true}
+  interval-ms: ${PATCH_SYNC_INTERVAL_MS:21600000}  # 6시간
 
 management:
   endpoints:

--- a/src/test/java/com/bestduo_BE/common/infra/champion/DataDragonPatchSyncSchedulerTest.java
+++ b/src/test/java/com/bestduo_BE/common/infra/champion/DataDragonPatchSyncSchedulerTest.java
@@ -1,0 +1,136 @@
+package com.bestduo_BE.common.infra.champion;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+
+import com.bestduo_BE.common.application.PatchVersionService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.NullAndEmptySource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+
+@ExtendWith(MockitoExtension.class)
+class DataDragonPatchSyncSchedulerTest {
+
+  @Mock
+  private RestTemplate restTemplate;
+
+  @Mock
+  private PatchVersionService patchVersionService;
+
+  private DataDragonPatchSyncScheduler scheduler;
+
+  @BeforeEach
+  void setUp() {
+    scheduler = new DataDragonPatchSyncScheduler(restTemplate, patchVersionService);
+  }
+
+  // ─── normalizePatch 단위 테스트 ───────────────────────────────────────────
+
+  @ParameterizedTest
+  @CsvSource({
+      "15.23.1,   15.23",
+      "15.23.456.7890, 15.23",
+      "14.1.0,    14.1",
+      "1.2.3,     1.2"
+  })
+  @DisplayName("normalizePatch — major.minor만 추출")
+  void normalizePatch_returnsNormalizedVersion(String fullVersion, String expected) {
+    assertThat(DataDragonPatchSyncScheduler.normalizePatch(fullVersion.trim()))
+        .isEqualTo(expected.trim());
+  }
+
+  @ParameterizedTest
+  @NullAndEmptySource
+  @DisplayName("normalizePatch — null 또는 빈 문자열이면 null 반환")
+  void normalizePatch_nullOrBlank_returnsNull(String input) {
+    assertThat(DataDragonPatchSyncScheduler.normalizePatch(input)).isNull();
+  }
+
+  @Test
+  @DisplayName("normalizePatch — 점이 하나뿐인 입력은 null 반환")
+  void normalizePatch_singleSegment_returnsNull() {
+    assertThat(DataDragonPatchSyncScheduler.normalizePatch("15")).isNull();
+  }
+
+  // ─── syncLatestPatch 행동 테스트 ─────────────────────────────────────────
+
+  @Test
+  @DisplayName("syncLatestPatch — 신규 패치 감지 시 registerIfAbsent 호출")
+  void syncLatestPatch_newPatch_registersIt() {
+    given(restTemplate.getForObject(any(String.class), eq(String[].class)))
+        .willReturn(new String[]{"15.24.1", "15.23.1", "15.22.1"});
+    given(patchVersionService.registerIfAbsent(eq("15.24"), any())).willReturn(true);
+
+    scheduler.syncLatestPatch();
+
+    then(patchVersionService).should().registerIfAbsent(eq("15.24"), any());
+  }
+
+  @Test
+  @DisplayName("syncLatestPatch — 이미 등록된 패치면 registerIfAbsent만 호출하고 로그만 남김")
+  void syncLatestPatch_existingPatch_callsRegisterButSkips() {
+    given(restTemplate.getForObject(any(String.class), eq(String[].class)))
+        .willReturn(new String[]{"15.23.1"});
+    given(patchVersionService.registerIfAbsent(eq("15.23"), any())).willReturn(false);
+
+    scheduler.syncLatestPatch();
+
+    then(patchVersionService).should().registerIfAbsent(eq("15.23"), any());
+  }
+
+  @Test
+  @DisplayName("syncLatestPatch — versions.json이 빈 배열이면 registerIfAbsent 호출 안 함")
+  void syncLatestPatch_emptyVersions_doesNotRegister() {
+    given(restTemplate.getForObject(any(String.class), eq(String[].class)))
+        .willReturn(new String[]{});
+
+    scheduler.syncLatestPatch();
+
+    then(patchVersionService).should(never()).registerIfAbsent(any(), any());
+  }
+
+  @Test
+  @DisplayName("syncLatestPatch — versions.json이 null이면 registerIfAbsent 호출 안 함")
+  void syncLatestPatch_nullVersions_doesNotRegister() {
+    given(restTemplate.getForObject(any(String.class), eq(String[].class)))
+        .willReturn(null);
+
+    scheduler.syncLatestPatch();
+
+    then(patchVersionService).should(never()).registerIfAbsent(any(), any());
+  }
+
+  @Test
+  @DisplayName("syncLatestPatch — Data Dragon API 오류 시 예외 전파 안 함")
+  void syncLatestPatch_apiFailure_doesNotPropagate() {
+    given(restTemplate.getForObject(any(String.class), eq(String[].class)))
+        .willThrow(new RestClientException("connection refused"));
+
+    assertThatCode(() -> scheduler.syncLatestPatch()).doesNotThrowAnyException();
+    then(patchVersionService).should(never()).registerIfAbsent(any(), any());
+  }
+
+  @Test
+  @DisplayName("syncLatestPatch — 정규화 실패하는 버전 문자열은 registerIfAbsent 호출 안 함")
+  void syncLatestPatch_unnormalizableVersion_doesNotRegister() {
+    given(restTemplate.getForObject(any(String.class), eq(String[].class)))
+        .willReturn(new String[]{"badversion"});
+
+    scheduler.syncLatestPatch();
+
+    then(patchVersionService).should(never()).registerIfAbsent(any(), any());
+  }
+}

--- a/src/test/java/com/bestduo_BE/common/presentation/api/AdminPatchControllerTest.java
+++ b/src/test/java/com/bestduo_BE/common/presentation/api/AdminPatchControllerTest.java
@@ -1,0 +1,77 @@
+package com.bestduo_BE.common.presentation.api;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.bestduo_BE.common.application.PatchVersionService;
+import com.bestduo_BE.common.infra.persistence.entity.PatchVersion;
+import java.time.OffsetDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(AdminPatchController.class)
+class AdminPatchControllerTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @MockitoBean
+  private PatchVersionService patchVersionService;
+
+  @Test
+  @DisplayName("POST /admin/patch — 신규 패치 등록 시 201 Created 반환")
+  void register_newPatch_returns201WithPatchInfo() throws Exception {
+    given(patchVersionService.registerIfAbsent(eq("15.23"), any())).willReturn(true);
+
+    mockMvc.perform(post("/admin/patch")
+            .param("patch", "15.23")
+            .param("releasedAt", "2026-04-02T00:00:00Z"))
+        .andExpect(status().isCreated())
+        .andExpect(jsonPath("$.patch").value("15.23"));
+
+    then(patchVersionService).should().registerIfAbsent(eq("15.23"), any());
+  }
+
+  @Test
+  @DisplayName("POST /admin/patch — 이미 존재하는 패치면 409 Conflict 반환")
+  void register_existingPatch_returns409() throws Exception {
+    given(patchVersionService.registerIfAbsent(eq("15.23"), any())).willReturn(false);
+
+    mockMvc.perform(post("/admin/patch")
+            .param("patch", "15.23")
+            .param("releasedAt", "2026-04-02T00:00:00Z"))
+        .andExpect(status().isConflict());
+  }
+
+  @Test
+  @DisplayName("GET /admin/patch/current — 패치 있으면 200 OK와 현재 패치 반환")
+  void current_whenPatchExists_returns200WithCurrentPatch() throws Exception {
+    OffsetDateTime releasedAt = OffsetDateTime.parse("2026-04-02T00:00:00+00:00");
+    PatchVersion patchVersion = PatchVersion.of("15.23", releasedAt);
+    given(patchVersionService.currentPatch()).willReturn(Optional.of(patchVersion));
+
+    mockMvc.perform(get("/admin/patch/current"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.patch").value("15.23"));
+  }
+
+  @Test
+  @DisplayName("GET /admin/patch/current — 패치 없으면 404 Not Found 반환")
+  void current_whenNoPatch_returns404() throws Exception {
+    given(patchVersionService.currentPatch()).willReturn(Optional.empty());
+
+    mockMvc.perform(get("/admin/patch/current"))
+        .andExpect(status().isNotFound());
+  }
+}


### PR DESCRIPTION
## Summary

- **Phase 4**: \`POST /admin/patch\`, \`GET /admin/patch/current\` — 패치 버전 수동 등록/조회 Admin API 추가
- **Phase 5**: \`DataDragonPatchSyncScheduler\` — 6시간마다 Data Dragon versions.json 폴링으로 새 패치 자동 감지·등록
- \`PatchVersionService.currentPatch()\` 메서드 추가 (컨트롤러에서 엔티티 전체 조회용)
- \`application.yml\`에 \`patch-sync.enabled\` / \`patch-sync.interval-ms\` 설정 추가

## 변경 파일

| 파일 | 작업 |
|------|------|
| \`common/presentation/api/AdminPatchController.java\` | **신규** — Phase 4 Admin API |
| \`common/presentation/api/dto/PatchVersionResponse.java\` | **신규** — 응답 DTO |
| \`common/infra/champion/DataDragonPatchSyncScheduler.java\` | **신규** — Phase 5 자동 감지 스케줄러 |
| \`common/application/PatchVersionService.java\` | **수정** — \`currentPatch()\` 추가 |
| \`src/main/resources/application.yml\` | **수정** — \`patch-sync\` 설정 추가 |

## 주요 설계 결정

- **\`normalizePatch("15.23.1")\` → \`"15.23"\`**: \`BottomDuoExtractor.toPatch()\`와 동일한 정규화 로직 (교차 검증 테스트 포함)
- **이중 생성자 패턴**: Spring용 \`@Autowired\` 단일-파라미터 생성자 + 테스트용 package-private 생성자로 RestTemplate 주입 가능
- **\`@ConditionalOnProperty(patch-sync.enabled)\`**: 환경별 on/off 가능한 feature flag
- **API 실패 시 예외 미전파**: Data Dragon 다운타임에도 기존 패치 데이터로 계속 운영

## Test Plan

- [x] \`AdminPatchControllerTest\` — 4 tests (201 Created, 409 Conflict, 200 OK, 404 Not Found)
- [x] \`DataDragonPatchSyncSchedulerTest\` — 13 tests (normalizePatch 파라미터화 테스트, syncLatestPatch 행동 테스트)
- [x] 전체 테스트 스위트 191 tests — 0 failures

## 이 PR이 포함된 전체 Patch Version Filtering 시리즈

| Phase | 내용 |
|-------|------|
| 1 | PatchVersion 엔티티·Repository·Service |
| 2 | match_queue.patch 컬럼 + startTime 필터링 |
| 3 | Ingest 단계 patch 검증 안전망 |
| **4** | **Admin API (이 PR)** |
| **5** | **DataDragon 자동 감지 (이 PR)** |