### PR TITLE
refactor: dailySeedCompleted 제거 (Phase 3)

### DIFF
--- a/src/main/java/com/bestduo_BE/coverage/infra/persistence/entity/CoverageBucket.java
+++ b/src/main/java/com/bestduo_BE/coverage/infra/persistence/entity/CoverageBucket.java
@@ -55,12 +55,6 @@ public class CoverageBucket {
   // ─────────────────────────────────────────────────────────────────────────
 
   // ── 일일 Seed 완료 상태 ──────────────────────────────────────────────────────
-  /** @deprecated Phase 3에서 제거 예정. Phase 2부터는 dailyPagesProcessed/quota로 판단한다. */
-  @Deprecated
-  @Builder.Default
-  @Column(name = "daily_seed_completed", nullable = false)
-  private boolean dailySeedCompleted = false;
-
   @Column(name = "daily_seed_reset_at")
   private OffsetDateTime dailySeedResetAt;
 
@@ -144,15 +138,9 @@ public class CoverageBucket {
     return this.dailyPagesProcessed < quota;
   }
 
-  /** @deprecated Phase 3에서 제거 예정. {@link #hasRemainingDailyQuota} 로 대체. */
-  @Deprecated
-  public void markDailySeedCompleted() {
-    this.dailySeedCompleted = true;
-    this.updatedAt = OffsetDateTime.now();
-  }
 
   /**
-   * 자정 경계를 넘었으면 {@code dailyPagesProcessed}와 {@code dailySeedCompleted}를 리셋하고
+   * 자정 경계를 넘었으면 {@code dailyPagesProcessed}를 리셋하고
    * {@code dailySeedResetAt}을 오늘 자정으로 기록한다.
    * {@code seedPage} / {@code seedDivision}은 사이클 위치를 유지하기 위해 변경하지 않는다.
    *
@@ -165,7 +153,6 @@ public class CoverageBucket {
     if (!needsReset) {
       return;
     }
-    this.dailySeedCompleted = false;
     this.dailyPagesProcessed = 0;
     this.dailySeedResetAt = today.atStartOfDay().atOffset(OffsetDateTime.now().getOffset());
     this.updatedAt = OffsetDateTime.now();

--- a/src/test/java/com/bestduo_BE/coverage/infra/persistence/entity/CoverageBucketPhase2Test.java
+++ b/src/test/java/com/bestduo_BE/coverage/infra/persistence/entity/CoverageBucketPhase2Test.java
@@ -15,57 +15,50 @@ class CoverageBucketPhase2Test {
   }
 
   @Test
-  @DisplayName("create() — dailySeedCompleted는 false, dailySeedResetAt은 null로 초기화된다")
-  void createInitializesDailySeedFields() {
+  @DisplayName("create() — dailySeedResetAt은 null로 초기화된다")
+  void createInitializesDailySeedResetAtAsNull() {
     CoverageBucket b = bucket();
 
-    assertThat(b.isDailySeedCompleted()).isFalse();
     assertThat(b.getDailySeedResetAt()).isNull();
-  }
-
-  @Test
-  @DisplayName("markDailySeedCompleted() — dailySeedCompleted가 true로 설정된다")
-  void markDailySeedCompletedSetsFlag() {
-    CoverageBucket b = bucket();
-
-    b.markDailySeedCompleted();
-
-    assertThat(b.isDailySeedCompleted()).isTrue();
   }
 
   @Test
   @DisplayName("resetDailySeedIfNeeded() — dailySeedResetAt이 오늘 이전이면 리셋한다")
   void resetDailySeedIfNeededResetsWhenOutdated() {
     CoverageBucket b = bucket();
-    b.markDailySeedCompleted();
-    // 어제 리셋 시점 설정 (오늘보다 이전)
     OffsetDateTime yesterday = OffsetDateTime.now().minusDays(1);
+
     b.resetDailySeedIfNeeded(yesterday, LocalDate.now());
 
-    assertThat(b.isDailySeedCompleted()).isFalse();
     assertThat(b.getDailySeedResetAt()).isNotNull();
+    assertThat(b.getDailyPagesProcessed()).isZero();
   }
 
   @Test
   @DisplayName("resetDailySeedIfNeeded() — dailySeedResetAt이 오늘이면 리셋하지 않는다")
   void resetDailySeedIfNeededSkipsWhenAlreadyResetToday() {
     CoverageBucket b = bucket();
-    b.markDailySeedCompleted();
+    for (int i = 0; i < 3; i++) {
+      b.incrementDailyPagesProcessed();
+    }
     OffsetDateTime todayTime = OffsetDateTime.now().withHour(0).withMinute(0).withSecond(0).withNano(0);
+
     b.resetDailySeedIfNeeded(todayTime, LocalDate.now());
 
-    // 이미 오늘 리셋했으면 completed가 true 유지
-    assertThat(b.isDailySeedCompleted()).isTrue();
+    assertThat(b.getDailyPagesProcessed()).isEqualTo(3);
   }
 
   @Test
   @DisplayName("resetDailySeedIfNeeded() — dailySeedResetAt이 null이면 리셋한다")
   void resetDailySeedIfNeededResetsWhenNullResetAt() {
     CoverageBucket b = bucket();
-    b.markDailySeedCompleted();
+    for (int i = 0; i < 3; i++) {
+      b.incrementDailyPagesProcessed();
+    }
 
     b.resetDailySeedIfNeeded(null, LocalDate.now());
 
-    assertThat(b.isDailySeedCompleted()).isFalse();
+    assertThat(b.getDailyPagesProcessed()).isZero();
+    assertThat(b.getDailySeedResetAt()).isNotNull();
   }
 }

--- a/src/test/java/com/bestduo_BE/pipeline/application/DailySeedRunnerTest.java
+++ b/src/test/java/com/bestduo_BE/pipeline/application/DailySeedRunnerTest.java
@@ -287,7 +287,7 @@ class DailySeedRunnerTest {
 
     CoverageBucket savedBucket = CoverageBucket.create("15.23", Tier.DIAMOND);
     given(coverageBucketRepository.save(argThat(b ->
-        b.getTier() == Tier.DIAMOND && b.getPatch().equals("15.23") && b.isDailySeedCompleted() == false
+        b.getTier() == Tier.DIAMOND && b.getPatch().equals("15.23")
     ))).willReturn(savedBucket);
 
     SeedBootstrapResult seedResult = new SeedBootstrapResult(1, 10, 3, 0, 0);
@@ -350,12 +350,6 @@ class DailySeedRunnerTest {
 
   private CoverageBucket bucketNotCompleted(Tier tier, String patch) {
     return CoverageBucket.create(patch, tier);
-  }
-
-  private CoverageBucket bucketWithDailySeedCompleted(Tier tier, String patch) {
-    CoverageBucket bucket = CoverageBucket.create(patch, tier);
-    bucket.markDailySeedCompleted();
-    return bucket;
   }
 
   /** dailyPagesProcessed = quota(기본값 10)로 설정한 버킷 */


### PR DESCRIPTION
## Summary

Phase 2에서 `@Deprecated` 처리했던 항목을 정리한다.

- `CoverageBucket.dailySeedCompleted` 필드 제거 (`daily_seed_completed` 컬럼 — `ddl-auto: update`로 자동 반영)
- `markDailySeedCompleted()` 메서드 제거
- `resetDailySeedIfNeeded()`에서 `dailySeedCompleted` 초기화 코드 제거

## Test plan

- [x] `./gradlew build` 통과
- [x] `CoverageBucketPhase2Test` — deprecated 항목 테스트 제거, `dailySeedResetAt` / `dailyPagesProcessed` 동작 검증으로 재작성
- [x] `DailySeedRunnerTest` — `isDailySeedCompleted()` 조건 및 dead helper(`bucketWithDailySeedCompleted`) 제거