### PR TITLE
feat: DIA/EME 사이클 기반 일일 quota 순환 구현

### DIFF
--- a/src/main/java/com/bestduo_BE/config/PipelineProperties.java
+++ b/src/main/java/com/bestduo_BE/config/PipelineProperties.java
@@ -43,6 +43,15 @@ public class PipelineProperties {
    */
   private int maxPagesPerDivision = 5;
 
+  /**
+   * 자동 생성되는 DIA/EME CoverageBucket의 목표 매치 수.
+   * 버킷 status(COLLECTING/SUFFICIENT) 판단 기준으로만 사용된다.
+   */
+  private long diaEmeCoverageTarget = 500_000L;
+
+  /** DIA/EME 버킷당 하루에 처리할 최대 페이지 수 (per-bucket). */
+  private int diaEmeDailyPageQuota = 10;
+
   /** Stage 3(INGEST)에서 그날 먼저 처리할 tier. ALL_TIERS이면 기존 우선순위(CHALLENGER→…→기타) 유지. */
   private Tier stage3PriorityTier = Tier.ALL_TIERS;
 

--- a/src/main/java/com/bestduo_BE/coverage/infra/persistence/entity/CoverageBucket.java
+++ b/src/main/java/com/bestduo_BE/coverage/infra/persistence/entity/CoverageBucket.java
@@ -69,12 +69,24 @@ public class CoverageBucket {
   // ─────────────────────────────────────────────────────────────────────────
 
   // ── 일일 Seed 완료 상태 ──────────────────────────────────────────────────────
+  /** @deprecated Phase 3에서 제거 예정. Phase 2부터는 dailyPagesProcessed/quota로 판단한다. */
+  @Deprecated
   @Builder.Default
   @Column(name = "daily_seed_completed", nullable = false)
   private boolean dailySeedCompleted = false;
 
   @Column(name = "daily_seed_reset_at")
   private OffsetDateTime dailySeedResetAt;
+
+  /** 오늘 처리한 페이지 수 (자정 리셋). 사이클 위치(seedPage/seedDivision)와 독립적으로 초기화된다. */
+  @Builder.Default
+  @Column(name = "daily_pages_processed", nullable = false)
+  private int dailyPagesProcessed = 0;
+
+  /** 사이클 완주 횟수 (IV → I wrap 발생마다 증가). */
+  @Builder.Default
+  @Column(name = "daily_cycle_count", nullable = false)
+  private int dailyCycleCount = 0;
   // ─────────────────────────────────────────────────────────────────────────
 
   @Column(name = "last_evaluated_at", nullable = false)
@@ -110,29 +122,61 @@ public class CoverageBucket {
    *
    * <p>apex 티어(MASTER/GRANDMASTER/CHALLENGER)는 Riot league-v4가 division 없이 단일 리그를
    * 제공하므로 페이지만 증가한다.
-   * 그 외 티어는 페이지가 maxPagesPerDivision에 도달하면 다음 division(I→II→III→IV→I)으로 rotation.
+   * 그 외 티어는 페이지가 maxPagesPerDivision(safety cap)에 도달하면 {@link #advanceToNextDivision()}을 통해
+   * 다음 division으로 이동한다. 정상 경로에서는 빈 응답이 먼저 division 전환을 트리거한다.
    */
   public void advanceSeedState(int maxPagesPerDivision) {
     if (APEX_TIERS.contains(this.tier)) {
       this.seedPage++;
     } else if (this.seedPage >= maxPagesPerDivision) {
-      int idx = DIVISIONS.indexOf(this.seedDivision);
-      this.seedDivision = DIVISIONS.get((idx + 1) % DIVISIONS.size());
-      this.seedPage = 1;
+      advanceToNextDivision();
     } else {
       this.seedPage++;
     }
     this.updatedAt = OffsetDateTime.now();
   }
 
-  /** 오늘 이 bucket의 seed를 완료했음을 기록한다. */
+  /**
+   * 빈 페이지 응답 시 호출. 현재 division이 소진됐으므로 다음 division의 1페이지로 이동.
+   * IV → I wrap 발생 시 {@code dailyCycleCount}를 증가시킨다.
+   */
+  public void advanceToNextDivision() {
+    int idx = DIVISIONS.indexOf(this.seedDivision);
+    boolean cycleCompleted = (idx == DIVISIONS.size() - 1);
+    this.seedDivision = DIVISIONS.get((idx + 1) % DIVISIONS.size());
+    this.seedPage = 1;
+    if (cycleCompleted) {
+      this.dailyCycleCount++;
+    }
+    this.updatedAt = OffsetDateTime.now();
+  }
+
+  /** 오늘 처리량을 1 증가시킨다. 빈 응답 포함 항상 호출해야 한다. */
+  public void incrementDailyPagesProcessed() {
+    this.dailyPagesProcessed++;
+    this.updatedAt = OffsetDateTime.now();
+  }
+
+  /**
+   * 오늘 처리 가능한 quota가 남아있으면 true.
+   *
+   * @param quota 하루 최대 처리 페이지 수
+   */
+  public boolean hasRemainingDailyQuota(int quota) {
+    return this.dailyPagesProcessed < quota;
+  }
+
+  /** @deprecated Phase 3에서 제거 예정. {@link #hasRemainingDailyQuota} 로 대체. */
+  @Deprecated
   public void markDailySeedCompleted() {
     this.dailySeedCompleted = true;
     this.updatedAt = OffsetDateTime.now();
   }
 
   /**
-   * 자정 경계를 넘었으면 dailySeedCompleted를 리셋하고 dailySeedResetAt을 오늘 자정으로 기록한다.
+   * 자정 경계를 넘었으면 {@code dailyPagesProcessed}와 {@code dailySeedCompleted}를 리셋하고
+   * {@code dailySeedResetAt}을 오늘 자정으로 기록한다.
+   * {@code seedPage} / {@code seedDivision}은 사이클 위치를 유지하기 위해 변경하지 않는다.
    *
    * @param lastResetAt 마지막으로 리셋된 시점 (null이면 한 번도 리셋 안 함)
    * @param today       오늘 날짜
@@ -144,6 +188,7 @@ public class CoverageBucket {
       return;
     }
     this.dailySeedCompleted = false;
+    this.dailyPagesProcessed = 0;
     this.dailySeedResetAt = today.atStartOfDay().atOffset(OffsetDateTime.now().getOffset());
     this.updatedAt = OffsetDateTime.now();
   }

--- a/src/main/java/com/bestduo_BE/pipeline/application/DailySeedRunner.java
+++ b/src/main/java/com/bestduo_BE/pipeline/application/DailySeedRunner.java
@@ -87,9 +87,9 @@ public class DailySeedRunner {
       return ChunkResult.noWork();
     }
     for (Tier tier : DIA_EME_TIERS) {
-      Optional<CoverageBucket> opt = coverageBucketRepository.findByPatchAndTier(currentPatch, tier);
-      if (opt.isPresent() && !opt.get().isDailySeedCompleted()) {
-        return runDiaEmePage(opt.get(), tier);
+      CoverageBucket bucket = getOrCreateBucket(currentPatch, tier);
+      if (bucket.hasRemainingDailyQuota(props.getDiaEmeDailyPageQuota())) {
+        return runDiaEmePage(bucket, tier);
       }
     }
 
@@ -114,11 +114,22 @@ public class DailySeedRunner {
     }
     for (Tier tier : DIA_EME_TIERS) {
       Optional<CoverageBucket> opt = coverageBucketRepository.findByPatchAndTier(currentPatch, tier);
-      if (opt.isPresent() && !opt.get().isDailySeedCompleted()) {
+      if (opt.isEmpty() || opt.get().hasRemainingDailyQuota(props.getDiaEmeDailyPageQuota())) {
         return true;
       }
     }
     return false;
+  }
+
+  private CoverageBucket getOrCreateBucket(String patch, Tier tier) {
+    return coverageBucketRepository.findByPatchAndTier(patch, tier)
+        .orElseGet(() -> {
+          int priority = DIA_EME_TIERS.indexOf(tier) + 1;
+          CoverageBucket newBucket = CoverageBucket.create(
+              patch, tier, props.getDiaEmeCoverageTarget(), priority);
+          log.info("CoverageBucket 자동 생성: patch={} tier={}", patch, tier);
+          return coverageBucketRepository.save(newBucket);
+        });
   }
 
   private ChunkResult runApexTierChunk(Tier tier) {
@@ -154,15 +165,16 @@ public class DailySeedRunner {
     budgetTracker.recordSeedCall(1);
 
     if (result.entriesFetched() == 0) {
-      // 페이지가 비었으면 해당 bucket 오늘 완료로 표시
-      bucket.markDailySeedCompleted();
-      coverageBucketRepository.save(bucket);
-      log.info("Stage1 DIA/EME bucket 완료: tier={}", tier);
+      // 빈 응답 = 해당 division 소진 → 다음 division으로 이동
+      bucket.advanceToNextDivision();
+      log.info("Stage1 DIA/EME division 소진, 다음 division으로 이동: tier={} division={}",
+          tier, bucket.getSeedDivision());
     } else {
-      // 다음 페이지/division으로 전진
+      // 정상 응답: 다음 페이지로 전진 (safety cap 도달 시 advanceToNextDivision 위임)
       bucket.advanceSeedState(props.getMaxPagesPerDivision());
-      coverageBucketRepository.save(bucket);
     }
+    bucket.incrementDailyPagesProcessed();
+    coverageBucketRepository.save(bucket);
 
     return ChunkResult.diaEmePage(tier, result.summonersSeeded());
   }

--- a/src/test/java/com/bestduo_BE/coverage/infra/persistence/entity/CoverageBucketCycleTest.java
+++ b/src/test/java/com/bestduo_BE/coverage/infra/persistence/entity/CoverageBucketCycleTest.java
@@ -1,0 +1,158 @@
+package com.bestduo_BE.coverage.infra.persistence.entity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.bestduo_BE.common.domain.model.Tier;
+import java.time.LocalDate;
+import java.time.OffsetDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class CoverageBucketCycleTest {
+
+  private CoverageBucket bucket() {
+    return CoverageBucket.create("15.7", Tier.DIAMOND, 500_000L, 1);
+  }
+
+  // ── advanceToNextDivision ──────────────────────────────────────────
+
+  @Test
+  @DisplayName("advanceToNextDivision() — I에서 호출하면 II/1로 이동한다")
+  void advanceToNextDivision_fromI_movesToII() {
+    CoverageBucket b = bucket(); // 기본 I/1
+    b.advanceToNextDivision();
+
+    assertThat(b.getSeedDivision()).isEqualTo("II");
+    assertThat(b.getSeedPage()).isEqualTo(1);
+  }
+
+  @Test
+  @DisplayName("advanceToNextDivision() — II에서 호출하면 III/1로 이동한다")
+  void advanceToNextDivision_fromII_movesToIII() {
+    CoverageBucket b = bucket();
+    b.advanceToNextDivision(); // I → II
+
+    b.advanceToNextDivision(); // II → III
+
+    assertThat(b.getSeedDivision()).isEqualTo("III");
+    assertThat(b.getSeedPage()).isEqualTo(1);
+  }
+
+  @Test
+  @DisplayName("advanceToNextDivision() — III에서 호출하면 IV/1로 이동한다")
+  void advanceToNextDivision_fromIII_movesToIV() {
+    CoverageBucket b = bucket();
+    b.advanceToNextDivision(); // I → II
+    b.advanceToNextDivision(); // II → III
+
+    b.advanceToNextDivision(); // III → IV
+
+    assertThat(b.getSeedDivision()).isEqualTo("IV");
+    assertThat(b.getSeedPage()).isEqualTo(1);
+  }
+
+  @Test
+  @DisplayName("advanceToNextDivision() — IV에서 호출하면 I/1로 wrap되고 dailyCycleCount가 증가한다")
+  void advanceToNextDivision_fromIV_wrapsToIAndIncrementsCycleCount() {
+    CoverageBucket b = bucket();
+    b.advanceToNextDivision(); // I → II
+    b.advanceToNextDivision(); // II → III
+    b.advanceToNextDivision(); // III → IV
+
+    b.advanceToNextDivision(); // IV → I (사이클 완주)
+
+    assertThat(b.getSeedDivision()).isEqualTo("I");
+    assertThat(b.getSeedPage()).isEqualTo(1);
+    assertThat(b.getDailyCycleCount()).isEqualTo(1);
+  }
+
+  @Test
+  @DisplayName("advanceToNextDivision() — 사이클이 아닌 전환에서는 dailyCycleCount가 증가하지 않는다")
+  void advanceToNextDivision_nonWrap_doesNotIncrementCycleCount() {
+    CoverageBucket b = bucket();
+
+    b.advanceToNextDivision(); // I → II
+
+    assertThat(b.getDailyCycleCount()).isEqualTo(0);
+  }
+
+  // ── hasRemainingDailyQuota ─────────────────────────────────────────
+
+  @Test
+  @DisplayName("hasRemainingDailyQuota() — 처리량이 quota 미만이면 true")
+  void hasRemainingDailyQuota_belowQuota_returnsTrue() {
+    CoverageBucket b = bucket(); // dailyPagesProcessed = 0
+
+    assertThat(b.hasRemainingDailyQuota(10)).isTrue();
+  }
+
+  @Test
+  @DisplayName("hasRemainingDailyQuota() — 처리량이 quota와 같으면 false")
+  void hasRemainingDailyQuota_equalsQuota_returnsFalse() {
+    CoverageBucket b = bucket();
+    for (int i = 0; i < 10; i++) {
+      b.incrementDailyPagesProcessed();
+    }
+
+    assertThat(b.hasRemainingDailyQuota(10)).isFalse();
+  }
+
+  @Test
+  @DisplayName("hasRemainingDailyQuota() — 처리량이 quota 초과이면 false")
+  void hasRemainingDailyQuota_exceedsQuota_returnsFalse() {
+    CoverageBucket b = bucket();
+    for (int i = 0; i < 11; i++) {
+      b.incrementDailyPagesProcessed();
+    }
+
+    assertThat(b.hasRemainingDailyQuota(10)).isFalse();
+  }
+
+  // ── incrementDailyPagesProcessed ──────────────────────────────────
+
+  @Test
+  @DisplayName("incrementDailyPagesProcessed() — 호출할 때마다 dailyPagesProcessed가 1씩 증가한다")
+  void incrementDailyPagesProcessed_incrementsByOne() {
+    CoverageBucket b = bucket();
+
+    b.incrementDailyPagesProcessed();
+    b.incrementDailyPagesProcessed();
+
+    assertThat(b.getDailyPagesProcessed()).isEqualTo(2);
+  }
+
+  // ── resetDailySeedIfNeeded (Phase 2 동작) ─────────────────────────
+
+  @Test
+  @DisplayName("resetDailySeedIfNeeded() — dailyPagesProcessed를 0으로 리셋하고 seedPage·seedDivision은 유지한다")
+  void resetDailySeedIfNeeded_resetsPagesProcessed_preservesSeedPosition() {
+    CoverageBucket b = bucket();
+    b.advanceToNextDivision(); // I → II
+    b.advanceSeedState(100);   // seedPage = 2
+    for (int i = 0; i < 5; i++) {
+      b.incrementDailyPagesProcessed();
+    }
+
+    OffsetDateTime yesterday = OffsetDateTime.now().minusDays(1);
+    b.resetDailySeedIfNeeded(yesterday, LocalDate.now());
+
+    assertThat(b.getDailyPagesProcessed()).isEqualTo(0);
+    assertThat(b.getSeedDivision()).isEqualTo("II");
+    assertThat(b.getSeedPage()).isEqualTo(2);
+  }
+
+  @Test
+  @DisplayName("resetDailySeedIfNeeded() — 오늘 이미 리셋했으면 dailyPagesProcessed를 변경하지 않는다")
+  void resetDailySeedIfNeeded_alreadyResetToday_doesNotReset() {
+    CoverageBucket b = bucket();
+    for (int i = 0; i < 5; i++) {
+      b.incrementDailyPagesProcessed();
+    }
+
+    OffsetDateTime todayMidnight = LocalDate.now().atStartOfDay()
+        .atOffset(OffsetDateTime.now().getOffset());
+    b.resetDailySeedIfNeeded(todayMidnight, LocalDate.now());
+
+    assertThat(b.getDailyPagesProcessed()).isEqualTo(5);
+  }
+}

--- a/src/test/java/com/bestduo_BE/pipeline/application/DailySeedRunnerTest.java
+++ b/src/test/java/com/bestduo_BE/pipeline/application/DailySeedRunnerTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
@@ -72,8 +73,8 @@ class DailySeedRunnerTest {
   }
 
   @Test
-  @DisplayName("모든 apex·DIA·EME 완료 시 hasWorkToday는 false")
-  void hasWorkToday_whenAllCompleted_returnsFalse() {
+  @DisplayName("모든 apex·DIA·EME quota 소진 시 hasWorkToday는 false")
+  void hasWorkToday_whenAllQuotaExhausted_returnsFalse() {
     given(budgetTracker.canSeed()).willReturn(true);
 
     DailyPipelineState state = DailyPipelineState.create(LocalDate.now());
@@ -82,8 +83,8 @@ class DailySeedRunnerTest {
     state.recordSeedCompletedTier("MASTER");
     given(budgetTracker.getOrCreateTodayState()).willReturn(state);
 
-    CoverageBucket diaBucket = bucketWithDailySeedCompleted(Tier.DIAMOND, "15.23");
-    CoverageBucket emeBucket = bucketWithDailySeedCompleted(Tier.EMERALD, "15.23");
+    CoverageBucket diaBucket = bucketWithQuotaExhausted(Tier.DIAMOND, "15.23");
+    CoverageBucket emeBucket = bucketWithQuotaExhausted(Tier.EMERALD, "15.23");
     given(patchVersionService.currentPatchVersion()).willReturn(Optional.of("15.23"));
     given(coverageBucketRepository.findByPatchAndTier("15.23", Tier.DIAMOND)).willReturn(Optional.of(diaBucket));
     given(coverageBucketRepository.findByPatchAndTier("15.23", Tier.EMERALD)).willReturn(Optional.of(emeBucket));
@@ -92,8 +93,8 @@ class DailySeedRunnerTest {
   }
 
   @Test
-  @DisplayName("DIA 버킷이 미완료이면 hasWorkToday는 true")
-  void hasWorkToday_whenDiaBucketNotCompleted_returnsTrue() {
+  @DisplayName("DIA 버킷의 quota가 남아있으면 hasWorkToday는 true")
+  void hasWorkToday_whenDiaBucketHasRemainingQuota_returnsTrue() {
     given(budgetTracker.canSeed()).willReturn(true);
 
     DailyPipelineState state = DailyPipelineState.create(LocalDate.now());
@@ -103,8 +104,9 @@ class DailySeedRunnerTest {
     given(budgetTracker.getOrCreateTodayState()).willReturn(state);
 
     given(patchVersionService.currentPatchVersion()).willReturn(Optional.of("15.23"));
-    CoverageBucket diaIncomplete = bucketNotCompleted(Tier.DIAMOND, "15.23");
-    given(coverageBucketRepository.findByPatchAndTier("15.23", Tier.DIAMOND)).willReturn(Optional.of(diaIncomplete));
+    // fresh bucket: dailyPagesProcessed=0 < quota=10
+    CoverageBucket diaFresh = bucketNotCompleted(Tier.DIAMOND, "15.23");
+    given(coverageBucketRepository.findByPatchAndTier("15.23", Tier.DIAMOND)).willReturn(Optional.of(diaFresh));
 
     assertThat(runner.hasWorkToday()).isTrue();
   }
@@ -171,8 +173,8 @@ class DailySeedRunnerTest {
   }
 
   @Test
-  @DisplayName("DIA 페이지가 빈 응답이면 해당 버킷을 dailySeedCompleted로 표시")
-  void runNextChunk_whenDiaPageEmpty_marksBucketCompleted() {
+  @DisplayName("DIA 페이지가 빈 응답이면 advanceToNextDivision을 호출하고 quota를 카운트한다")
+  void runNextChunk_whenDiaPageEmpty_advancesToNextDivisionAndCountsQuota() {
     given(budgetTracker.canSeed()).willReturn(true);
 
     DailyPipelineState state = DailyPipelineState.create(LocalDate.now());
@@ -193,13 +195,44 @@ class DailySeedRunnerTest {
 
     runner.runNextChunk();
 
-    assertThat(diaBucket.isDailySeedCompleted()).isTrue();
+    // 빈 응답 → division 전환 (I → II), quota 카운트
+    assertThat(diaBucket.getSeedDivision()).isEqualTo("II");
+    assertThat(diaBucket.getSeedPage()).isEqualTo(1);
+    assertThat(diaBucket.getDailyPagesProcessed()).isEqualTo(1);
     verify(coverageBucketRepository).save(diaBucket);
   }
 
   @Test
-  @DisplayName("모든 티어 완료 시 runNextChunk는 NO_WORK 반환")
-  void runNextChunk_whenAllCompleted_returnsNoWork() {
+  @DisplayName("DIA 페이지가 정상 응답이면 seedPage가 증가하고 quota를 카운트한다")
+  void runNextChunk_whenDiaPageNotEmpty_advancesPageAndCountsQuota() {
+    given(budgetTracker.canSeed()).willReturn(true);
+
+    DailyPipelineState state = DailyPipelineState.create(LocalDate.now());
+    state.recordSeedCompletedTier("CHALLENGER");
+    state.recordSeedCompletedTier("GRANDMASTER");
+    state.recordSeedCompletedTier("MASTER");
+    given(budgetTracker.getOrCreateTodayState()).willReturn(state);
+
+    given(patchVersionService.currentPatchVersion()).willReturn(Optional.of("15.23"));
+
+    CoverageBucket diaBucket = bucketNotCompleted(Tier.DIAMOND, "15.23");
+    given(coverageBucketRepository.findByPatchAndTier("15.23", Tier.DIAMOND)).willReturn(Optional.of(diaBucket));
+    given(coverageBucketRepository.save(any(CoverageBucket.class))).willReturn(diaBucket);
+
+    // 정상 응답
+    SeedBootstrapResult normalResult = new SeedBootstrapResult(1, 10, 5, 0, 0);
+    given(seedBootstrapExecutor.execute(any())).willReturn(normalResult);
+
+    runner.runNextChunk();
+
+    assertThat(diaBucket.getSeedPage()).isEqualTo(2);
+    assertThat(diaBucket.getDailyPagesProcessed()).isEqualTo(1);
+    verify(coverageBucketRepository).save(diaBucket);
+  }
+
+  @Test
+  @DisplayName("모든 티어 quota 소진 시 runNextChunk는 NO_WORK 반환")
+  void runNextChunk_whenAllQuotaExhausted_returnsNoWork() {
     given(budgetTracker.canSeed()).willReturn(true);
 
     DailyPipelineState state = DailyPipelineState.create(LocalDate.now());
@@ -210,13 +243,66 @@ class DailySeedRunnerTest {
 
     given(patchVersionService.currentPatchVersion()).willReturn(Optional.of("15.23"));
     given(coverageBucketRepository.findByPatchAndTier("15.23", Tier.DIAMOND))
-        .willReturn(Optional.of(bucketWithDailySeedCompleted(Tier.DIAMOND, "15.23")));
+        .willReturn(Optional.of(bucketWithQuotaExhausted(Tier.DIAMOND, "15.23")));
     given(coverageBucketRepository.findByPatchAndTier("15.23", Tier.EMERALD))
-        .willReturn(Optional.of(bucketWithDailySeedCompleted(Tier.EMERALD, "15.23")));
+        .willReturn(Optional.of(bucketWithQuotaExhausted(Tier.EMERALD, "15.23")));
 
     DailySeedRunner.ChunkResult result = runner.runNextChunk();
 
     assertThat(result.type()).isEqualTo(DailySeedRunner.ChunkResult.Type.NO_WORK);
+  }
+
+  // ── Phase 1: 버킷 자동 생성 ────────────────────────────────────────
+
+  @Test
+  @DisplayName("DIA 버킷이 DB에 없으면 hasWorkToday는 true를 반환한다")
+  void hasWorkToday_whenDiaBucketMissing_returnsTrue() {
+    given(budgetTracker.canSeed()).willReturn(true);
+
+    DailyPipelineState state = DailyPipelineState.create(LocalDate.now());
+    state.recordSeedCompletedTier("CHALLENGER");
+    state.recordSeedCompletedTier("GRANDMASTER");
+    state.recordSeedCompletedTier("MASTER");
+    given(budgetTracker.getOrCreateTodayState()).willReturn(state);
+
+    given(patchVersionService.currentPatchVersion()).willReturn(Optional.of("15.23"));
+    given(coverageBucketRepository.findByPatchAndTier("15.23", Tier.DIAMOND)).willReturn(Optional.empty());
+
+    assertThat(runner.hasWorkToday()).isTrue();
+  }
+
+  @Test
+  @DisplayName("DIA 버킷이 DB에 없으면 runNextChunk는 버킷을 생성하고 DIA 페이지를 실행한다")
+  void runNextChunk_whenDiaBucketMissing_createsBucketAndExecutesDiaPage() {
+    given(budgetTracker.canSeed()).willReturn(true);
+
+    DailyPipelineState state = DailyPipelineState.create(LocalDate.now());
+    state.recordSeedCompletedTier("CHALLENGER");
+    state.recordSeedCompletedTier("GRANDMASTER");
+    state.recordSeedCompletedTier("MASTER");
+    given(budgetTracker.getOrCreateTodayState()).willReturn(state);
+
+    given(patchVersionService.currentPatchVersion()).willReturn(Optional.of("15.23"));
+    given(coverageBucketRepository.findByPatchAndTier("15.23", Tier.DIAMOND)).willReturn(Optional.empty());
+
+    CoverageBucket savedBucket = CoverageBucket.create("15.23", Tier.DIAMOND, props.getDiaEmeCoverageTarget(), 1);
+    given(coverageBucketRepository.save(argThat(b ->
+        b.getTier() == Tier.DIAMOND && b.getPatch().equals("15.23") && b.isDailySeedCompleted() == false
+    ))).willReturn(savedBucket);
+
+    SeedBootstrapResult seedResult = new SeedBootstrapResult(1, 10, 3, 0, 0);
+    given(seedBootstrapExecutor.execute(argThat(cmd ->
+        "DIAMOND".equals(cmd.tier()) && cmd.startPage() == 1
+    ))).willReturn(seedResult);
+
+    DailySeedRunner.ChunkResult chunk = runner.runNextChunk();
+
+    assertThat(chunk.type()).isEqualTo(DailySeedRunner.ChunkResult.Type.DIA_EME_PAGE);
+    assertThat(chunk.tier()).isEqualTo(Tier.DIAMOND);
+    // 버킷 생성 시 save 1회 이상 호출됨을 검증
+    verify(coverageBucketRepository, atLeastOnce()).save(argThat(b ->
+        b.getTier() == Tier.DIAMOND && b.getPatch().equals("15.23")
+    ));
   }
 
   @Test
@@ -238,6 +324,28 @@ class DailySeedRunnerTest {
     verify(coverageBucketRepository, never()).findByPatchAndTier(any(), any());
   }
 
+  // ── Phase 2: quota 기반 ────────────────────────────────────────────
+
+  @Test
+  @DisplayName("DIA quota가 소진됐으면 hasWorkToday는 false를 반환한다")
+  void hasWorkToday_whenDiaQuotaExhausted_returnsFalse() {
+    given(budgetTracker.canSeed()).willReturn(true);
+
+    DailyPipelineState state = DailyPipelineState.create(LocalDate.now());
+    state.recordSeedCompletedTier("CHALLENGER");
+    state.recordSeedCompletedTier("GRANDMASTER");
+    state.recordSeedCompletedTier("MASTER");
+    given(budgetTracker.getOrCreateTodayState()).willReturn(state);
+
+    given(patchVersionService.currentPatchVersion()).willReturn(Optional.of("15.23"));
+    given(coverageBucketRepository.findByPatchAndTier("15.23", Tier.DIAMOND))
+        .willReturn(Optional.of(bucketWithQuotaExhausted(Tier.DIAMOND, "15.23")));
+    given(coverageBucketRepository.findByPatchAndTier("15.23", Tier.EMERALD))
+        .willReturn(Optional.of(bucketWithQuotaExhausted(Tier.EMERALD, "15.23")));
+
+    assertThat(runner.hasWorkToday()).isFalse();
+  }
+
   // ── helpers ────────────────────────────────────────────────────────
 
   private CoverageBucket bucketNotCompleted(Tier tier, String patch) {
@@ -247,6 +355,15 @@ class DailySeedRunnerTest {
   private CoverageBucket bucketWithDailySeedCompleted(Tier tier, String patch) {
     CoverageBucket bucket = CoverageBucket.create(patch, tier, 1000L, 1);
     bucket.markDailySeedCompleted();
+    return bucket;
+  }
+
+  /** dailyPagesProcessed = quota(기본값 10)로 설정한 버킷 */
+  private CoverageBucket bucketWithQuotaExhausted(Tier tier, String patch) {
+    CoverageBucket bucket = CoverageBucket.create(patch, tier, 1000L, 1);
+    for (int i = 0; i < props.getDiaEmeDailyPageQuota(); i++) {
+      bucket.incrementDailyPagesProcessed();
+    }
     return bucket;
   }
 }


### PR DESCRIPTION
## Summary

- **Phase 1** — CoverageBucket 자동 생성: 버킷이 DB에 없어도 `runNextChunk` 진입 시 자동 생성 후 실행
- **Phase 2** — 사이클 기반 quota: 빈 응답 시 division 전환(`advanceToNextDivision`), 일일 `diaEmeDailyPageQuota` 페이지 처리 후 정지, 자정 리셋 시 `seedPage`/`seedDivision` 유지 (사이클 위치 영속)

## 핵심 변경

| 파일 | 변경 내용 |
|---|---|
| `CoverageBucket` | `dailyPagesProcessed`, `dailyCycleCount` 필드 추가; `advanceToNextDivision()`, `hasRemainingDailyQuota()`, `incrementDailyPagesProcessed()` 신규; `resetDailySeedIfNeeded()`는 `dailyPagesProcessed`만 리셋 |
| `DailySeedRunner` | `getOrCreateBucket()` 헬퍼 추가; 빈 응답 → `advanceToNextDivision`; 항상 `incrementDailyPagesProcessed`; quota 기반 판단 |
| `PipelineProperties` | `diaEmeDailyPageQuota = 10` 추가 |
| `CoverageBucketCycleTest` | 신규: `advanceToNextDivision` 전환·wrap, quota 소진/잔여 시나리오 |
| `DailySeedRunnerTest` | Phase 1·2 테스트 추가 및 기존 `dailySeedCompleted` 기반 테스트 quota 기반으로 전환 |

## Test plan

- [x] `./gradlew test` 전체 통과 확인
- [x] `CoverageBucketCycleTest` — I→II→III→IV→I wrap, `dailyCycleCount` 증가, quota 소진/잔여
- [x] `DailySeedRunnerTest` — 버킷 자동 생성, 빈 응답 division 전환 + quota 카운트, quota 소진 시 NO_WORK
- [ ] `dailySeedCompleted` 필드·메서드 제거 (Phase 3)

> Closes #29 (재구현으로 대체)