### PR TITLE
feat: Stage 3 priority tier 환경 변수 설정 지원

### DIFF
--- a/docs/stage3_priority_tier_plan.md
+++ b/docs/stage3_priority_tier_plan.md
@@ -1,0 +1,124 @@
+# Stage 3 Priority Tier 환경 변수 설정 계획
+
+## 요구사항
+
+Stage 3(`MatchIngestWorker.executeWithPriority`)에서 그날 먼저 처리할 tier를
+환경 변수(`PIPELINE_STAGE3_PRIORITY_TIER`)로 동적으로 지정할 수 있게 한다.
+현재 코드에서 `Tier.ALL_TIERS`로 하드코딩된 부분을 설정값으로 교체한다.
+
+---
+
+## 현재 구조
+
+```
+PipelineRunner.executeTick()
+  └─ matchIngestWorker.executeWithPriority(
+         props.getIngestBatchSize(),
+         currentPatch              ← requestedTier = ALL_TIERS 하드코딩
+     )
+  └─ MatchQueueDispatcher.pickAndLockWithPriority(
+         limit, maxRetry, cooldown,
+         requestedTier=ALL_TIERS,  ← null로 변환되어 tier 필터 없음
+         currentPatch
+     )
+```
+
+DB 쿼리(`pickReadyWithPriorityAndLock`) 정렬:
+`CHALLENGER(0) → GRANDMASTER(1) → MASTER(2) → DIAMOND(3) → EMERALD(4) → 기타(5)`
+
+**문제**: tier 우선순위가 SQL 내에 하드코딩되어 있어, 당일 처리 우선 tier를 동적으로 바꿀 수 없다.
+
+---
+
+## 구현 전략
+
+`requestedTier`를 설정값으로 노출한다.
+- `ALL_TIERS`이면 현재 동작 유지 (전체, SQL 정렬 기준 처리)
+- 특정 tier이면 해당 tier를 `requestedTier`로 전달하여 해당 tier 우선 처리
+
+`executeWithPriority(int, Tier, String)` 오버로드가 이미 존재하므로 추가 구현 불필요.
+
+---
+
+## Phase 1 — PipelineProperties 필드 추가
+
+**파일**: `src/main/java/com/bestduo_BE/config/PipelineProperties.java`
+
+```java
+/** Stage 3(INGEST)에서 그날 먼저 처리할 tier. ALL_TIERS이면 기존 우선순위 유지. */
+private Tier stage3PriorityTier = Tier.ALL_TIERS;
+```
+
+- Spring Boot `@ConfigurationProperties`가 YAML → Enum 자동 변환
+- 기본값 `ALL_TIERS` → 기존 동작과 완전히 동일
+
+---
+
+## Phase 2 — application.yml 환경 변수 매핑
+
+**파일**: `src/main/resources/application.yml`
+
+```yaml
+pipeline:
+  stage3-priority-tier: ${PIPELINE_STAGE3_PRIORITY_TIER:ALL_TIERS}
+```
+
+**파일**: `src/test/resources/application.yml`
+
+```yaml
+pipeline:
+  stage3-priority-tier: ALL_TIERS
+```
+
+---
+
+## Phase 3 — PipelineRunner Stage 3 호출부 수정
+
+**파일**: `src/main/java/com/bestduo_BE/pipeline/application/PipelineRunner.java`
+
+현재:
+```java
+MatchIngestWorker.Result result = matchIngestWorker.executeWithPriority(
+    props.getIngestBatchSize(), currentPatch);
+```
+
+변경 후:
+```java
+Tier priorityTier = props.getStage3PriorityTier();
+MatchIngestWorker.Result result = matchIngestWorker.executeWithPriority(
+    props.getIngestBatchSize(), priorityTier, currentPatch);
+```
+
+---
+
+## Phase 4 — 테스트 수정/추가
+
+**파일**: `src/test/java/com/bestduo_BE/pipeline/application/PipelineRunnerTest.java`
+
+| 테스트 케이스 | 설명 |
+|---|---|
+| `stage3_ALL_TIERS이면_executeWithPriority에_ALL_TIERS_전달` | 기본 동작 유지 확인 |
+| `stage3_CHALLENGER_설정시_CHALLENGER_tier로_executeWithPriority_호출` | 특정 tier 전달 확인 |
+
+---
+
+## 변경 파일 요약
+
+| 파일 | 변경 종류 |
+|---|---|
+| `config/PipelineProperties.java` | 필드 1개 추가 |
+| `resources/application.yml` (main) | 설정 키 1개 추가 |
+| `resources/application.yml` (test) | 설정 키 1개 추가 |
+| `pipeline/application/PipelineRunner.java` | `executeTick()` 2줄 수정 |
+| `pipeline/application/PipelineRunnerTest.java` | 테스트 케이스 추가 |
+
+---
+
+## 리스크 분석
+
+| 항목 | 수준 | 비고 |
+|---|---|---|
+| 기존 동작 변경 | 없음 | 기본값 `ALL_TIERS` = 현재 동작과 동일 |
+| `executeWithPriority(int, Tier, String)` 시그니처 이미 존재 | 없음 | 추가 구현 불필요 |
+| Enum 문자열 오타 시 앱 기동 실패 | 낮음 | Spring Boot 기동 시점에 즉시 감지됨 |
+| 특정 tier 지정 시 해당 큐가 비면 폴링 대기 발생 가능 | 낮음 | 의도된 동작 (해당 tier 소진 후 폴링) |

--- a/src/main/java/com/bestduo_BE/config/PipelineProperties.java
+++ b/src/main/java/com/bestduo_BE/config/PipelineProperties.java
@@ -1,5 +1,6 @@
 package com.bestduo_BE.config;
 
+import com.bestduo_BE.common.domain.model.Tier;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -35,6 +36,9 @@ public class PipelineProperties {
    * 이 수에 도달하면 다음 division으로 이동한다.
    */
   private int maxPagesPerDivision = 5;
+
+  /** Stage 3(INGEST)에서 그날 먼저 처리할 tier. ALL_TIERS이면 기존 우선순위(CHALLENGER→…→기타) 유지. */
+  private Tier stage3PriorityTier = Tier.ALL_TIERS;
 
   private TierMatchCount tierMatchCount = new TierMatchCount();
 

--- a/src/main/java/com/bestduo_BE/pipeline/application/PipelineRunner.java
+++ b/src/main/java/com/bestduo_BE/pipeline/application/PipelineRunner.java
@@ -1,6 +1,7 @@
 package com.bestduo_BE.pipeline.application;
 
 import com.bestduo_BE.common.application.PatchVersionService;
+import com.bestduo_BE.common.domain.model.Tier;
 import com.bestduo_BE.common.infra.riot.exception.RiotRateLimitedException;
 import com.bestduo_BE.config.PipelineProperties;
 import com.bestduo_BE.ingest.application.MatchIngestWorker;
@@ -82,9 +83,10 @@ public class PipelineRunner {
 
     // Stage 3: Ingest (상시, patch+tier 우선순위)
     String currentPatch = patchVersionService.currentPatchVersion().orElse(null);
-    log.debug("Stage 3 실행 (currentPatch={})", currentPatch);
+    Tier priorityTier = props.getStage3PriorityTier();
+    log.debug("Stage 3 실행 (currentPatch={}, priorityTier={})", currentPatch, priorityTier);
     MatchIngestWorker.Result result = matchIngestWorker.executeWithPriority(
-        props.getIngestBatchSize(), currentPatch);
+        props.getIngestBatchSize(), priorityTier, currentPatch);
 
     if (result.picked() == 0) {
       log.debug("match_queue 비어있음. {}ms 대기", props.getPollingIntervalMs());

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -68,6 +68,7 @@ pipeline:
   tier-match-count:
     apex-tiers: 30
     diamond-emerald: 10
+  stage3-priority-tier: ${PIPELINE_STAGE3_PRIORITY_TIER:ALL_TIERS}
 
 management:
   endpoints:

--- a/src/test/java/com/bestduo_BE/pipeline/application/PipelineRunnerTest.java
+++ b/src/test/java/com/bestduo_BE/pipeline/application/PipelineRunnerTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import com.bestduo_BE.common.application.PatchVersionService;
+import com.bestduo_BE.common.domain.model.Tier;
 import com.bestduo_BE.common.infra.riot.exception.RiotRateLimitedException;
 import com.bestduo_BE.config.PipelineProperties;
 import com.bestduo_BE.ingest.application.MatchIngestWorker;
@@ -48,7 +49,7 @@ class PipelineRunnerTest {
 
     verify(dailySeedRunner).runNextChunk();
     verify(collectMatchIdsRunner, never()).runBatch();
-    verify(matchIngestWorker, never()).executeWithPriority(anyInt(), any());
+    verify(matchIngestWorker, never()).executeWithPriority(anyInt(), any(), any());
   }
 
   @Test
@@ -60,35 +61,51 @@ class PipelineRunnerTest {
     runner.executeTick();
 
     verify(collectMatchIdsRunner).runBatch();
-    verify(matchIngestWorker, never()).executeWithPriority(anyInt(), any());
+    verify(matchIngestWorker, never()).executeWithPriority(anyInt(), any(), any());
   }
 
   @Test
-  @DisplayName("Stage 1·2 없으면 currentPatch와 함께 Stage 3 executeWithPriority를 호출한다")
+  @DisplayName("Stage 1·2 없으면 ALL_TIERS + currentPatch로 Stage 3 executeWithPriority를 호출한다")
   void executeTick_whenNoStage1Or2_runsStage3WithCurrentPatch() throws InterruptedException {
     given(dailySeedRunner.hasWorkToday()).willReturn(false);
     given(collectMatchIdsRunner.hasPending()).willReturn(false);
     given(patchVersionService.currentPatchVersion()).willReturn(Optional.of("15.23"));
-    given(matchIngestWorker.executeWithPriority(anyInt(), any()))
+    given(matchIngestWorker.executeWithPriority(anyInt(), any(), any()))
         .willReturn(ingestResult(1));
 
     runner.executeTick();
 
-    verify(matchIngestWorker).executeWithPriority(props.getIngestBatchSize(), "15.23");
+    verify(matchIngestWorker).executeWithPriority(props.getIngestBatchSize(), Tier.ALL_TIERS, "15.23");
   }
 
   @Test
-  @DisplayName("patch 정보가 없으면 null로 Stage 3를 호출한다")
+  @DisplayName("patch 정보가 없으면 ALL_TIERS + null patch로 Stage 3를 호출한다")
   void executeTick_whenNoPatch_callsStage3WithNullPatch() throws InterruptedException {
     given(dailySeedRunner.hasWorkToday()).willReturn(false);
     given(collectMatchIdsRunner.hasPending()).willReturn(false);
     given(patchVersionService.currentPatchVersion()).willReturn(Optional.empty());
-    given(matchIngestWorker.executeWithPriority(anyInt(), any()))
+    given(matchIngestWorker.executeWithPriority(anyInt(), any(), any()))
         .willReturn(ingestResult(1));
 
     runner.executeTick();
 
-    verify(matchIngestWorker).executeWithPriority(props.getIngestBatchSize(), null);
+    verify(matchIngestWorker).executeWithPriority(props.getIngestBatchSize(), Tier.ALL_TIERS, null);
+  }
+
+  @Test
+  @DisplayName("stage3PriorityTier가 EMERALD이면 EMERALD tier로 Stage 3를 호출한다")
+  void executeTick_whenStage3PriorityTierIsEmerald_callsStage3WithEmeraldTier()
+      throws InterruptedException {
+    props.setStage3PriorityTier(Tier.EMERALD);
+    given(dailySeedRunner.hasWorkToday()).willReturn(false);
+    given(collectMatchIdsRunner.hasPending()).willReturn(false);
+    given(patchVersionService.currentPatchVersion()).willReturn(Optional.of("15.23"));
+    given(matchIngestWorker.executeWithPriority(anyInt(), any(), any()))
+        .willReturn(ingestResult(1));
+
+    runner.executeTick();
+
+    verify(matchIngestWorker).executeWithPriority(props.getIngestBatchSize(), Tier.EMERALD, "15.23");
   }
 
   @Test
@@ -97,7 +114,7 @@ class PipelineRunnerTest {
     given(dailySeedRunner.hasWorkToday()).willReturn(false);
     given(collectMatchIdsRunner.hasPending()).willReturn(false);
     given(patchVersionService.currentPatchVersion()).willReturn(Optional.empty());
-    given(matchIngestWorker.executeWithPriority(anyInt(), any()))
+    given(matchIngestWorker.executeWithPriority(anyInt(), any(), any()))
         .willReturn(ingestResult(0));
 
     long start = System.currentTimeMillis();
@@ -124,7 +141,7 @@ class PipelineRunnerTest {
     given(dailySeedRunner.hasWorkToday()).willReturn(false);
     given(collectMatchIdsRunner.hasPending()).willReturn(false);
     given(patchVersionService.currentPatchVersion()).willReturn(Optional.empty());
-    given(matchIngestWorker.executeWithPriority(anyInt(), any()))
+    given(matchIngestWorker.executeWithPriority(anyInt(), any(), any()))
         .willThrow(new RiotRateLimitedException("429"));
 
     assertThatThrownBy(() -> runner.executeTick())

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -21,3 +21,4 @@ work-item:
 pipeline:
   runner:
     enabled: false
+  stage3-priority-tier: ALL_TIERS


### PR DESCRIPTION
## Summary

- `PIPELINE_STAGE3_PRIORITY_TIER` 환경 변수로 Stage 3에서 그날 먼저 처리할 tier를 동적으로 지정할 수 있게 한다
- 기본값 `ALL_TIERS` → 기존 동작(CHALLENGER → GRANDMASTER → … 순 SQL 정렬)을 그대로 유지
- 특정 tier 지정 시 해당 tier를 `requestedTier`로 전달하여 필터링 우선 처리

## 변경 파일

| 파일 | 변경 내용 |
|---|---|
| `PipelineProperties.java` | `stage3PriorityTier: Tier` 필드 추가 (기본값 `ALL_TIERS`) |
| `application.yml` (main) | `stage3-priority-tier: ${PIPELINE_STAGE3_PRIORITY_TIER:ALL_TIERS}` 매핑 |
| `application.yml` (test) | `stage3-priority-tier: ALL_TIERS` 고정 |
| `PipelineRunner.java` | `executeTick()`에서 `props.getStage3PriorityTier()`를 3-arg `executeWithPriority`에 전달 |
| `PipelineRunnerTest.java` | mock을 3-arg 시그니처로 교체 + EMERALD tier 케이스 추가 |

## 사용법

```bash
# 오늘은 EMERALD 먼저 처리
PIPELINE_STAGE3_PRIORITY_TIER=EMERALD

# 기본 동작 (env 미설정 시 ALL_TIERS)
# PIPELINE_STAGE3_PRIORITY_TIER=ALL_TIERS
```

## Test plan

- [ ] `PipelineRunnerTest` 전체 GREEN 확인
- [ ] `stage3PriorityTier=EMERALD` 설정 시 `executeWithPriority(batchSize, EMERALD, patch)` 호출 확인
- [ ] 기본값(`ALL_TIERS`) 상태에서 기존 동작 변경 없음 확인
- [ ] 잘못된 enum 값 설정 시 앱 기동 실패로 즉시 감지 확인 (수동)