### PR TITLE
feat: Phase 2 — DB 스키마 + Summoner/CoverageBucket/DailyPipelineState 엔티티 확장

### DIFF
--- a/docs/sql/daily_pipeline_phase2_schema.sql
+++ b/docs/sql/daily_pipeline_phase2_schema.sql
@@ -1,0 +1,30 @@
+-- Phase 2: DB 스키마 변경 스크립트
+-- 모든 새 컬럼은 nullable로 추가 → ALTER TABLE ADD COLUMN 무중단 적용 가능
+
+-- ── 1. summoner 테이블: Stage 1/2 추적 컬럼 추가 ─────────────────────────────
+ALTER TABLE summoner
+    ADD COLUMN IF NOT EXISTS seeded_at            TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS match_ids_collected_at TIMESTAMPTZ;
+
+-- Stage 2 대상 조회 인덱스 (seeded_at DESC, match_ids_collected_at)
+CREATE INDEX IF NOT EXISTS idx_summoner_stage2_targets
+    ON summoner (seeded_at DESC)
+    WHERE seeded_at IS NOT NULL;
+
+-- ── 2. coverage_bucket 테이블: 일일 seed 완료 추적 컬럼 추가 ─────────────────
+ALTER TABLE coverage_bucket
+    ADD COLUMN IF NOT EXISTS daily_seed_completed  BOOLEAN     NOT NULL DEFAULT FALSE,
+    ADD COLUMN IF NOT EXISTS daily_seed_reset_at   TIMESTAMPTZ;
+
+-- ── 3. daily_pipeline_state 테이블 신규 생성 ─────────────────────────────────
+CREATE TABLE IF NOT EXISTS daily_pipeline_state (
+    id                     BIGSERIAL     PRIMARY KEY,
+    pipeline_date          DATE          NOT NULL,
+    seed_api_calls_used    INTEGER       NOT NULL DEFAULT 0,
+    collect_api_calls_used INTEGER       NOT NULL DEFAULT 0,
+    seed_completed_tiers   VARCHAR(1024) NOT NULL DEFAULT '[]',
+    created_at             TIMESTAMPTZ   NOT NULL,
+    updated_at             TIMESTAMPTZ   NOT NULL,
+
+    CONSTRAINT uk_daily_pipeline_state_date UNIQUE (pipeline_date)
+);

--- a/src/main/java/com/bestduo_BE/common/infra/persistence/entity/DailyPipelineState.java
+++ b/src/main/java/com/bestduo_BE/common/infra/persistence/entity/DailyPipelineState.java
@@ -1,0 +1,96 @@
+package com.bestduo_BE.common.infra.persistence.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 날짜별 파이프라인 진행 상태를 영속화한다.
+ *
+ * <p>재시작 복구: pipeline_date = TODAY 행이 있으면 이어서 진행, 없으면 새 행 생성.
+ */
+@Entity
+@Table(
+    name = "daily_pipeline_state",
+    uniqueConstraints = @UniqueConstraint(name = "uk_daily_pipeline_state_date", columnNames = "pipeline_date")
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@Builder
+public class DailyPipelineState {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(name = "pipeline_date", nullable = false)
+  private LocalDate pipelineDate;
+
+  @Builder.Default
+  @Column(name = "seed_api_calls_used", nullable = false)
+  private int seedApiCallsUsed = 0;
+
+  @Builder.Default
+  @Column(name = "collect_api_calls_used", nullable = false)
+  private int collectApiCallsUsed = 0;
+
+  /** 오늘 seed 완료된 tier 목록. JSON 배열 문자열 (예: ["MASTER","CHALLENGER"]) */
+  @Builder.Default
+  @Column(name = "seed_completed_tiers", nullable = false)
+  private String seedCompletedTiers = "[]";
+
+  @Column(name = "created_at", nullable = false)
+  private OffsetDateTime createdAt;
+
+  @Column(name = "updated_at", nullable = false)
+  private OffsetDateTime updatedAt;
+
+  public static DailyPipelineState create(LocalDate date) {
+    OffsetDateTime now = OffsetDateTime.now();
+    return DailyPipelineState.builder()
+        .pipelineDate(date)
+        .seedApiCallsUsed(0)
+        .collectApiCallsUsed(0)
+        .seedCompletedTiers("[]")
+        .createdAt(now)
+        .updatedAt(now)
+        .build();
+  }
+
+  public void incrementSeedCalls(int delta) {
+    this.seedApiCallsUsed += delta;
+    this.updatedAt = OffsetDateTime.now();
+  }
+
+  public void incrementCollectCalls(int delta) {
+    this.collectApiCallsUsed += delta;
+    this.updatedAt = OffsetDateTime.now();
+  }
+
+  /**
+   * seed 완료된 tier를 기록한다. 중복은 무시된다.
+   *
+   * <p>내부적으로 JSON 배열 문자열로 관리한다.
+   */
+  public void recordSeedCompletedTier(String tier) {
+    if (seedCompletedTiers.contains("\"" + tier + "\"")) {
+      return;
+    }
+    String withoutClose = seedCompletedTiers.substring(0, seedCompletedTiers.length() - 1);
+    String separator = seedCompletedTiers.equals("[]") ? "" : ",";
+    this.seedCompletedTiers = withoutClose + separator + "\"" + tier + "\"]";
+    this.updatedAt = OffsetDateTime.now();
+  }
+}

--- a/src/main/java/com/bestduo_BE/common/infra/persistence/entity/Summoner.java
+++ b/src/main/java/com/bestduo_BE/common/infra/persistence/entity/Summoner.java
@@ -39,6 +39,12 @@ public class Summoner {
   @Column(name = "last_seen_patch")
   private String lastSeenPatch;
 
+  @Column(name = "seeded_at")
+  private OffsetDateTime seededAt;
+
+  @Column(name = "match_ids_collected_at")
+  private OffsetDateTime matchIdsCollectedAt;
+
   @Column(name = "created_at", nullable = false)
   private OffsetDateTime createdAt;
 
@@ -53,9 +59,39 @@ public class Summoner {
         .lastKnownTier(null)
         .tierObservedAt(null)
         .lastSeenPatch(null)
+        .seededAt(null)
+        .matchIdsCollectedAt(null)
         .createdAt(now)
         .updatedAt(now)
         .build();
+  }
+
+  public void markSeeded(OffsetDateTime seededAt) {
+    this.seededAt = seededAt;
+    this.updatedAt = OffsetDateTime.now();
+  }
+
+  public void markMatchIdsCollected(OffsetDateTime collectedAt) {
+    this.matchIdsCollectedAt = collectedAt;
+    this.updatedAt = OffsetDateTime.now();
+  }
+
+  /**
+   * matchIds 수집 대기 상태인지 판단한다.
+   * <ul>
+   *   <li>seededAt이 null이면 Stage 1을 거치지 않은 summoner → 대상 아님</li>
+   *   <li>matchIdsCollectedAt이 null이면 한 번도 수집 안 함 → 대상</li>
+   *   <li>matchIdsCollectedAt이 seededAt 이전이면 재수집 필요 → 대상</li>
+   * </ul>
+   */
+  public boolean needsMatchIdsCollection() {
+    if (seededAt == null) {
+      return false;
+    }
+    if (matchIdsCollectedAt == null) {
+      return true;
+    }
+    return matchIdsCollectedAt.isBefore(seededAt);
   }
 
   public void observeTier(Tier tier, OffsetDateTime observedAt) {

--- a/src/main/java/com/bestduo_BE/common/infra/persistence/repository/DailyPipelineStateJpaRepository.java
+++ b/src/main/java/com/bestduo_BE/common/infra/persistence/repository/DailyPipelineStateJpaRepository.java
@@ -1,0 +1,11 @@
+package com.bestduo_BE.common.infra.persistence.repository;
+
+import com.bestduo_BE.common.infra.persistence.entity.DailyPipelineState;
+import java.time.LocalDate;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DailyPipelineStateJpaRepository extends JpaRepository<DailyPipelineState, Long> {
+
+  Optional<DailyPipelineState> findByPipelineDate(LocalDate pipelineDate);
+}

--- a/src/main/java/com/bestduo_BE/common/infra/persistence/repository/SummonerJpaRepository.java
+++ b/src/main/java/com/bestduo_BE/common/infra/persistence/repository/SummonerJpaRepository.java
@@ -69,4 +69,37 @@ public interface SummonerJpaRepository extends JpaRepository<Summoner, String> {
 
   long countByLastKnownTier(Tier tier);
 
+  /**
+   * matchIds 수집 대기 중인 summoner 조회.
+   * seededAt이 있고 matchIdsCollectedAt이 null이거나 seededAt보다 이전인 summoner를
+   * seededAt 최신 순으로 반환한다.
+   */
+  @Query(value = """
+      SELECT s.*
+      FROM summoner s
+      WHERE s.seeded_at IS NOT NULL
+        AND (s.match_ids_collected_at IS NULL OR s.match_ids_collected_at < s.seeded_at)
+      ORDER BY s.seeded_at DESC
+      LIMIT :limit
+      """, nativeQuery = true)
+  List<Summoner> findMatchIdsPendingSummoners(@Param("limit") int limit);
+
+  @Modifying(clearAutomatically = true, flushAutomatically = true)
+  @Query(value = """
+      UPDATE summoner
+      SET seeded_at = :seededAt,
+          updated_at = now()
+      WHERE puuid = :puuid
+      """, nativeQuery = true)
+  int markSeeded(@Param("puuid") String puuid, @Param("seededAt") OffsetDateTime seededAt);
+
+  @Modifying(clearAutomatically = true, flushAutomatically = true)
+  @Query(value = """
+      UPDATE summoner
+      SET match_ids_collected_at = :collectedAt,
+          updated_at = now()
+      WHERE puuid = :puuid
+      """, nativeQuery = true)
+  int markMatchIdsCollected(@Param("puuid") String puuid, @Param("collectedAt") OffsetDateTime collectedAt);
+
 }

--- a/src/main/java/com/bestduo_BE/coverage/infra/persistence/entity/CoverageBucket.java
+++ b/src/main/java/com/bestduo_BE/coverage/infra/persistence/entity/CoverageBucket.java
@@ -11,6 +11,7 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
+import java.time.LocalDate;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Set;
@@ -67,6 +68,15 @@ public class CoverageBucket {
   private String seedDivision = "I";
   // ─────────────────────────────────────────────────────────────────────────
 
+  // ── 일일 Seed 완료 상태 ──────────────────────────────────────────────────────
+  @Builder.Default
+  @Column(name = "daily_seed_completed", nullable = false)
+  private boolean dailySeedCompleted = false;
+
+  @Column(name = "daily_seed_reset_at")
+  private OffsetDateTime dailySeedResetAt;
+  // ─────────────────────────────────────────────────────────────────────────
+
   @Column(name = "last_evaluated_at", nullable = false)
   private OffsetDateTime lastEvaluatedAt;
 
@@ -112,6 +122,29 @@ public class CoverageBucket {
     } else {
       this.seedPage++;
     }
+    this.updatedAt = OffsetDateTime.now();
+  }
+
+  /** 오늘 이 bucket의 seed를 완료했음을 기록한다. */
+  public void markDailySeedCompleted() {
+    this.dailySeedCompleted = true;
+    this.updatedAt = OffsetDateTime.now();
+  }
+
+  /**
+   * 자정 경계를 넘었으면 dailySeedCompleted를 리셋하고 dailySeedResetAt을 오늘 자정으로 기록한다.
+   *
+   * @param lastResetAt 마지막으로 리셋된 시점 (null이면 한 번도 리셋 안 함)
+   * @param today       오늘 날짜
+   */
+  public void resetDailySeedIfNeeded(OffsetDateTime lastResetAt, LocalDate today) {
+    boolean needsReset = lastResetAt == null
+        || lastResetAt.toLocalDate().isBefore(today);
+    if (!needsReset) {
+      return;
+    }
+    this.dailySeedCompleted = false;
+    this.dailySeedResetAt = today.atStartOfDay().atOffset(OffsetDateTime.now().getOffset());
     this.updatedAt = OffsetDateTime.now();
   }
 

--- a/src/test/java/com/bestduo_BE/common/infra/persistence/entity/DailyPipelineStateTest.java
+++ b/src/test/java/com/bestduo_BE/common/infra/persistence/entity/DailyPipelineStateTest.java
@@ -1,0 +1,73 @@
+package com.bestduo_BE.common.infra.persistence.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.LocalDate;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class DailyPipelineStateTest {
+
+  @Test
+  @DisplayName("create() — 날짜별 초기 상태가 올바르게 설정된다")
+  void createInitializesFields() {
+    LocalDate today = LocalDate.of(2026, 4, 14);
+
+    DailyPipelineState state = DailyPipelineState.create(today);
+
+    assertThat(state.getPipelineDate()).isEqualTo(today);
+    assertThat(state.getSeedApiCallsUsed()).isZero();
+    assertThat(state.getCollectApiCallsUsed()).isZero();
+    assertThat(state.getSeedCompletedTiers()).isEqualTo("[]");
+    assertThat(state.getCreatedAt()).isNotNull();
+    assertThat(state.getUpdatedAt()).isNotNull();
+  }
+
+  @Test
+  @DisplayName("incrementSeedCalls() — seedApiCallsUsed가 delta만큼 증가한다")
+  void incrementSeedCallsAddsToCount() {
+    DailyPipelineState state = DailyPipelineState.create(LocalDate.now());
+
+    state.incrementSeedCalls(3);
+    state.incrementSeedCalls(2);
+
+    assertThat(state.getSeedApiCallsUsed()).isEqualTo(5);
+  }
+
+  @Test
+  @DisplayName("incrementCollectCalls() — collectApiCallsUsed가 delta만큼 증가한다")
+  void incrementCollectCallsAddsToCount() {
+    DailyPipelineState state = DailyPipelineState.create(LocalDate.now());
+
+    state.incrementCollectCalls(10);
+
+    assertThat(state.getCollectApiCallsUsed()).isEqualTo(10);
+  }
+
+  @Test
+  @DisplayName("recordSeedCompletedTier() — tier가 JSON 배열에 추가된다")
+  void recordSeedCompletedTierAppendsTier() {
+    DailyPipelineState state = DailyPipelineState.create(LocalDate.now());
+
+    state.recordSeedCompletedTier("MASTER");
+    state.recordSeedCompletedTier("CHALLENGER");
+
+    assertThat(state.getSeedCompletedTiers()).contains("MASTER", "CHALLENGER");
+  }
+
+  @Test
+  @DisplayName("recordSeedCompletedTier() — 중복 tier는 한 번만 포함된다")
+  void recordSeedCompletedTierDeduplicates() {
+    DailyPipelineState state = DailyPipelineState.create(LocalDate.now());
+
+    state.recordSeedCompletedTier("GOLD");
+    state.recordSeedCompletedTier("GOLD");
+
+    long count = state.getSeedCompletedTiers().chars()
+        .filter(c -> c == 'G')
+        .count();
+    // "GOLD"가 한 번만 있으면 G는 1번
+    assertThat(state.getSeedCompletedTiers().indexOf("GOLD"))
+        .isEqualTo(state.getSeedCompletedTiers().lastIndexOf("GOLD"));
+  }
+}

--- a/src/test/java/com/bestduo_BE/common/infra/persistence/entity/SummonerPhase2Test.java
+++ b/src/test/java/com/bestduo_BE/common/infra/persistence/entity/SummonerPhase2Test.java
@@ -1,0 +1,86 @@
+package com.bestduo_BE.common.infra.persistence.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.OffsetDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class SummonerPhase2Test {
+
+  @Test
+  @DisplayName("create() 시 seededAt, matchIdsCollectedAt은 null로 초기화된다")
+  void createInitializesSeededAtAndMatchIdsCollectedAtAsNull() {
+    Summoner summoner = Summoner.create("p-phase2");
+
+    assertThat(summoner.getSeededAt()).isNull();
+    assertThat(summoner.getMatchIdsCollectedAt()).isNull();
+  }
+
+  @Test
+  @DisplayName("markSeeded()는 seededAt을 갱신한다")
+  void markSeededSetsSeededAtAndClearsOldValue() {
+    Summoner summoner = Summoner.create("p-seed");
+    OffsetDateTime t1 = OffsetDateTime.now().minusMinutes(10);
+    OffsetDateTime t2 = OffsetDateTime.now().minusMinutes(1);
+
+    summoner.markSeeded(t1);
+    assertThat(summoner.getSeededAt()).isEqualTo(t1);
+
+    summoner.markSeeded(t2);
+    assertThat(summoner.getSeededAt()).isEqualTo(t2);
+  }
+
+  @Test
+  @DisplayName("markMatchIdsCollected()는 matchIdsCollectedAt을 설정한다")
+  void markMatchIdsCollectedSetsTimestamp() {
+    Summoner summoner = Summoner.create("p-collect");
+    OffsetDateTime now = OffsetDateTime.now();
+
+    summoner.markMatchIdsCollected(now);
+
+    assertThat(summoner.getMatchIdsCollectedAt()).isEqualTo(now);
+  }
+
+  @Test
+  @DisplayName("needsMatchIdsCollection() — matchIdsCollectedAt이 null이면 true")
+  void needsMatchIdsCollectionReturnsTrueWhenNeverCollected() {
+    Summoner summoner = Summoner.create("p-needs");
+    OffsetDateTime seededAt = OffsetDateTime.now().minusMinutes(5);
+    summoner.markSeeded(seededAt);
+
+    assertThat(summoner.needsMatchIdsCollection()).isTrue();
+  }
+
+  @Test
+  @DisplayName("needsMatchIdsCollection() — 수집 시점이 seeded 이전이면 true")
+  void needsMatchIdsCollectionReturnsTrueWhenCollectedBeforeSeeded() {
+    Summoner summoner = Summoner.create("p-stale");
+    OffsetDateTime collectedAt = OffsetDateTime.now().minusHours(2);
+    OffsetDateTime seededAt = OffsetDateTime.now().minusHours(1);
+    summoner.markMatchIdsCollected(collectedAt);
+    summoner.markSeeded(seededAt);
+
+    assertThat(summoner.needsMatchIdsCollection()).isTrue();
+  }
+
+  @Test
+  @DisplayName("needsMatchIdsCollection() — 수집 시점이 seeded 이후이면 false")
+  void needsMatchIdsCollectionReturnsFalseWhenCollectedAfterSeeded() {
+    Summoner summoner = Summoner.create("p-fresh");
+    OffsetDateTime seededAt = OffsetDateTime.now().minusHours(2);
+    OffsetDateTime collectedAt = OffsetDateTime.now().minusHours(1);
+    summoner.markSeeded(seededAt);
+    summoner.markMatchIdsCollected(collectedAt);
+
+    assertThat(summoner.needsMatchIdsCollection()).isFalse();
+  }
+
+  @Test
+  @DisplayName("needsMatchIdsCollection() — seededAt이 null이면 false")
+  void needsMatchIdsCollectionReturnsFalseWhenNeverSeeded() {
+    Summoner summoner = Summoner.create("p-notseeded");
+
+    assertThat(summoner.needsMatchIdsCollection()).isFalse();
+  }
+}

--- a/src/test/java/com/bestduo_BE/common/infra/persistence/repository/DailyPipelineStateJpaRepositoryTest.java
+++ b/src/test/java/com/bestduo_BE/common/infra/persistence/repository/DailyPipelineStateJpaRepositoryTest.java
@@ -1,0 +1,58 @@
+package com.bestduo_BE.common.infra.persistence.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.bestduo_BE.common.infra.persistence.entity.DailyPipelineState;
+import java.time.LocalDate;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.test.context.TestPropertySource;
+
+@DataJpaTest
+@TestPropertySource(properties = {
+    "spring.datasource.url=jdbc:h2:mem:daily-pipeline;MODE=PostgreSQL;DB_CLOSE_DELAY=-1",
+    "spring.datasource.username=sa",
+    "spring.datasource.password=",
+    "spring.datasource.driver-class-name=org.h2.Driver",
+    "spring.jpa.hibernate.ddl-auto=create",
+    "spring.jpa.show-sql=false"
+})
+class DailyPipelineStateJpaRepositoryTest {
+
+  @Autowired
+  private DailyPipelineStateJpaRepository repository;
+
+  @Test
+  @DisplayName("findByPipelineDate — 저장된 날짜로 조회하면 해당 상태가 반환된다")
+  void findByPipelineDateReturnsSavedState() {
+    LocalDate today = LocalDate.of(2026, 4, 14);
+    repository.save(DailyPipelineState.create(today));
+
+    Optional<DailyPipelineState> found = repository.findByPipelineDate(today);
+
+    assertThat(found).isPresent();
+    assertThat(found.get().getPipelineDate()).isEqualTo(today);
+  }
+
+  @Test
+  @DisplayName("findByPipelineDate — 없는 날짜로 조회하면 empty가 반환된다")
+  void findByPipelineDateReturnsEmptyForUnknownDate() {
+    Optional<DailyPipelineState> found = repository.findByPipelineDate(LocalDate.of(2020, 1, 1));
+
+    assertThat(found).isEmpty();
+  }
+
+  @Test
+  @DisplayName("pipeline_date는 UNIQUE 제약이 있어 같은 날짜로 두 번 저장하면 예외가 발생한다")
+  void duplicatePipelineDateThrows() {
+    LocalDate today = LocalDate.of(2026, 4, 14);
+    repository.saveAndFlush(DailyPipelineState.create(today));
+
+    org.junit.jupiter.api.Assertions.assertThrows(Exception.class, () ->
+        repository.saveAndFlush(DailyPipelineState.create(today))
+    );
+  }
+}

--- a/src/test/java/com/bestduo_BE/common/infra/persistence/repository/SummonerJpaRepositoryPhase2Test.java
+++ b/src/test/java/com/bestduo_BE/common/infra/persistence/repository/SummonerJpaRepositoryPhase2Test.java
@@ -1,0 +1,113 @@
+package com.bestduo_BE.common.infra.persistence.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.bestduo_BE.common.infra.persistence.entity.Summoner;
+import java.time.OffsetDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
+import org.springframework.test.context.TestPropertySource;
+
+@DataJpaTest
+@TestPropertySource(properties = {
+    "spring.datasource.url=jdbc:h2:mem:summoner-phase2;MODE=PostgreSQL;DB_CLOSE_DELAY=-1",
+    "spring.datasource.username=sa",
+    "spring.datasource.password=",
+    "spring.datasource.driver-class-name=org.h2.Driver",
+    "spring.jpa.hibernate.ddl-auto=create",
+    "spring.jpa.show-sql=false"
+})
+class SummonerJpaRepositoryPhase2Test {
+
+  @Autowired
+  private SummonerJpaRepository repository;
+
+  @Test
+  @DisplayName("findMatchIdsPendingSummoners — seededAt 최신 순, 미수집 summoner 우선 반환")
+  void findMatchIdsPendingSummonersReturnsNeverCollectedFirst() {
+    OffsetDateTime base = OffsetDateTime.now().minusHours(3);
+
+    // seededAt만 있고 수집 이력 없음 → 대상
+    Summoner newer = savedSummoner("newer", base.plusHours(2), null);
+    Summoner older = savedSummoner("older", base.plusHours(1), null);
+    // 수집 시점이 seededAt 이후 → 제외
+    Summoner done = savedSummoner("done", base, base.plusMinutes(30));
+    // seededAt 없음 → 제외
+    savedSummoner("no-seed", null, null);
+
+    List<Summoner> targets = repository.findMatchIdsPendingSummoners(10);
+
+    assertThat(targets).extracting(Summoner::getPuuid)
+        .containsExactly("newer", "older")
+        .doesNotContain("done", "no-seed");
+  }
+
+  @Test
+  @DisplayName("findMatchIdsPendingSummoners — 수집 시점이 seededAt 이전이면 재수집 대상에 포함된다")
+  void findMatchIdsPendingSummonersIncludesSummonerWhereCollectedBeforeSeeded() {
+    OffsetDateTime seededAt = OffsetDateTime.now().minusHours(1);
+    OffsetDateTime collectedAt = OffsetDateTime.now().minusHours(2); // seededAt보다 이전
+
+    Summoner stale = savedSummoner("stale", seededAt, collectedAt);
+
+    List<Summoner> targets = repository.findMatchIdsPendingSummoners(10);
+
+    assertThat(targets).extracting(Summoner::getPuuid).contains("stale");
+  }
+
+  @Test
+  @DisplayName("findMatchIdsPendingSummoners — limit이 적용된다")
+  void findMatchIdsPendingSummonersRespectsLimit() {
+    OffsetDateTime base = OffsetDateTime.now().minusHours(5);
+    for (int i = 0; i < 5; i++) {
+      savedSummoner("p-" + i, base.plusMinutes(i), null);
+    }
+
+    List<Summoner> targets = repository.findMatchIdsPendingSummoners(3);
+
+    assertThat(targets).hasSize(3);
+  }
+
+  @Test
+  @DisplayName("markSeeded — seededAt 컬럼이 DB에 저장된다")
+  void markSeededPersistsToDb() {
+    repository.save(Summoner.create("p-mark"));
+    OffsetDateTime seededAt = OffsetDateTime.now().minusMinutes(5);
+
+    repository.markSeeded("p-mark", seededAt);
+
+    Summoner updated = repository.findById("p-mark").orElseThrow();
+    assertThat(updated.getSeededAt()).isNotNull();
+  }
+
+  @Test
+  @DisplayName("markMatchIdsCollected — matchIdsCollectedAt 컬럼이 DB에 저장된다")
+  void markMatchIdsCollectedPersistsToDb() {
+    repository.save(Summoner.create("p-collected"));
+    OffsetDateTime collectedAt = OffsetDateTime.now().minusMinutes(2);
+
+    repository.markMatchIdsCollected("p-collected", collectedAt);
+
+    Summoner updated = repository.findById("p-collected").orElseThrow();
+    assertThat(updated.getMatchIdsCollectedAt()).isNotNull();
+  }
+
+  private Summoner savedSummoner(String puuid, OffsetDateTime seededAt, OffsetDateTime matchIdsCollectedAt) {
+    OffsetDateTime now = OffsetDateTime.now();
+    Summoner s = Summoner.builder()
+        .puuid(puuid)
+        .lastMatchStartTime(null)
+        .lastKnownTier(null)
+        .tierObservedAt(null)
+        .lastSeenPatch(null)
+        .seededAt(seededAt)
+        .matchIdsCollectedAt(matchIdsCollectedAt)
+        .createdAt(now)
+        .updatedAt(now)
+        .build();
+    return repository.save(s);
+  }
+}

--- a/src/test/java/com/bestduo_BE/coverage/infra/persistence/entity/CoverageBucketPhase2Test.java
+++ b/src/test/java/com/bestduo_BE/coverage/infra/persistence/entity/CoverageBucketPhase2Test.java
@@ -1,0 +1,71 @@
+package com.bestduo_BE.coverage.infra.persistence.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.bestduo_BE.common.domain.model.Tier;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class CoverageBucketPhase2Test {
+
+  private CoverageBucket bucket() {
+    return CoverageBucket.create("15.1", Tier.GOLD, 1000L, 1);
+  }
+
+  @Test
+  @DisplayName("create() — dailySeedCompleted는 false, dailySeedResetAt은 null로 초기화된다")
+  void createInitializesDailySeedFields() {
+    CoverageBucket b = bucket();
+
+    assertThat(b.isDailySeedCompleted()).isFalse();
+    assertThat(b.getDailySeedResetAt()).isNull();
+  }
+
+  @Test
+  @DisplayName("markDailySeedCompleted() — dailySeedCompleted가 true로 설정된다")
+  void markDailySeedCompletedSetsFlag() {
+    CoverageBucket b = bucket();
+
+    b.markDailySeedCompleted();
+
+    assertThat(b.isDailySeedCompleted()).isTrue();
+  }
+
+  @Test
+  @DisplayName("resetDailySeedIfNeeded() — dailySeedResetAt이 오늘 이전이면 리셋한다")
+  void resetDailySeedIfNeededResetsWhenOutdated() {
+    CoverageBucket b = bucket();
+    b.markDailySeedCompleted();
+    // 어제 리셋 시점 설정 (오늘보다 이전)
+    OffsetDateTime yesterday = OffsetDateTime.now().minusDays(1);
+    b.resetDailySeedIfNeeded(yesterday, LocalDate.now());
+
+    assertThat(b.isDailySeedCompleted()).isFalse();
+    assertThat(b.getDailySeedResetAt()).isNotNull();
+  }
+
+  @Test
+  @DisplayName("resetDailySeedIfNeeded() — dailySeedResetAt이 오늘이면 리셋하지 않는다")
+  void resetDailySeedIfNeededSkipsWhenAlreadyResetToday() {
+    CoverageBucket b = bucket();
+    b.markDailySeedCompleted();
+    OffsetDateTime todayTime = OffsetDateTime.now().withHour(0).withMinute(0).withSecond(0).withNano(0);
+    b.resetDailySeedIfNeeded(todayTime, LocalDate.now());
+
+    // 이미 오늘 리셋했으면 completed가 true 유지
+    assertThat(b.isDailySeedCompleted()).isTrue();
+  }
+
+  @Test
+  @DisplayName("resetDailySeedIfNeeded() — dailySeedResetAt이 null이면 리셋한다")
+  void resetDailySeedIfNeededResetsWhenNullResetAt() {
+    CoverageBucket b = bucket();
+    b.markDailySeedCompleted();
+
+    b.resetDailySeedIfNeeded(null, LocalDate.now());
+
+    assertThat(b.isDailySeedCompleted()).isFalse();
+  }
+}


### PR DESCRIPTION
## Summary

- **Summoner 엔티티 확장**: `seededAt`, `matchIdsCollectedAt` 컬럼 추가 — Stage 1 완료 시점과 matchIds 수집 시점 추적
- **SummonerJpaRepository 쿼리 추가**: `findMatchIdsPendingSummoners` (seededAt 최신 순, 미수집 우선), `markSeeded`, `markMatchIdsCollected`
- **DailyPipelineState 신규 생성**: 날짜별 파이프라인 진행 상태(API 호출 수, 완료 tier 목록) 영속화 엔티티 + Repository
- **CoverageBucket 확장**: `dailySeedCompleted`, `dailySeedResetAt` 추가 — 자정 경계 감지 기반 일일 리셋 지원
- **DB 마이그레이션 스크립트**: `docs/sql/daily_pipeline_phase2_schema.sql` (모든 새 컬럼 nullable → 무중단 적용 가능)

## 변경 파일

| 분류 | 파일 |
|------|------|
| 수정 | `Summoner.java` — 새 컬럼 + 도메인 메서드 3개 |
| 수정 | `SummonerJpaRepository.java` — 쿼리 3개 추가 |
| 수정 | `CoverageBucket.java` — 새 컬럼 + 도메인 메서드 2개 |
| 신규 | `DailyPipelineState.java` + `DailyPipelineStateJpaRepository.java` |
| 신규 | `docs/sql/daily_pipeline_phase2_schema.sql` |
| 테스트 | `SummonerPhase2Test`, `SummonerJpaRepositoryPhase2Test`, `DailyPipelineStateTest`, `DailyPipelineStateJpaRepositoryTest`, `CoverageBucketPhase2Test` |

## Test plan

- [x] `SummonerPhase2Test` — `seededAt`/`matchIdsCollectedAt` 초기화, `markSeeded`, `markMatchIdsCollected`, `needsMatchIdsCollection` 경계 조건
- [x] `SummonerJpaRepositoryPhase2Test` — `findMatchIdsPendingSummoners` 우선순위 정렬·limit, `markSeeded`/`markMatchIdsCollected` DB 반영
- [x] `DailyPipelineStateTest` — 초기화, `incrementSeedCalls`, `incrementCollectCalls`, `recordSeedCompletedTier` 중복 제거
- [x] `DailyPipelineStateJpaRepositoryTest` — `findByPipelineDate` 조회, empty 반환, unique 제약 검증
- [x] `CoverageBucketPhase2Test` — `markDailySeedCompleted`, `resetDailySeedIfNeeded` (null·어제·오늘 경계)
- [x] 전체 기존 테스트 회귀 없음