### PR TITLE
feat: DIA/EME 일일 순환 seed 자동화

### DIFF
--- a/docs/sql/daily_pipeline_phase2_schema.sql
+++ b/docs/sql/daily_pipeline_phase2_schema.sql
@@ -14,7 +14,8 @@ CREATE INDEX IF NOT EXISTS idx_summoner_stage2_targets
 -- ── 2. coverage_bucket 테이블: 일일 seed 완료 추적 컬럼 추가 ─────────────────
 ALTER TABLE coverage_bucket
     ADD COLUMN IF NOT EXISTS daily_seed_completed  BOOLEAN     NOT NULL DEFAULT FALSE,
-    ADD COLUMN IF NOT EXISTS daily_seed_reset_at   TIMESTAMPTZ;
+    ADD COLUMN IF NOT EXISTS daily_seed_reset_at   TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS daily_seed_steps_processed INTEGER NOT NULL DEFAULT 0;
 
 -- ── 3. daily_pipeline_state 테이블 신규 생성 ─────────────────────────────────
 CREATE TABLE IF NOT EXISTS daily_pipeline_state (

--- a/src/main/java/com/bestduo_BE/config/PipelineProperties.java
+++ b/src/main/java/com/bestduo_BE/config/PipelineProperties.java
@@ -37,10 +37,13 @@ public class PipelineProperties {
   /** Stage 2에서 match_queue에 enqueue할 때 사용하는 기본 우선순위 */
   private int collectPriority = 50;
 
-  /**
-   * DIA/EME CoverageBucket에서 한 division 내 최대 page 수.
-   * 이 수에 도달하면 다음 division으로 이동한다.
-   */
+  private long diaEmeCoverageTarget = 500_000L;
+
+  private int diaEmeDailyPageQuota = 10;
+
+  private int diaEmeSafetyMaxPage = 100;
+
+  @Deprecated
   private int maxPagesPerDivision = 5;
 
   /** Stage 3(INGEST)에서 그날 먼저 처리할 tier. ALL_TIERS이면 기존 우선순위(CHALLENGER→…→기타) 유지. */

--- a/src/main/java/com/bestduo_BE/coverage/infra/persistence/entity/CoverageBucket.java
+++ b/src/main/java/com/bestduo_BE/coverage/infra/persistence/entity/CoverageBucket.java
@@ -75,6 +75,10 @@ public class CoverageBucket {
 
   @Column(name = "daily_seed_reset_at")
   private OffsetDateTime dailySeedResetAt;
+
+  @Builder.Default
+  @Column(name = "daily_seed_steps_processed", nullable = false)
+  private int dailySeedStepsProcessed = 0;
   // ─────────────────────────────────────────────────────────────────────────
 
   @Column(name = "last_evaluated_at", nullable = false)
@@ -105,24 +109,36 @@ public class CoverageBucket {
         .build();
   }
 
-  /**
-   * SEED WorkItem 발행 직후 호출. 다음 SEED가 새 페이지/division을 사용하도록 상태를 전진시킨다.
-   *
-   * <p>apex 티어(MASTER/GRANDMASTER/CHALLENGER)는 Riot league-v4가 division 없이 단일 리그를
-   * 제공하므로 페이지만 증가한다.
-   * 그 외 티어는 페이지가 maxPagesPerDivision에 도달하면 다음 division(I→II→III→IV→I)으로 rotation.
-   */
+  public void advanceToNextPage() {
+    this.seedPage++;
+    this.updatedAt = OffsetDateTime.now();
+  }
+
+  public void advanceToNextDivisionStart() {
+    int idx = DIVISIONS.indexOf(this.seedDivision);
+    this.seedDivision = DIVISIONS.get((idx + 1) % DIVISIONS.size());
+    this.seedPage = 1;
+    this.updatedAt = OffsetDateTime.now();
+  }
+
+  public void incrementDailySeedProgress() {
+    this.dailySeedStepsProcessed++;
+    this.updatedAt = OffsetDateTime.now();
+  }
+
+  public boolean isDailyQuotaReached(int quota) {
+    return this.dailySeedStepsProcessed >= quota;
+  }
+
+  @Deprecated
   public void advanceSeedState(int maxPagesPerDivision) {
     if (APEX_TIERS.contains(this.tier)) {
-      this.seedPage++;
+      advanceToNextPage();
     } else if (this.seedPage >= maxPagesPerDivision) {
-      int idx = DIVISIONS.indexOf(this.seedDivision);
-      this.seedDivision = DIVISIONS.get((idx + 1) % DIVISIONS.size());
-      this.seedPage = 1;
+      advanceToNextDivisionStart();
     } else {
-      this.seedPage++;
+      advanceToNextPage();
     }
-    this.updatedAt = OffsetDateTime.now();
   }
 
   /** 오늘 이 bucket의 seed를 완료했음을 기록한다. */
@@ -144,6 +160,7 @@ public class CoverageBucket {
       return;
     }
     this.dailySeedCompleted = false;
+    this.dailySeedStepsProcessed = 0;
     this.dailySeedResetAt = today.atStartOfDay().atOffset(OffsetDateTime.now().getOffset());
     this.updatedAt = OffsetDateTime.now();
   }

--- a/src/main/java/com/bestduo_BE/pipeline/application/DailySeedRunner.java
+++ b/src/main/java/com/bestduo_BE/pipeline/application/DailySeedRunner.java
@@ -10,10 +10,11 @@ import com.bestduo_BE.coverage.infra.persistence.entity.CoverageBucket;
 import com.bestduo_BE.coverage.infra.persistence.repository.CoverageBucketJpaRepository;
 import com.bestduo_BE.seed.application.SeedBootstrapExecutor;
 import com.bestduo_BE.seed.application.SeedBootstrapExecutor.SeedBootstrapResult;
+import java.time.LocalDate;
 import java.util.List;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.stereotype.Component;
 
 /**
@@ -86,10 +87,19 @@ public class DailySeedRunner {
       log.warn("DIA/EME seed 스킵: 현재 패치 정보 없음");
       return ChunkResult.noWork();
     }
+    LocalDate today = LocalDate.now();
     for (Tier tier : DIA_EME_TIERS) {
-      Optional<CoverageBucket> opt = coverageBucketRepository.findByPatchAndTier(currentPatch, tier);
-      if (opt.isPresent() && !opt.get().isDailySeedCompleted()) {
-        return runDiaEmePage(opt.get(), tier);
+      CoverageBucket bucket = getOrCreateDiaEmeBucket(currentPatch, tier);
+      bucket.resetDailySeedIfNeeded(bucket.getDailySeedResetAt(), today);
+
+      if (bucket.isDailyQuotaReached(props.getDiaEmeDailyPageQuota())) {
+        bucket.markDailySeedCompleted();
+        coverageBucketRepository.save(bucket);
+        continue;
+      }
+
+      if (!bucket.isDailySeedCompleted()) {
+        return runDiaEmePage(bucket, tier);
       }
     }
 
@@ -112,13 +122,43 @@ public class DailySeedRunner {
     if (currentPatch == null) {
       return false;
     }
+    LocalDate today = LocalDate.now();
     for (Tier tier : DIA_EME_TIERS) {
-      Optional<CoverageBucket> opt = coverageBucketRepository.findByPatchAndTier(currentPatch, tier);
-      if (opt.isPresent() && !opt.get().isDailySeedCompleted()) {
+      CoverageBucket bucket = coverageBucketRepository.findByPatchAndTier(currentPatch, tier)
+          .orElse(null);
+      if (bucket == null || hasQuotaRemaining(bucket, today)) {
         return true;
       }
     }
     return false;
+  }
+
+  private CoverageBucket getOrCreateDiaEmeBucket(String currentPatch, Tier tier) {
+    return coverageBucketRepository.findByPatchAndTier(currentPatch, tier)
+        .orElseGet(() -> createDiaEmeBucket(currentPatch, tier));
+  }
+
+  private CoverageBucket createDiaEmeBucket(String currentPatch, Tier tier) {
+    CoverageBucket bucket = CoverageBucket.create(
+        currentPatch,
+        tier,
+        props.getDiaEmeCoverageTarget(),
+        DIA_EME_TIERS.indexOf(tier) + 1);
+    try {
+      return coverageBucketRepository.save(bucket);
+    } catch (DataIntegrityViolationException ex) {
+      return coverageBucketRepository.findByPatchAndTier(currentPatch, tier)
+          .orElseThrow(() -> ex);
+    }
+  }
+
+  private boolean hasQuotaRemaining(CoverageBucket bucket, LocalDate today) {
+    return needsDailyReset(bucket, today) || !bucket.isDailySeedCompleted();
+  }
+
+  private boolean needsDailyReset(CoverageBucket bucket, LocalDate today) {
+    return bucket.getDailySeedResetAt() == null
+        || bucket.getDailySeedResetAt().toLocalDate().isBefore(today);
   }
 
   private ChunkResult runApexTierChunk(Tier tier) {
@@ -138,6 +178,7 @@ public class DailySeedRunner {
   private ChunkResult runDiaEmePage(CoverageBucket bucket, Tier tier) {
     log.info("Stage1 DIA/EME 페이지 시작: tier={} page={} division={}",
         tier, bucket.getSeedPage(), bucket.getSeedDivision());
+    int currentPage = bucket.getSeedPage();
 
     SeedBootstrapCommand cmd = new SeedBootstrapCommand(
         QUEUE,
@@ -152,17 +193,19 @@ public class DailySeedRunner {
     SeedBootstrapResult result = seedBootstrapExecutor.execute(cmd);
 
     budgetTracker.recordSeedCall(1);
+    bucket.incrementDailySeedProgress();
 
-    if (result.entriesFetched() == 0) {
-      // 페이지가 비었으면 해당 bucket 오늘 완료로 표시
-      bucket.markDailySeedCompleted();
-      coverageBucketRepository.save(bucket);
-      log.info("Stage1 DIA/EME bucket 완료: tier={}", tier);
+    if (result.entriesFetched() == 0 || currentPage >= props.getDiaEmeSafetyMaxPage()) {
+      bucket.advanceToNextDivisionStart();
     } else {
-      // 다음 페이지/division으로 전진
-      bucket.advanceSeedState(props.getMaxPagesPerDivision());
-      coverageBucketRepository.save(bucket);
+      bucket.advanceToNextPage();
     }
+
+    if (bucket.isDailyQuotaReached(props.getDiaEmeDailyPageQuota())) {
+      bucket.markDailySeedCompleted();
+    }
+
+    coverageBucketRepository.save(bucket);
 
     return ChunkResult.diaEmePage(tier, result.summonersSeeded());
   }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -39,7 +39,9 @@ pipeline:
   collect-batch-size: 20
   ingest-batch-size: 10
   polling-interval-ms: 5000
-  max-pages-per-division: 5
+  dia-eme-coverage-target: 500000
+  dia-eme-daily-page-quota: 10
+  dia-eme-safety-max-page: 100
   tier-match-count:
     apex-tiers: 30
     diamond-emerald: 10

--- a/src/test/java/com/bestduo_BE/coverage/infra/persistence/entity/CoverageBucketPhase2Test.java
+++ b/src/test/java/com/bestduo_BE/coverage/infra/persistence/entity/CoverageBucketPhase2Test.java
@@ -21,6 +21,7 @@ class CoverageBucketPhase2Test {
 
     assertThat(b.isDailySeedCompleted()).isFalse();
     assertThat(b.getDailySeedResetAt()).isNull();
+    assertThat(b.getDailySeedStepsProcessed()).isZero();
   }
 
   @Test
@@ -34,15 +35,68 @@ class CoverageBucketPhase2Test {
   }
 
   @Test
-  @DisplayName("resetDailySeedIfNeeded() — dailySeedResetAt이 오늘 이전이면 리셋한다")
-  void resetDailySeedIfNeededResetsWhenOutdated() {
+  @DisplayName("advanceToNextPage() — 현재 division을 유지하고 page만 증가시킨다")
+  void advanceToNextPageKeepsDivisionAndIncrementsPage() {
     CoverageBucket b = bucket();
+    b.advanceToNextPage();
+
+    assertThat(b.getSeedDivision()).isEqualTo("I");
+    assertThat(b.getSeedPage()).isEqualTo(2);
+  }
+
+  @Test
+  @DisplayName("advanceToNextDivisionStart() — 현재 division이 끝나면 다음 division 1페이지로 이동한다")
+  void advanceToNextDivisionStartMovesToNextDivision() {
+    CoverageBucket b = bucket();
+    b.advanceToNextPage();
+    b.advanceToNextPage();
+    b.advanceToNextDivisionStart();
+
+    assertThat(b.getSeedDivision()).isEqualTo("II");
+    assertThat(b.getSeedPage()).isEqualTo(1);
+  }
+
+  @Test
+  @DisplayName("advanceToNextDivisionStart() — IV division 다음은 I / 1 로 순환한다")
+  void advanceToNextDivisionStartWrapsFromIvToI() {
+    CoverageBucket b = bucket();
+    b.advanceToNextDivisionStart();
+    b.advanceToNextDivisionStart();
+    b.advanceToNextDivisionStart();
+    b.advanceToNextDivisionStart();
+
+    assertThat(b.getSeedDivision()).isEqualTo("I");
+    assertThat(b.getSeedPage()).isEqualTo(1);
+  }
+
+  @Test
+  @DisplayName("incrementDailySeedProgress() — 하루 step 진행량을 1 증가시킨다")
+  void incrementDailySeedProgressIncrementsSteps() {
+    CoverageBucket b = bucket();
+
+    b.incrementDailySeedProgress();
+
+    assertThat(b.getDailySeedStepsProcessed()).isEqualTo(1);
+    assertThat(b.isDailyQuotaReached(1)).isTrue();
+  }
+
+  @Test
+  @DisplayName("resetDailySeedIfNeeded() — dailySeedResetAt이 오늘 이전이면 step과 완료 상태를 리셋하고 cursor는 유지한다")
+  void resetDailySeedIfNeededResetsWhenOutdatedButPreservesCursor() {
+    CoverageBucket b = bucket();
+    b.advanceToNextDivisionStart();
+    b.advanceToNextPage();
+    b.incrementDailySeedProgress();
+    b.incrementDailySeedProgress();
     b.markDailySeedCompleted();
-    // 어제 리셋 시점 설정 (오늘보다 이전)
     OffsetDateTime yesterday = OffsetDateTime.now().minusDays(1);
+
     b.resetDailySeedIfNeeded(yesterday, LocalDate.now());
 
     assertThat(b.isDailySeedCompleted()).isFalse();
+    assertThat(b.getDailySeedStepsProcessed()).isZero();
+    assertThat(b.getSeedDivision()).isEqualTo("II");
+    assertThat(b.getSeedPage()).isEqualTo(2);
     assertThat(b.getDailySeedResetAt()).isNotNull();
   }
 
@@ -50,22 +104,26 @@ class CoverageBucketPhase2Test {
   @DisplayName("resetDailySeedIfNeeded() — dailySeedResetAt이 오늘이면 리셋하지 않는다")
   void resetDailySeedIfNeededSkipsWhenAlreadyResetToday() {
     CoverageBucket b = bucket();
+    b.incrementDailySeedProgress();
     b.markDailySeedCompleted();
     OffsetDateTime todayTime = OffsetDateTime.now().withHour(0).withMinute(0).withSecond(0).withNano(0);
+
     b.resetDailySeedIfNeeded(todayTime, LocalDate.now());
 
-    // 이미 오늘 리셋했으면 completed가 true 유지
     assertThat(b.isDailySeedCompleted()).isTrue();
+    assertThat(b.getDailySeedStepsProcessed()).isEqualTo(1);
   }
 
   @Test
   @DisplayName("resetDailySeedIfNeeded() — dailySeedResetAt이 null이면 리셋한다")
   void resetDailySeedIfNeededResetsWhenNullResetAt() {
     CoverageBucket b = bucket();
+    b.incrementDailySeedProgress();
     b.markDailySeedCompleted();
 
     b.resetDailySeedIfNeeded(null, LocalDate.now());
 
     assertThat(b.isDailySeedCompleted()).isFalse();
+    assertThat(b.getDailySeedStepsProcessed()).isZero();
   }
 }

--- a/src/test/java/com/bestduo_BE/pipeline/application/DailySeedRunnerTest.java
+++ b/src/test/java/com/bestduo_BE/pipeline/application/DailySeedRunnerTest.java
@@ -17,6 +17,7 @@ import com.bestduo_BE.coverage.infra.persistence.repository.CoverageBucketJpaRep
 import com.bestduo_BE.seed.application.SeedBootstrapExecutor;
 import com.bestduo_BE.seed.application.SeedBootstrapExecutor.SeedBootstrapResult;
 import java.time.LocalDate;
+import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -25,6 +26,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.DataIntegrityViolationException;
 
 @ExtendWith(MockitoExtension.class)
 class DailySeedRunnerTest {
@@ -109,6 +111,23 @@ class DailySeedRunnerTest {
     assertThat(runner.hasWorkToday()).isTrue();
   }
 
+  @Test
+  @DisplayName("DIA 버킷이 없어도 auto-create 대상이면 hasWorkToday는 true")
+  void hasWorkToday_whenDiaBucketMissing_returnsTrue() {
+    given(budgetTracker.canSeed()).willReturn(true);
+
+    DailyPipelineState state = DailyPipelineState.create(LocalDate.now());
+    state.recordSeedCompletedTier("CHALLENGER");
+    state.recordSeedCompletedTier("GRANDMASTER");
+    state.recordSeedCompletedTier("MASTER");
+    given(budgetTracker.getOrCreateTodayState()).willReturn(state);
+
+    given(patchVersionService.currentPatchVersion()).willReturn(Optional.of("15.23"));
+    given(coverageBucketRepository.findByPatchAndTier("15.23", Tier.DIAMOND)).willReturn(Optional.empty());
+
+    assertThat(runner.hasWorkToday()).isTrue();
+  }
+
   // ── runNextChunk ────────────────────────────────────────────────────
 
   @Test
@@ -171,8 +190,8 @@ class DailySeedRunnerTest {
   }
 
   @Test
-  @DisplayName("DIA 페이지가 빈 응답이면 해당 버킷을 dailySeedCompleted로 표시")
-  void runNextChunk_whenDiaPageEmpty_marksBucketCompleted() {
+  @DisplayName("DIA 버킷이 없으면 auto-create 후 첫 페이지를 실행한다")
+  void runNextChunk_whenDiaBucketMissing_autoCreatesAndExecutesDiaPage() {
     given(budgetTracker.canSeed()).willReturn(true);
 
     DailyPipelineState state = DailyPipelineState.create(LocalDate.now());
@@ -183,18 +202,209 @@ class DailySeedRunnerTest {
 
     given(patchVersionService.currentPatchVersion()).willReturn(Optional.of("15.23"));
 
-    CoverageBucket diaBucket = bucketNotCompleted(Tier.DIAMOND, "15.23");
+    given(coverageBucketRepository.findByPatchAndTier("15.23", Tier.DIAMOND)).willReturn(Optional.empty());
+    given(coverageBucketRepository.save(any(CoverageBucket.class)))
+        .willAnswer(invocation -> invocation.getArgument(0));
+
+    SeedBootstrapResult seedResult = new SeedBootstrapResult(1, 10, 3, 0, 0);
+    given(seedBootstrapExecutor.execute(argThat(cmd ->
+        "DIAMOND".equals(cmd.tier())
+            && "I".equals(cmd.division())
+            && cmd.startPage() == 1
+    ))).willReturn(seedResult);
+
+    DailySeedRunner.ChunkResult chunk = runner.runNextChunk();
+
+    assertThat(chunk.type()).isEqualTo(DailySeedRunner.ChunkResult.Type.DIA_EME_PAGE);
+    verify(coverageBucketRepository, org.mockito.Mockito.atLeastOnce()).save(argThat(bucket ->
+        bucket.getTier() == Tier.DIAMOND
+            && "15.23".equals(bucket.getPatch())
+            && bucket.getTargetMatchCount() == props.getDiaEmeCoverageTarget()
+    ));
+  }
+
+  @Test
+  @DisplayName("auto-create 저장이 unique 충돌이면 기존 버킷을 다시 읽어 실행한다")
+  void runNextChunk_whenAutoCreateConflicts_reloadsExistingBucket() {
+    given(budgetTracker.canSeed()).willReturn(true);
+
+    DailyPipelineState state = DailyPipelineState.create(LocalDate.now());
+    state.recordSeedCompletedTier("CHALLENGER");
+    state.recordSeedCompletedTier("GRANDMASTER");
+    state.recordSeedCompletedTier("MASTER");
+    given(budgetTracker.getOrCreateTodayState()).willReturn(state);
+
+    given(patchVersionService.currentPatchVersion()).willReturn(Optional.of("15.23"));
+
+    CoverageBucket existingBucket = customBucket(Tier.DIAMOND, "15.23", "III", 7, 0, false, null);
+    given(coverageBucketRepository.findByPatchAndTier("15.23", Tier.DIAMOND))
+        .willReturn(Optional.empty())
+        .willReturn(Optional.of(existingBucket));
+    given(coverageBucketRepository.save(any(CoverageBucket.class)))
+        .willThrow(new DataIntegrityViolationException("duplicate key"))
+        .willReturn(existingBucket);
+
+    SeedBootstrapResult seedResult = new SeedBootstrapResult(1, 5, 2, 0, 0);
+    given(seedBootstrapExecutor.execute(argThat(cmd ->
+        "DIAMOND".equals(cmd.tier())
+            && "III".equals(cmd.division())
+            && cmd.startPage() == 7
+    ))).willReturn(seedResult);
+
+    DailySeedRunner.ChunkResult chunk = runner.runNextChunk();
+
+    assertThat(chunk.type()).isEqualTo(DailySeedRunner.ChunkResult.Type.DIA_EME_PAGE);
+    assertThat(existingBucket.getSeedDivision()).isEqualTo("III");
+    assertThat(existingBucket.getSeedPage()).isEqualTo(8);
+  }
+
+  @Test
+  @DisplayName("DIA 페이지가 빈 응답이면 완료 대신 다음 division 시작점으로 이동한다")
+  void runNextChunk_whenDiaPageEmpty_rollsToNextDivisionStart() {
+    given(budgetTracker.canSeed()).willReturn(true);
+
+    DailyPipelineState state = DailyPipelineState.create(LocalDate.now());
+    state.recordSeedCompletedTier("CHALLENGER");
+    state.recordSeedCompletedTier("GRANDMASTER");
+    state.recordSeedCompletedTier("MASTER");
+    given(budgetTracker.getOrCreateTodayState()).willReturn(state);
+
+    given(patchVersionService.currentPatchVersion()).willReturn(Optional.of("15.23"));
+
+    CoverageBucket diaBucket = customBucket(Tier.DIAMOND, "15.23", "I", 99, 0, false, OffsetDateTime.now());
     given(coverageBucketRepository.findByPatchAndTier("15.23", Tier.DIAMOND)).willReturn(Optional.of(diaBucket));
     given(coverageBucketRepository.save(any(CoverageBucket.class))).willReturn(diaBucket);
 
-    // 빈 응답 (entriesFetched = 0)
     SeedBootstrapResult emptyResult = new SeedBootstrapResult(1, 0, 0, 0, 0);
     given(seedBootstrapExecutor.execute(any())).willReturn(emptyResult);
 
     runner.runNextChunk();
 
-    assertThat(diaBucket.isDailySeedCompleted()).isTrue();
+    assertThat(diaBucket.isDailySeedCompleted()).isFalse();
+    assertThat(diaBucket.getSeedDivision()).isEqualTo("II");
+    assertThat(diaBucket.getSeedPage()).isEqualTo(1);
+    assertThat(diaBucket.getDailySeedStepsProcessed()).isEqualTo(1);
     verify(coverageBucketRepository).save(diaBucket);
+  }
+
+  @Test
+  @DisplayName("DIA 페이지가 정상 응답이면 같은 division의 다음 페이지로 이동한다")
+  void runNextChunk_whenDiaPageHasEntries_advancesToNextPage() {
+    given(budgetTracker.canSeed()).willReturn(true);
+
+    DailyPipelineState state = DailyPipelineState.create(LocalDate.now());
+    state.recordSeedCompletedTier("CHALLENGER");
+    state.recordSeedCompletedTier("GRANDMASTER");
+    state.recordSeedCompletedTier("MASTER");
+    given(budgetTracker.getOrCreateTodayState()).willReturn(state);
+
+    given(patchVersionService.currentPatchVersion()).willReturn(Optional.of("15.23"));
+
+    CoverageBucket diaBucket = customBucket(Tier.DIAMOND, "15.23", "II", 4, 0, false, OffsetDateTime.now());
+    given(coverageBucketRepository.findByPatchAndTier("15.23", Tier.DIAMOND)).willReturn(Optional.of(diaBucket));
+    given(coverageBucketRepository.save(any(CoverageBucket.class))).willReturn(diaBucket);
+
+    SeedBootstrapResult seedResult = new SeedBootstrapResult(1, 10, 3, 0, 0);
+    given(seedBootstrapExecutor.execute(any())).willReturn(seedResult);
+
+    runner.runNextChunk();
+
+    assertThat(diaBucket.isDailySeedCompleted()).isFalse();
+    assertThat(diaBucket.getSeedDivision()).isEqualTo("II");
+    assertThat(diaBucket.getSeedPage()).isEqualTo(5);
+    assertThat(diaBucket.getDailySeedStepsProcessed()).isEqualTo(1);
+  }
+
+  @Test
+  @DisplayName("DIA 페이지 실행 후 일일 quota를 모두 쓰면 완료 처리한다")
+  void runNextChunk_whenDailyQuotaReached_marksBucketCompleted() {
+    props.setDiaEmeDailyPageQuota(10);
+    given(budgetTracker.canSeed()).willReturn(true);
+
+    DailyPipelineState state = DailyPipelineState.create(LocalDate.now());
+    state.recordSeedCompletedTier("CHALLENGER");
+    state.recordSeedCompletedTier("GRANDMASTER");
+    state.recordSeedCompletedTier("MASTER");
+    given(budgetTracker.getOrCreateTodayState()).willReturn(state);
+
+    given(patchVersionService.currentPatchVersion()).willReturn(Optional.of("15.23"));
+
+    CoverageBucket diaBucket = customBucket(Tier.DIAMOND, "15.23", "IV", 8, 9, false, OffsetDateTime.now());
+    given(coverageBucketRepository.findByPatchAndTier("15.23", Tier.DIAMOND)).willReturn(Optional.of(diaBucket));
+    given(coverageBucketRepository.save(any(CoverageBucket.class))).willReturn(diaBucket);
+
+    SeedBootstrapResult seedResult = new SeedBootstrapResult(1, 3, 1, 0, 0);
+    given(seedBootstrapExecutor.execute(any())).willReturn(seedResult);
+
+    runner.runNextChunk();
+
+    assertThat(diaBucket.getDailySeedStepsProcessed()).isEqualTo(10);
+    assertThat(diaBucket.isDailySeedCompleted()).isTrue();
+  }
+
+  @Test
+  @DisplayName("다음 날에는 quota만 reset되고 cursor는 유지된 채 실행된다")
+  void runNextChunk_whenNewDay_resetsQuotaButPreservesCursor() {
+    props.setDiaEmeDailyPageQuota(10);
+    given(budgetTracker.canSeed()).willReturn(true);
+
+    DailyPipelineState state = DailyPipelineState.create(LocalDate.now());
+    state.recordSeedCompletedTier("CHALLENGER");
+    state.recordSeedCompletedTier("GRANDMASTER");
+    state.recordSeedCompletedTier("MASTER");
+    given(budgetTracker.getOrCreateTodayState()).willReturn(state);
+
+    given(patchVersionService.currentPatchVersion()).willReturn(Optional.of("15.23"));
+
+    CoverageBucket diaBucket = customBucket(
+        Tier.DIAMOND,
+        "15.23",
+        "III",
+        7,
+        10,
+        true,
+        OffsetDateTime.now().minusDays(1));
+    given(coverageBucketRepository.findByPatchAndTier("15.23", Tier.DIAMOND)).willReturn(Optional.of(diaBucket));
+    given(coverageBucketRepository.save(any(CoverageBucket.class))).willReturn(diaBucket);
+
+    SeedBootstrapResult seedResult = new SeedBootstrapResult(1, 6, 2, 0, 0);
+    given(seedBootstrapExecutor.execute(argThat(cmd ->
+        "III".equals(cmd.division()) && cmd.startPage() == 7
+    ))).willReturn(seedResult);
+
+    runner.runNextChunk();
+
+    assertThat(diaBucket.getDailySeedStepsProcessed()).isEqualTo(1);
+    assertThat(diaBucket.isDailySeedCompleted()).isFalse();
+    assertThat(diaBucket.getSeedDivision()).isEqualTo("III");
+    assertThat(diaBucket.getSeedPage()).isEqualTo(8);
+  }
+
+  @Test
+  @DisplayName("safety cap에 도달하면 응답이 있어도 다음 division 시작점으로 이동한다")
+  void runNextChunk_whenSafetyCapReached_rollsToNextDivisionStart() {
+    props.setDiaEmeSafetyMaxPage(100);
+    given(budgetTracker.canSeed()).willReturn(true);
+
+    DailyPipelineState state = DailyPipelineState.create(LocalDate.now());
+    state.recordSeedCompletedTier("CHALLENGER");
+    state.recordSeedCompletedTier("GRANDMASTER");
+    state.recordSeedCompletedTier("MASTER");
+    given(budgetTracker.getOrCreateTodayState()).willReturn(state);
+
+    given(patchVersionService.currentPatchVersion()).willReturn(Optional.of("15.23"));
+
+    CoverageBucket diaBucket = customBucket(Tier.DIAMOND, "15.23", "IV", 100, 0, false, OffsetDateTime.now());
+    given(coverageBucketRepository.findByPatchAndTier("15.23", Tier.DIAMOND)).willReturn(Optional.of(diaBucket));
+    given(coverageBucketRepository.save(any(CoverageBucket.class))).willReturn(diaBucket);
+
+    SeedBootstrapResult seedResult = new SeedBootstrapResult(1, 8, 3, 0, 0);
+    given(seedBootstrapExecutor.execute(any())).willReturn(seedResult);
+
+    runner.runNextChunk();
+
+    assertThat(diaBucket.getSeedDivision()).isEqualTo("I");
+    assertThat(diaBucket.getSeedPage()).isEqualTo(1);
   }
 
   @Test
@@ -245,8 +455,40 @@ class DailySeedRunnerTest {
   }
 
   private CoverageBucket bucketWithDailySeedCompleted(Tier tier, String patch) {
-    CoverageBucket bucket = CoverageBucket.create(patch, tier, 1000L, 1);
-    bucket.markDailySeedCompleted();
-    return bucket;
+    return customBucket(
+        tier,
+        patch,
+        "I",
+        1,
+        props.getDiaEmeDailyPageQuota(),
+        true,
+        OffsetDateTime.now());
+  }
+
+  private CoverageBucket customBucket(
+      Tier tier,
+      String patch,
+      String division,
+      int page,
+      int dailySeedStepsProcessed,
+      boolean dailySeedCompleted,
+      OffsetDateTime dailySeedResetAt) {
+    OffsetDateTime now = OffsetDateTime.now();
+    return CoverageBucket.builder()
+        .patch(patch)
+        .tier(tier)
+        .targetMatchCount(1000L)
+        .currentMatchCount(0L)
+        .status(com.bestduo_BE.coverage.domain.model.CoverageBucketStatus.COLLECTING)
+        .priority(1)
+        .seedDivision(division)
+        .seedPage(page)
+        .dailySeedStepsProcessed(dailySeedStepsProcessed)
+        .dailySeedCompleted(dailySeedCompleted)
+        .dailySeedResetAt(dailySeedResetAt)
+        .lastEvaluatedAt(now)
+        .createdAt(now)
+        .updatedAt(now)
+        .build();
   }
 }


### PR DESCRIPTION
## Summary
- DIA/EME CoverageBucket에 일일 step 추적과 cursor 유지 reset 로직을 추가했습니다.
- DailySeedRunner가 bucket auto-create, 빈 페이지 division rollover, safety cap, 일일 quota 완료 처리를 수행하도록 확장했습니다.
- 관련 설정값과 테스트를 보강하고 schema SQL 문서에 `daily_seed_steps_processed` 컬럼을 반영했습니다.

## Validation
- ./gradlew test --tests com.bestduo_BE.pipeline.application.DailySeedRunnerTest --tests com.bestduo_BE.coverage.infra.persistence.entity.CoverageBucketPhase2Test
- ./gradlew build

## Notes
- 현재 구현은 single-runner 가정에서 동작합니다.
- Oracle 리뷰 기준으로, 운영이 멀티 인스턴스가 아니라면 현재 범위는 머지 가능 상태입니다.