### PR TITLE
feat: 신규 패치 3일 유예 기간(grace period) 도입

### DIFF
--- a/src/main/java/com/bestduo_BE/common/application/PatchVersionService.java
+++ b/src/main/java/com/bestduo_BE/common/application/PatchVersionService.java
@@ -1,8 +1,10 @@
 package com.bestduo_BE.common.application;
 
+import com.bestduo_BE.common.domain.model.EffectivePatchContext;
 import com.bestduo_BE.common.infra.persistence.entity.PatchVersion;
 import com.bestduo_BE.common.infra.persistence.repository.PatchVersionJpaRepository;
 import java.time.OffsetDateTime;
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -10,6 +12,12 @@ import org.springframework.stereotype.Service;
 @Service
 @RequiredArgsConstructor
 public class PatchVersionService {
+
+  /**
+   * 새 패치 출시 직후에는 게임 데이터가 부족해 match ID 수집이 빈 결과를 반환한다.
+   * 출시 후 이 일수가 지나야 최신 패치를 effective patch로 승격한다.
+   */
+  private static final int PATCH_GRACE_PERIOD_DAYS = 3;
 
   private final PatchVersionJpaRepository patchVersionRepository;
 
@@ -28,6 +36,42 @@ public class PatchVersionService {
   /** 최신 PatchVersion 엔티티 반환. 데이터 없으면 Optional.empty() */
   public Optional<PatchVersion> currentPatch() {
     return patchVersionRepository.findTopByOrderByReleasedAtDesc();
+  }
+
+  /**
+   * match ID 수집에 사용할 "유효 패치" 컨텍스트를 반환한다.
+   *
+   * <p>최신 패치 출시 후 {@code PATCH_GRACE_PERIOD_DAYS}일 미만이면 grace period:
+   * <ul>
+   *   <li>이전 패치가 있으면 이전 패치를 effective patch로 사용하고 endTime을 설정한다.</li>
+   *   <li>이전 패치가 없으면(패치가 1개뿐) 최신 패치로 graceful fallback (endTime 없음).</li>
+   * </ul>
+   * 그 외에는 최신 패치를 그대로 사용한다.
+   */
+  public Optional<EffectivePatchContext> resolveEffectivePatchContext() {
+    List<PatchVersion> recent = patchVersionRepository.findTop2ByOrderByReleasedAtDesc();
+    if (recent.isEmpty()) {
+      return Optional.empty();
+    }
+
+    PatchVersion latest = recent.get(0);
+    boolean inGracePeriod = OffsetDateTime.now()
+        .isBefore(latest.getReleasedAt().plusDays(PATCH_GRACE_PERIOD_DAYS));
+
+    if (inGracePeriod && recent.size() >= 2) {
+      PatchVersion previous = recent.get(1);
+      return Optional.of(new EffectivePatchContext(
+          previous.getPatch(),
+          previous.releasedAtEpochSeconds(),
+          latest.releasedAtEpochSeconds()
+      ));
+    }
+
+    return Optional.of(new EffectivePatchContext(
+        latest.getPatch(),
+        latest.releasedAtEpochSeconds(),
+        null
+    ));
   }
 
   /** 새 패치 등록 (멱등: 이미 존재하면 false 반환) */

--- a/src/main/java/com/bestduo_BE/common/application/port/MatchIdsFinder.java
+++ b/src/main/java/com/bestduo_BE/common/application/port/MatchIdsFinder.java
@@ -4,7 +4,10 @@ import java.util.List;
 
 public interface MatchIdsFinder {
   List<String> findRecentMatchIds(String puuid, int count);
-  // ✅ 신규(Phase5 증분 refresh)
+
   // Riot API startTime 파라미터는 "epoch seconds"
   List<String> findMatchIdsSince(String puuid, long startTimeSeconds, int count);
+
+  // grace period 중 사용: startTime ~ endTime 범위로 제한
+  List<String> findMatchIdsBetween(String puuid, long startTimeSeconds, long endTimeSeconds, int count);
 }

--- a/src/main/java/com/bestduo_BE/common/domain/model/EffectivePatchContext.java
+++ b/src/main/java/com/bestduo_BE/common/domain/model/EffectivePatchContext.java
@@ -1,0 +1,23 @@
+package com.bestduo_BE.common.domain.model;
+
+/**
+ * match ID 수집 시 사용할 "유효 패치" 컨텍스트.
+ *
+ * <p>새 패치 출시 후 {@code PATCH_GRACE_PERIOD_DAYS}일 미만이면 grace period로 간주해
+ * 이전 패치를 effective patch로 사용하고 {@code endTimeEpochSeconds}를 설정한다.
+ *
+ * @param patch                 effective patch 문자열 (e.g., "16.7")
+ * @param startTimeEpochSeconds Riot API startTime 파라미터 (epoch seconds)
+ * @param endTimeEpochSeconds   Riot API endTime 파라미터 (epoch seconds); grace period가 아니면 null
+ */
+public record EffectivePatchContext(
+    String patch,
+    long startTimeEpochSeconds,
+    Long endTimeEpochSeconds
+) {
+
+  /** grace period 중이면 true (endTime이 설정됨) */
+  public boolean isInGracePeriod() {
+    return endTimeEpochSeconds != null;
+  }
+}

--- a/src/main/java/com/bestduo_BE/common/infra/persistence/repository/PatchVersionJpaRepository.java
+++ b/src/main/java/com/bestduo_BE/common/infra/persistence/repository/PatchVersionJpaRepository.java
@@ -1,6 +1,7 @@
 package com.bestduo_BE.common.infra.persistence.repository;
 
 import com.bestduo_BE.common.infra.persistence.entity.PatchVersion;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -11,4 +12,7 @@ public interface PatchVersionJpaRepository extends JpaRepository<PatchVersion, L
   Optional<PatchVersion> findByPatch(String patch);
 
   Optional<PatchVersion> findTopByOrderByReleasedAtDesc();
+
+  /** 최신 2개 패치를 최신 순으로 반환 (grace period 판별용) */
+  List<PatchVersion> findTop2ByOrderByReleasedAtDesc();
 }

--- a/src/main/java/com/bestduo_BE/common/infra/riot/MatchIdsFinderImpl.java
+++ b/src/main/java/com/bestduo_BE/common/infra/riot/MatchIdsFinderImpl.java
@@ -60,4 +60,26 @@ public class MatchIdsFinderImpl implements MatchIdsFinder {
       throw new RiotApiException("Failed to load match ids since startTime from Riot API", e);
     }
   }
+
+  @Override
+  public List<String> findMatchIdsBetween(
+      String puuid, long startTimeSeconds, long endTimeSeconds, int count) {
+    try {
+      String[] matchIds = regionalRestTemplate.getForObject(
+          "/lol/match/v5/matches/by-puuid/{puuid}/ids?startTime={startTime}&endTime={endTime}&count={count}",
+          String[].class,
+          puuid,
+          startTimeSeconds,
+          endTimeSeconds,
+          count
+      );
+      return matchIds == null ? List.of() : Arrays.asList(matchIds);
+    } catch (RestClientException e) {
+      log.error(
+          "Failed to load match ids between. puuid={}, startTimeSeconds={}, endTimeSeconds={}, count={}",
+          puuid, startTimeSeconds, endTimeSeconds, count, e
+      );
+      throw new RiotApiException("Failed to load match ids between timerange from Riot API", e);
+    }
+  }
 }

--- a/src/main/java/com/bestduo_BE/pipeline/application/CollectMatchIdsRunner.java
+++ b/src/main/java/com/bestduo_BE/pipeline/application/CollectMatchIdsRunner.java
@@ -3,6 +3,7 @@ package com.bestduo_BE.pipeline.application;
 import com.bestduo_BE.common.application.PatchVersionService;
 import com.bestduo_BE.common.application.port.MatchIdsFinder;
 import com.bestduo_BE.common.application.port.MatchQueueEnqueuer;
+import com.bestduo_BE.common.domain.model.EffectivePatchContext;
 import com.bestduo_BE.common.domain.model.Tier;
 import com.bestduo_BE.common.infra.persistence.entity.Summoner;
 import com.bestduo_BE.common.infra.persistence.repository.SummonerJpaRepository;
@@ -68,8 +69,7 @@ public class CollectMatchIdsRunner {
       return BatchResult.noPending();
     }
 
-    String currentPatch = patchVersionService.currentPatchVersion().orElse(null);
-    Long patchStartTime = patchVersionService.currentPatchStartTimeEpochSeconds().orElse(null);
+    EffectivePatchContext ctx = patchVersionService.resolveEffectivePatchContext().orElse(null);
 
     int apiCalls = 0;
     int matchIdsQueued = 0;
@@ -79,7 +79,7 @@ public class CollectMatchIdsRunner {
         break;
       }
       try {
-        int queued = collectForSummoner(summoner, currentPatch, patchStartTime);
+        int queued = collectForSummoner(summoner, ctx);
         matchIdsQueued += queued;
         summonerRepository.markMatchIdsCollected(summoner.getPuuid(), OffsetDateTime.now());
         budgetTracker.recordCollectCall(1);
@@ -101,22 +101,27 @@ public class CollectMatchIdsRunner {
 
   // ── private helpers ─────────────────────────────────────────────────────
 
-  private int collectForSummoner(Summoner summoner, String currentPatch, Long patchStartTime) {
+  private int collectForSummoner(Summoner summoner, EffectivePatchContext ctx) {
     int matchCount = matchCountFor(summoner.getLastKnownTier());
 
     List<String> matchIds;
-    if (patchStartTime != null) {
-      matchIds = matchIdsFinder.findMatchIdsSince(summoner.getPuuid(), patchStartTime, matchCount);
-    } else {
+    if (ctx == null) {
       matchIds = matchIdsFinder.findRecentMatchIds(summoner.getPuuid(), matchCount);
+    } else if (ctx.isInGracePeriod()) {
+      matchIds = matchIdsFinder.findMatchIdsBetween(
+          summoner.getPuuid(), ctx.startTimeEpochSeconds(), ctx.endTimeEpochSeconds(), matchCount);
+    } else {
+      matchIds = matchIdsFinder.findMatchIdsSince(
+          summoner.getPuuid(), ctx.startTimeEpochSeconds(), matchCount);
     }
 
     if (matchIds == null || matchIds.isEmpty()) {
       return 0;
     }
 
+    String patch = ctx != null ? ctx.patch() : null;
     Tier tier = summoner.getLastKnownTier() != null ? summoner.getLastKnownTier() : Tier.ALL_TIERS;
-    matchQueueEnqueuer.enqueueAllIdempotent(matchIds, tier, props.getCollectPriority(), currentPatch);
+    matchQueueEnqueuer.enqueueAllIdempotent(matchIds, tier, props.getCollectPriority(), patch);
     return matchIds.size();
   }
 

--- a/src/test/java/com/bestduo_BE/common/application/PatchVersionServiceTest.java
+++ b/src/test/java/com/bestduo_BE/common/application/PatchVersionServiceTest.java
@@ -6,9 +6,11 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
+import com.bestduo_BE.common.domain.model.EffectivePatchContext;
 import com.bestduo_BE.common.infra.persistence.entity.PatchVersion;
 import com.bestduo_BE.common.infra.persistence.repository.PatchVersionJpaRepository;
 import java.time.OffsetDateTime;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -104,5 +106,80 @@ class PatchVersionServiceTest {
 
     assertThat(result).isFalse();
     verify(patchVersionRepository, never()).save(any());
+  }
+
+  // ── resolveEffectivePatchContext ─────────────────────────────────────────
+
+  @Test
+  @DisplayName("resolveEffectivePatchContext — 패치가 없으면 empty 반환")
+  void resolveEffectivePatchContext_whenNoPatch_returnsEmpty() {
+    given(patchVersionRepository.findTop2ByOrderByReleasedAtDesc()).willReturn(List.of());
+
+    Optional<EffectivePatchContext> result = service.resolveEffectivePatchContext();
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  @DisplayName("resolveEffectivePatchContext — 최신 패치가 3일 이상 지났으면 정상 컨텍스트 반환")
+  void resolveEffectivePatchContext_whenLatestPatchMature_returnsNormalContext() {
+    OffsetDateTime releasedAt = OffsetDateTime.now().minusDays(4);
+    PatchVersion latest = PatchVersion.of("16.8", releasedAt);
+    given(patchVersionRepository.findTop2ByOrderByReleasedAtDesc()).willReturn(List.of(latest));
+
+    Optional<EffectivePatchContext> result = service.resolveEffectivePatchContext();
+
+    assertThat(result).isPresent();
+    EffectivePatchContext ctx = result.get();
+    assertThat(ctx.patch()).isEqualTo("16.8");
+    assertThat(ctx.startTimeEpochSeconds()).isEqualTo(releasedAt.toEpochSecond());
+    assertThat(ctx.isInGracePeriod()).isFalse();
+  }
+
+  @Test
+  @DisplayName("resolveEffectivePatchContext — grace period 중이고 이전 패치 있으면 이전 패치 + endTime 반환")
+  void resolveEffectivePatchContext_whenInGracePeriodWithPrevious_returnsPreviousPatchWithEndTime() {
+    OffsetDateTime prevReleasedAt = OffsetDateTime.now().minusDays(10);
+    OffsetDateTime latestReleasedAt = OffsetDateTime.now().minusDays(1);
+    PatchVersion previous = PatchVersion.of("16.7", prevReleasedAt);
+    PatchVersion latest = PatchVersion.of("16.8", latestReleasedAt);
+    given(patchVersionRepository.findTop2ByOrderByReleasedAtDesc()).willReturn(List.of(latest, previous));
+
+    Optional<EffectivePatchContext> result = service.resolveEffectivePatchContext();
+
+    assertThat(result).isPresent();
+    EffectivePatchContext ctx = result.get();
+    assertThat(ctx.patch()).isEqualTo("16.7");
+    assertThat(ctx.startTimeEpochSeconds()).isEqualTo(prevReleasedAt.toEpochSecond());
+    assertThat(ctx.endTimeEpochSeconds()).isEqualTo(latestReleasedAt.toEpochSecond());
+    assertThat(ctx.isInGracePeriod()).isTrue();
+  }
+
+  @Test
+  @DisplayName("resolveEffectivePatchContext — grace period 중이지만 이전 패치 없으면 최신 패치로 fallback")
+  void resolveEffectivePatchContext_whenInGracePeriodWithoutPrevious_fallsBackToLatest() {
+    OffsetDateTime releasedAt = OffsetDateTime.now().minusDays(1);
+    PatchVersion latest = PatchVersion.of("16.8", releasedAt);
+    given(patchVersionRepository.findTop2ByOrderByReleasedAtDesc()).willReturn(List.of(latest));
+
+    Optional<EffectivePatchContext> result = service.resolveEffectivePatchContext();
+
+    assertThat(result).isPresent();
+    EffectivePatchContext ctx = result.get();
+    assertThat(ctx.patch()).isEqualTo("16.8");
+    assertThat(ctx.isInGracePeriod()).isFalse();
+  }
+
+  @Test
+  @DisplayName("resolveEffectivePatchContext — 출시 정확히 3일이 지난 시점은 grace period 아님")
+  void resolveEffectivePatchContext_whenExactlyThreeDaysOld_notInGracePeriod() {
+    OffsetDateTime releasedAt = OffsetDateTime.now().minusDays(3).minusMinutes(1);
+    PatchVersion latest = PatchVersion.of("16.8", releasedAt);
+    given(patchVersionRepository.findTop2ByOrderByReleasedAtDesc()).willReturn(List.of(latest));
+
+    Optional<EffectivePatchContext> result = service.resolveEffectivePatchContext();
+
+    assertThat(result).isPresent();
+    assertThat(result.get().isInGracePeriod()).isFalse();
   }
 }

--- a/src/test/java/com/bestduo_BE/common/infra/riot/MatchIdsFinderImplTest.java
+++ b/src/test/java/com/bestduo_BE/common/infra/riot/MatchIdsFinderImplTest.java
@@ -118,4 +118,62 @@ class MatchIdsFinderImplTest {
     assertThrows(RiotApiException.class,
         () -> finder.findMatchIdsSince("puuid-def", 1600000000L, 15));
   }
+
+  @Test
+  @DisplayName("findMatchIdsBetween — startTime과 endTime을 포함한 매치 ID 목록을 반환한다")
+  void findMatchIdsBetween_returnsIdsWithBothTimeParams() {
+    given(regionalRestTemplate.getForObject(
+        "/lol/match/v5/matches/by-puuid/{puuid}/ids?startTime={startTime}&endTime={endTime}&count={count}",
+        String[].class,
+        "puuid-xyz",
+        1700000000L,
+        1700259200L,
+        10
+    )).willReturn(new String[]{"KR_20", "KR_21"});
+
+    List<String> result = finder.findMatchIdsBetween("puuid-xyz", 1700000000L, 1700259200L, 10);
+
+    assertEquals(List.of("KR_20", "KR_21"), result);
+    then(regionalRestTemplate).should().getForObject(
+        eq("/lol/match/v5/matches/by-puuid/{puuid}/ids?startTime={startTime}&endTime={endTime}&count={count}"),
+        eq(String[].class),
+        eq("puuid-xyz"),
+        eq(1700000000L),
+        eq(1700259200L),
+        eq(10)
+    );
+  }
+
+  @Test
+  @DisplayName("findMatchIdsBetween — API가 null을 반환하면 빈 리스트를 반환한다")
+  void findMatchIdsBetween_returnsEmptyListWhenApiReturnsNull() {
+    given(regionalRestTemplate.getForObject(
+        "/lol/match/v5/matches/by-puuid/{puuid}/ids?startTime={startTime}&endTime={endTime}&count={count}",
+        String[].class,
+        "puuid-xyz",
+        1700000000L,
+        1700259200L,
+        10
+    )).willReturn(null);
+
+    List<String> result = finder.findMatchIdsBetween("puuid-xyz", 1700000000L, 1700259200L, 10);
+
+    assertTrue(result.isEmpty());
+  }
+
+  @Test
+  @DisplayName("findMatchIdsBetween — REST 예외를 RiotApiException으로 감싼다")
+  void findMatchIdsBetween_wrapsRestExceptionsInRiotApiException() {
+    given(regionalRestTemplate.getForObject(
+        "/lol/match/v5/matches/by-puuid/{puuid}/ids?startTime={startTime}&endTime={endTime}&count={count}",
+        String[].class,
+        "puuid-xyz",
+        1700000000L,
+        1700259200L,
+        10
+    )).willThrow(new RestClientException("timeout"));
+
+    assertThrows(RiotApiException.class,
+        () -> finder.findMatchIdsBetween("puuid-xyz", 1700000000L, 1700259200L, 10));
+  }
 }

--- a/src/test/java/com/bestduo_BE/pipeline/application/CollectMatchIdsRunnerTest.java
+++ b/src/test/java/com/bestduo_BE/pipeline/application/CollectMatchIdsRunnerTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.verify;
 import com.bestduo_BE.common.application.PatchVersionService;
 import com.bestduo_BE.common.application.port.MatchIdsFinder;
 import com.bestduo_BE.common.application.port.MatchQueueEnqueuer;
+import com.bestduo_BE.common.domain.model.EffectivePatchContext;
 import com.bestduo_BE.common.domain.model.Tier;
 import com.bestduo_BE.common.infra.persistence.entity.Summoner;
 import com.bestduo_BE.common.infra.persistence.repository.SummonerJpaRepository;
@@ -118,32 +119,33 @@ class CollectMatchIdsRunnerTest {
   }
 
   @Test
-  @DisplayName("DIAMOND tier summoner에게 diamondEmerald matchCount 적용")
-  void runBatch_usesCorrectMatchCountForDiamond() {
+  @DisplayName("정상 패치(grace period 아님): DIAMOND tier summoner에게 findMatchIdsSince 호출")
+  void runBatch_normalPatch_usesCorrectMatchCountForDiamond() {
     Summoner summoner = summonerWithTier("p-dia", Tier.DIAMOND);
+    EffectivePatchContext ctx = new EffectivePatchContext("15.23", 1700000000L, null);
     given(budgetTracker.canCollect()).willReturn(true);
     given(summonerRepository.findMatchIdsPendingSummoners(props.getCollectBatchSize()))
         .willReturn(List.of(summoner));
-    given(patchVersionService.currentPatchVersion()).willReturn(Optional.of("15.23"));
-    given(patchVersionService.currentPatchStartTimeEpochSeconds()).willReturn(Optional.of(1700000000L));
+    given(patchVersionService.resolveEffectivePatchContext()).willReturn(Optional.of(ctx));
     given(matchIdsFinder.findMatchIdsSince("p-dia", 1700000000L, 10))
         .willReturn(List.of("m1", "m2"));
 
     CollectMatchIdsRunner.BatchResult result = runner.runBatch();
 
     verify(matchIdsFinder).findMatchIdsSince("p-dia", 1700000000L, 10);
+    verify(matchIdsFinder, never()).findMatchIdsBetween(any(), anyLong(), anyLong(), anyInt());
     assertThat(result.matchIdsQueued()).isEqualTo(2);
   }
 
   @Test
-  @DisplayName("CHALLENGER tier summoner에게 apexTiers matchCount 적용")
-  void runBatch_usesCorrectMatchCountForChallenger() {
+  @DisplayName("정상 패치(grace period 아님): CHALLENGER tier summoner에게 apexTiers matchCount 적용")
+  void runBatch_normalPatch_usesApexMatchCountForChallenger() {
     Summoner summoner = summonerWithTier("p-chall", Tier.CHALLENGER);
+    EffectivePatchContext ctx = new EffectivePatchContext("15.23", 1700000000L, null);
     given(budgetTracker.canCollect()).willReturn(true);
     given(summonerRepository.findMatchIdsPendingSummoners(props.getCollectBatchSize()))
         .willReturn(List.of(summoner));
-    given(patchVersionService.currentPatchVersion()).willReturn(Optional.of("15.23"));
-    given(patchVersionService.currentPatchStartTimeEpochSeconds()).willReturn(Optional.of(1700000000L));
+    given(patchVersionService.resolveEffectivePatchContext()).willReturn(Optional.of(ctx));
     given(matchIdsFinder.findMatchIdsSince("p-chall", 1700000000L, 30))
         .willReturn(List.of("m1", "m2", "m3"));
 
@@ -153,14 +155,50 @@ class CollectMatchIdsRunnerTest {
   }
 
   @Test
-  @DisplayName("matchIds를 수집한 후 matchIdsCollectedAt을 갱신한다")
-  void runBatch_marksMatchIdsCollectedAfterCollection() {
-    Summoner summoner = summonerWithTier("p-1", Tier.EMERALD);
+  @DisplayName("grace period 중: findMatchIdsBetween이 endTime과 함께 호출된다")
+  void runBatch_inGracePeriod_callsFindMatchIdsBetweenWithEndTime() {
+    Summoner summoner = summonerWithTier("p-dia", Tier.DIAMOND);
+    EffectivePatchContext ctx = new EffectivePatchContext("16.7", 1699000000L, 1700000000L);
     given(budgetTracker.canCollect()).willReturn(true);
     given(summonerRepository.findMatchIdsPendingSummoners(props.getCollectBatchSize()))
         .willReturn(List.of(summoner));
-    given(patchVersionService.currentPatchVersion()).willReturn(Optional.of("15.23"));
-    given(patchVersionService.currentPatchStartTimeEpochSeconds()).willReturn(Optional.of(1700000000L));
+    given(patchVersionService.resolveEffectivePatchContext()).willReturn(Optional.of(ctx));
+    given(matchIdsFinder.findMatchIdsBetween("p-dia", 1699000000L, 1700000000L, 10))
+        .willReturn(List.of("m1", "m2"));
+
+    CollectMatchIdsRunner.BatchResult result = runner.runBatch();
+
+    verify(matchIdsFinder).findMatchIdsBetween("p-dia", 1699000000L, 1700000000L, 10);
+    verify(matchIdsFinder, never()).findMatchIdsSince(any(), anyLong(), anyInt());
+    assertThat(result.matchIdsQueued()).isEqualTo(2);
+  }
+
+  @Test
+  @DisplayName("grace period 중: MatchQueue는 이전 패치(16.7)로 태깅된다")
+  void runBatch_inGracePeriod_enqueuedWithPreviousPatchTag() {
+    Summoner summoner = summonerWithTier("p-dia", Tier.DIAMOND);
+    EffectivePatchContext ctx = new EffectivePatchContext("16.7", 1699000000L, 1700000000L);
+    given(budgetTracker.canCollect()).willReturn(true);
+    given(summonerRepository.findMatchIdsPendingSummoners(props.getCollectBatchSize()))
+        .willReturn(List.of(summoner));
+    given(patchVersionService.resolveEffectivePatchContext()).willReturn(Optional.of(ctx));
+    given(matchIdsFinder.findMatchIdsBetween(any(), anyLong(), anyLong(), anyInt()))
+        .willReturn(List.of("m1"));
+
+    runner.runBatch();
+
+    verify(matchQueueEnqueuer).enqueueAllIdempotent(any(), any(), anyInt(), eq("16.7"));
+  }
+
+  @Test
+  @DisplayName("matchIds를 수집한 후 matchIdsCollectedAt을 갱신한다")
+  void runBatch_marksMatchIdsCollectedAfterCollection() {
+    Summoner summoner = summonerWithTier("p-1", Tier.EMERALD);
+    EffectivePatchContext ctx = new EffectivePatchContext("15.23", 1700000000L, null);
+    given(budgetTracker.canCollect()).willReturn(true);
+    given(summonerRepository.findMatchIdsPendingSummoners(props.getCollectBatchSize()))
+        .willReturn(List.of(summoner));
+    given(patchVersionService.resolveEffectivePatchContext()).willReturn(Optional.of(ctx));
     given(matchIdsFinder.findMatchIdsSince(eq("p-1"), anyLong(), anyInt()))
         .willReturn(List.of("m1"));
 
@@ -171,20 +209,20 @@ class CollectMatchIdsRunnerTest {
   }
 
   @Test
-  @DisplayName("patchStartTime이 없으면 findRecentMatchIds를 사용")
-  void runBatch_whenNoPatchStartTime_usesRecentMatchIds() {
+  @DisplayName("패치 정보가 없으면 findRecentMatchIds를 사용")
+  void runBatch_whenNoPatchContext_usesRecentMatchIds() {
     Summoner summoner = summonerWithTier("p-gold", Tier.GOLD);
     given(budgetTracker.canCollect()).willReturn(true);
     given(summonerRepository.findMatchIdsPendingSummoners(props.getCollectBatchSize()))
         .willReturn(List.of(summoner));
-    given(patchVersionService.currentPatchVersion()).willReturn(Optional.empty());
-    given(patchVersionService.currentPatchStartTimeEpochSeconds()).willReturn(Optional.empty());
+    given(patchVersionService.resolveEffectivePatchContext()).willReturn(Optional.empty());
     given(matchIdsFinder.findRecentMatchIds("p-gold", 10)).willReturn(List.of("m1"));
 
     runner.runBatch();
 
     verify(matchIdsFinder).findRecentMatchIds("p-gold", 10);
     verify(matchIdsFinder, never()).findMatchIdsSince(any(), anyLong(), anyInt());
+    verify(matchIdsFinder, never()).findMatchIdsBetween(any(), anyLong(), anyLong(), anyInt());
   }
 
   @Test
@@ -192,11 +230,11 @@ class CollectMatchIdsRunnerTest {
   void runBatch_skipsSummonerOnIndividualError() {
     Summoner bad = summonerWithTier("p-bad", Tier.GOLD);
     Summoner good = summonerWithTier("p-good", Tier.GOLD);
+    EffectivePatchContext ctx = new EffectivePatchContext("15.23", 1700000000L, null);
     given(budgetTracker.canCollect()).willReturn(true);
     given(summonerRepository.findMatchIdsPendingSummoners(props.getCollectBatchSize()))
         .willReturn(List.of(bad, good));
-    given(patchVersionService.currentPatchVersion()).willReturn(Optional.of("15.23"));
-    given(patchVersionService.currentPatchStartTimeEpochSeconds()).willReturn(Optional.of(1700000000L));
+    given(patchVersionService.resolveEffectivePatchContext()).willReturn(Optional.of(ctx));
     given(matchIdsFinder.findMatchIdsSince(eq("p-bad"), anyLong(), anyInt()))
         .willThrow(new RuntimeException("API error"));
     given(matchIdsFinder.findMatchIdsSince(eq("p-good"), anyLong(), anyInt()))
@@ -204,7 +242,6 @@ class CollectMatchIdsRunnerTest {
 
     CollectMatchIdsRunner.BatchResult result = runner.runBatch();
 
-    // 실패한 summoner도 API 호출이 발생했으므로 예산 차감 및 apiCalls에 포함된다
     verify(summonerRepository).markMatchIdsCollected(eq("p-good"), any());
     verify(summonerRepository, never()).markMatchIdsCollected(eq("p-bad"), any());
     assertThat(result.apiCalls()).isEqualTo(2);
@@ -214,11 +251,11 @@ class CollectMatchIdsRunnerTest {
   @DisplayName("429 예외는 전파된다")
   void runBatch_propagatesRateLimitedException() {
     Summoner summoner = summonerWithTier("p-1", Tier.GOLD);
+    EffectivePatchContext ctx = new EffectivePatchContext("15.23", 1700000000L, null);
     given(budgetTracker.canCollect()).willReturn(true);
     given(summonerRepository.findMatchIdsPendingSummoners(props.getCollectBatchSize()))
         .willReturn(List.of(summoner));
-    given(patchVersionService.currentPatchVersion()).willReturn(Optional.of("15.23"));
-    given(patchVersionService.currentPatchStartTimeEpochSeconds()).willReturn(Optional.of(1700000000L));
+    given(patchVersionService.resolveEffectivePatchContext()).willReturn(Optional.of(ctx));
     given(matchIdsFinder.findMatchIdsSince(any(), anyLong(), anyInt()))
         .willThrow(new RiotRateLimitedException("429"));
 
@@ -230,11 +267,11 @@ class CollectMatchIdsRunnerTest {
   @DisplayName("matchIds가 비어있으면 enqueue 하지 않지만 collectedAt은 갱신")
   void runBatch_whenNoMatchIds_doesNotEnqueueButMarksCollected() {
     Summoner summoner = summonerWithTier("p-empty", Tier.GOLD);
+    EffectivePatchContext ctx = new EffectivePatchContext("15.23", 1700000000L, null);
     given(budgetTracker.canCollect()).willReturn(true);
     given(summonerRepository.findMatchIdsPendingSummoners(props.getCollectBatchSize()))
         .willReturn(List.of(summoner));
-    given(patchVersionService.currentPatchVersion()).willReturn(Optional.of("15.23"));
-    given(patchVersionService.currentPatchStartTimeEpochSeconds()).willReturn(Optional.of(1700000000L));
+    given(patchVersionService.resolveEffectivePatchContext()).willReturn(Optional.of(ctx));
     given(matchIdsFinder.findMatchIdsSince(any(), anyLong(), anyInt())).willReturn(List.of());
 
     runner.runBatch();


### PR DESCRIPTION
## 관련 이슈
Closes #35

## 배경
새 패치(예: 16.8) 출시 직후 게임 데이터가 부족해 `CollectMatchIdsRunner`가 match ID를 수집할 때 대부분의 소환사에서 빈 결과가 반환되는 문제가 실제 운영에서 확인됐다.

## 변경 내용

### 동작 방식
```
[새 패치 출시 후 < 3일 — grace period]
  startTime = 이전 패치(16.7) releasedAt
  endTime   = 신규 패치(16.8) releasedAt  ← 신규 추가
  MatchQueue 태깅 patch = "16.7"

[새 패치 출시 후 >= 3일 — 정상]
  startTime = 신규 패치(16.8) releasedAt
  endTime   = (없음)
  MatchQueue 태깅 patch = "16.8"
```

### 추가/수정 파일
| 파일 | 내용 |
|------|------|
| `EffectivePatchContext` (신규) | grace period 상태를 담는 값 객체 (`patch`, `startTime`, `endTime`) |
| `PatchVersionJpaRepository` | `findTop2ByOrderByReleasedAtDesc()` 추가 |
| `PatchVersionService` | `PATCH_GRACE_PERIOD_DAYS = 3` 상수 + `resolveEffectivePatchContext()` 추가 |
| `MatchIdsFinder` (port) | `findMatchIdsBetween(puuid, startTime, endTime, count)` 추가 |
| `MatchIdsFinderImpl` | `findMatchIdsBetween` 구현 |
| `CollectMatchIdsRunner` | `resolveEffectivePatchContext()` 기반으로 교체 |

## 테스트 계획
- [x] grace period 중 `findMatchIdsBetween`이 `endTime`과 함께 호출됨
- [x] grace period 해제 후 `findMatchIdsSince`가 호출되고 `endTime` 없음
- [x] 패치 데이터 없을 때 `findRecentMatchIds` fallback 유지
- [x] 패치 1개뿐일 때(이전 패치 없음) grace period여도 현재 패치로 graceful fallback
- [x] grace period 경계(정확히 3일) 테스트
- [x] grace period 중 MatchQueue가 이전 패치(16.7)로 태깅됨