### PR TITLE
feat: /admin/** X-Admin-Key 인증 + Actuator 노출 축소

### DIFF
--- a/src/main/java/com/bestduo_BE/config/WebConfig.java
+++ b/src/main/java/com/bestduo_BE/config/WebConfig.java
@@ -1,11 +1,22 @@
 package com.bestduo_BE.config;
 
+import com.bestduo_BE.config.admin.AdminApiKeyInterceptor;
+import com.bestduo_BE.config.admin.AdminApiKeyProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
 @Configuration
+@EnableConfigurationProperties(AdminApiKeyProperties.class)
 public class WebConfig implements WebMvcConfigurer {
+
+    private final AdminApiKeyInterceptor adminApiKeyInterceptor;
+
+    public WebConfig(AdminApiKeyInterceptor adminApiKeyInterceptor) {
+        this.adminApiKeyInterceptor = adminApiKeyInterceptor;
+    }
 
     @Override
     public void addCorsMappings(CorsRegistry registry) {
@@ -18,5 +29,11 @@ public class WebConfig implements WebMvcConfigurer {
                 .allowedOriginPatterns("*")
                 .allowedMethods("GET", "POST", "OPTIONS")
                 .allowedHeaders("*");
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(adminApiKeyInterceptor)
+                .addPathPatterns("/admin/**");
     }
 }

--- a/src/main/java/com/bestduo_BE/config/admin/AdminApiKeyInterceptor.java
+++ b/src/main/java/com/bestduo_BE/config/admin/AdminApiKeyInterceptor.java
@@ -1,0 +1,31 @@
+package com.bestduo_BE.config.admin;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+/**
+ * /admin/** 경로에 대해 X-Admin-Key 헤더 검증. 실패 시 401을 반환하고 컨트롤러 진입을 막는다.
+ */
+@Component
+public class AdminApiKeyInterceptor implements HandlerInterceptor {
+
+  static final String HEADER_NAME = "X-Admin-Key";
+
+  private final AdminApiKeyProperties properties;
+
+  public AdminApiKeyInterceptor(AdminApiKeyProperties properties) {
+    this.properties = properties;
+  }
+
+  @Override
+  public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+    String provided = request.getHeader(HEADER_NAME);
+    if (provided == null || provided.isBlank() || !provided.equals(properties.getKey())) {
+      response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+      return false;
+    }
+    return true;
+  }
+}

--- a/src/main/java/com/bestduo_BE/config/admin/AdminApiKeyProperties.java
+++ b/src/main/java/com/bestduo_BE/config/admin/AdminApiKeyProperties.java
@@ -1,0 +1,20 @@
+package com.bestduo_BE.config.admin;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+/**
+ * Admin API 인증용 키 설정. `admin.api.key` env/yml로 주입하며, 비어 있으면 앱 시작이 거부된다.
+ */
+@ConfigurationProperties(prefix = "admin.api")
+@Validated
+@Getter
+@Setter
+public class AdminApiKeyProperties {
+
+  @NotBlank
+  private String key;
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -53,10 +53,14 @@ management:
   endpoints:
     web:
       exposure:
-        include: health,metrics,prometheus
+        include: health,prometheus
   endpoint:
     health:
-      show-details: always
+      show-details: never
+
+admin:
+  api:
+    key: ${ADMIN_API_KEY:}
 
 monitoring:
   datasource:

--- a/src/test/java/com/bestduo_BE/aggregate/presentation/api/BottomDuoAggregateControllerTest.java
+++ b/src/test/java/com/bestduo_BE/aggregate/presentation/api/BottomDuoAggregateControllerTest.java
@@ -32,7 +32,8 @@ class BottomDuoAggregateControllerTest {
     AggregateBottomDuoStats.Result result = new AggregateBottomDuoStats.Result(10, 7);
     when(aggregateBottomDuoStat.execute()).thenReturn(result);
 
-    mockMvc.perform(post("/admin/aggregate/bottom-duo-stat"))
+    mockMvc.perform(post("/admin/aggregate/bottom-duo-stat")
+            .header("X-Admin-Key", "test-admin-key"))
         .andExpect(status().isOk())
         .andExpect(content().json(objectMapper.writeValueAsString(result)));
 

--- a/src/test/java/com/bestduo_BE/aggregate/presentation/api/BottomDuoMatchupAggregateControllerTest.java
+++ b/src/test/java/com/bestduo_BE/aggregate/presentation/api/BottomDuoMatchupAggregateControllerTest.java
@@ -32,7 +32,8 @@ class BottomDuoMatchupAggregateControllerTest {
     AggregateBottomDuoMatchup.Result result = new AggregateBottomDuoMatchup.Result(12);
     when(aggregateBottomDuoMatchup.execute()).thenReturn(result);
 
-    mockMvc.perform(post("/admin/aggregate/bottom-duo-matchup"))
+    mockMvc.perform(post("/admin/aggregate/bottom-duo-matchup")
+            .header("X-Admin-Key", "test-admin-key"))
         .andExpect(status().isOk())
         .andExpect(content().json(objectMapper.writeValueAsString(result)));
 

--- a/src/test/java/com/bestduo_BE/common/presentation/api/AdminPatchControllerTest.java
+++ b/src/test/java/com/bestduo_BE/common/presentation/api/AdminPatchControllerTest.java
@@ -35,6 +35,7 @@ class AdminPatchControllerTest {
     given(patchVersionService.registerIfAbsent(eq("15.23"), any())).willReturn(true);
 
     mockMvc.perform(post("/admin/patch")
+            .header("X-Admin-Key", "test-admin-key")
             .param("patch", "15.23")
             .param("releasedAt", "2026-04-02T00:00:00Z"))
         .andExpect(status().isCreated())
@@ -49,6 +50,7 @@ class AdminPatchControllerTest {
     given(patchVersionService.registerIfAbsent(eq("15.23"), any())).willReturn(false);
 
     mockMvc.perform(post("/admin/patch")
+            .header("X-Admin-Key", "test-admin-key")
             .param("patch", "15.23")
             .param("releasedAt", "2026-04-02T00:00:00Z"))
         .andExpect(status().isConflict());
@@ -61,7 +63,8 @@ class AdminPatchControllerTest {
     PatchVersion patchVersion = PatchVersion.of("15.23", releasedAt);
     given(patchVersionService.currentPatch()).willReturn(Optional.of(patchVersion));
 
-    mockMvc.perform(get("/admin/patch/current"))
+    mockMvc.perform(get("/admin/patch/current")
+            .header("X-Admin-Key", "test-admin-key"))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.patch").value("15.23"));
   }
@@ -71,7 +74,8 @@ class AdminPatchControllerTest {
   void current_whenNoPatch_returns404() throws Exception {
     given(patchVersionService.currentPatch()).willReturn(Optional.empty());
 
-    mockMvc.perform(get("/admin/patch/current"))
+    mockMvc.perform(get("/admin/patch/current")
+            .header("X-Admin-Key", "test-admin-key"))
         .andExpect(status().isNotFound());
   }
 }

--- a/src/test/java/com/bestduo_BE/config/admin/AdminApiKeyInterceptorTest.java
+++ b/src/test/java/com/bestduo_BE/config/admin/AdminApiKeyInterceptorTest.java
@@ -1,0 +1,83 @@
+package com.bestduo_BE.config.admin;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+class AdminApiKeyInterceptorTest {
+
+  private static final String VALID_KEY = "secret-key-123";
+  private static final String HEADER = "X-Admin-Key";
+
+  private AdminApiKeyInterceptor interceptor;
+  private HttpServletRequest request;
+  private HttpServletResponse response;
+  private MockHttpServletRequest mockRequest;
+  private MockHttpServletResponse mockResponse;
+
+  @BeforeEach
+  void setUp() {
+    AdminApiKeyProperties properties = new AdminApiKeyProperties();
+    properties.setKey(VALID_KEY);
+    interceptor = new AdminApiKeyInterceptor(properties);
+
+    mockRequest = new MockHttpServletRequest();
+    mockResponse = new MockHttpServletResponse();
+    request = mockRequest;
+    response = mockResponse;
+  }
+
+  @Nested
+  @DisplayName("preHandle")
+  class PreHandle {
+
+    @Test
+    @DisplayName("올바른 X-Admin-Key 헤더면 true를 반환하고 요청을 통과시킨다")
+    void preHandle_validKey_returnsTrue() throws Exception {
+      mockRequest.addHeader(HEADER, VALID_KEY);
+
+      boolean result = interceptor.preHandle(request, response, new Object());
+
+      assertThat(result).isTrue();
+      assertThat(mockResponse.getStatus()).isEqualTo(HttpServletResponse.SC_OK);
+    }
+
+    @Test
+    @DisplayName("헤더가 아예 없으면 false를 반환하고 401을 응답한다")
+    void preHandle_missingHeader_returnsFalseAndUnauthorized() throws Exception {
+      boolean result = interceptor.preHandle(request, response, new Object());
+
+      assertThat(result).isFalse();
+      assertThat(mockResponse.getStatus()).isEqualTo(HttpServletResponse.SC_UNAUTHORIZED);
+    }
+
+    @Test
+    @DisplayName("헤더 값이 빈 문자열이면 false를 반환하고 401을 응답한다")
+    void preHandle_emptyHeader_returnsFalseAndUnauthorized() throws Exception {
+      mockRequest.addHeader(HEADER, "");
+
+      boolean result = interceptor.preHandle(request, response, new Object());
+
+      assertThat(result).isFalse();
+      assertThat(mockResponse.getStatus()).isEqualTo(HttpServletResponse.SC_UNAUTHORIZED);
+    }
+
+    @Test
+    @DisplayName("헤더 값이 설정된 키와 다르면 false를 반환하고 401을 응답한다")
+    void preHandle_mismatchedKey_returnsFalseAndUnauthorized() throws Exception {
+      mockRequest.addHeader(HEADER, "wrong-key");
+
+      boolean result = interceptor.preHandle(request, response, new Object());
+
+      assertThat(result).isFalse();
+      assertThat(mockResponse.getStatus()).isEqualTo(HttpServletResponse.SC_UNAUTHORIZED);
+    }
+  }
+}

--- a/src/test/java/com/bestduo_BE/config/admin/AdminApiKeyPropertiesTest.java
+++ b/src/test/java/com/bestduo_BE/config/admin/AdminApiKeyPropertiesTest.java
@@ -1,0 +1,63 @@
+package com.bestduo_BE.config.admin;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import java.util.Set;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class AdminApiKeyPropertiesTest {
+
+  private static ValidatorFactory factory;
+  private static Validator validator;
+
+  @BeforeAll
+  static void setUp() {
+    factory = Validation.buildDefaultValidatorFactory();
+    validator = factory.getValidator();
+  }
+
+  @AfterAll
+  static void tearDown() {
+    factory.close();
+  }
+
+  @Test
+  @DisplayName("key가 null이면 검증 위반이 발생한다")
+  void validate_nullKey_violates() {
+    AdminApiKeyProperties properties = new AdminApiKeyProperties();
+    properties.setKey(null);
+
+    Set<ConstraintViolation<AdminApiKeyProperties>> violations = validator.validate(properties);
+
+    assertThat(violations).isNotEmpty();
+  }
+
+  @Test
+  @DisplayName("key가 빈 문자열이면 검증 위반이 발생한다")
+  void validate_blankKey_violates() {
+    AdminApiKeyProperties properties = new AdminApiKeyProperties();
+    properties.setKey("   ");
+
+    Set<ConstraintViolation<AdminApiKeyProperties>> violations = validator.validate(properties);
+
+    assertThat(violations).isNotEmpty();
+  }
+
+  @Test
+  @DisplayName("key가 정상 문자열이면 검증이 통과한다")
+  void validate_validKey_passes() {
+    AdminApiKeyProperties properties = new AdminApiKeyProperties();
+    properties.setKey("my-secret-key");
+
+    Set<ConstraintViolation<AdminApiKeyProperties>> violations = validator.validate(properties);
+
+    assertThat(violations).isEmpty();
+  }
+}

--- a/src/test/java/com/bestduo_BE/coverage/presentation/api/AdminCoverageControllerTest.java
+++ b/src/test/java/com/bestduo_BE/coverage/presentation/api/AdminCoverageControllerTest.java
@@ -33,7 +33,8 @@ class AdminCoverageControllerTest {
         new CoverageBucketResponse(1L, "15.7", Tier.MASTER)
     ));
 
-    mockMvc.perform(get("/admin/coverage"))
+    mockMvc.perform(get("/admin/coverage")
+            .header("X-Admin-Key", "test-admin-key"))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$[0].tier").value("MASTER"))
         .andExpect(jsonPath("$[0].patch").value("15.7"));
@@ -46,7 +47,8 @@ class AdminCoverageControllerTest {
         new CoverageBucketResponse(1L, "15.7", Tier.MASTER)
     );
 
-    mockMvc.perform(get("/admin/coverage/1"))
+    mockMvc.perform(get("/admin/coverage/1")
+            .header("X-Admin-Key", "test-admin-key"))
         .andExpect(status().isOk())
         .andExpect(jsonPath("$.id").value(1))
         .andExpect(jsonPath("$.tier").value("MASTER"));
@@ -57,7 +59,8 @@ class AdminCoverageControllerTest {
   void getReturnsNotFoundWhenBucketIsMissing() throws Exception {
     given(coverageBucketService.get(99L)).willThrow(new CoverageBucketNotFoundException(99L));
 
-    mockMvc.perform(get("/admin/coverage/99"))
+    mockMvc.perform(get("/admin/coverage/99")
+            .header("X-Admin-Key", "test-admin-key"))
         .andExpect(status().isNotFound());
   }
 }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -18,3 +18,7 @@ external:
 pipeline:
   runner:
     enabled: false
+
+admin:
+  api:
+    key: test-admin-key


### PR DESCRIPTION
## 배경

Phase 1 운영 준비(operations readiness) 4개 PR 중 첫 번째. 현재 `/admin/**` 라우트와 Actuator `/actuator/**` 가 인증 없이 노출되어 누구나 파이프라인 실행/큐 상태 조회/패치 수정 등 운영 작업을 트리거할 수 있음. 최소 침습으로 막는 것이 목적.

## 변경 사항

- **`AdminApiKeyInterceptor`**: 요청 헤더 `X-Admin-Key` 값을 설정값과 비교, 불일치 시 401. `/admin/**` 에만 적용.
- **`AdminApiKeyProperties`**: `@ConfigurationProperties(prefix = "admin.api")` + `@Validated @NotBlank` 로 시작 시 누락 감지.
- **`WebConfig`**: `@EnableConfigurationProperties` + `addInterceptors` 에 인터셉터 등록 (`/admin/**` 패턴 한정).
- **`application.yml`**:
  - `management.endpoints.web.exposure.include` → `health, prometheus` 로 축소 (기본 `*` 이 아니라 명시적 허용)
  - `management.endpoint.health.show-details: never`
  - `admin.api.key: \${ADMIN_API_KEY}` 환경변수 주입
- **`src/test/resources/application.yml`**: 테스트용 기본 키 `test-admin-key` 추가.
- **기존 admin 계열 컨트롤러 테스트 4개 업데이트**: `AdminPatchControllerTest`, `AdminCoverageControllerTest`, `BottomDuoAggregateControllerTest`, `BottomDuoMatchupAggregateControllerTest` 에 `X-Admin-Key` 헤더 추가.
- **신규 테스트 2개**:
  - `AdminApiKeyInterceptorTest` — 헤더 누락/오일치/정상 3가지 케이스
  - `AdminApiKeyPropertiesTest` — `@NotBlank` 바인딩 검증 실패 케이스

## 스코프 경계

- Public `/bottom-duo/**` 엔드포인트는 영향 없음.
- Actuator `/health` 는 노출 유지 (헬스체크용), `/prometheus` 는 별도 보호 없이 노출 (메트릭 스크랩 목적). 프로덕션에서 Prometheus 보호가 필요하면 후속 PR로 처리.
- Admin 키 로테이션/여러 키 지원은 YAGNI 로 제외.

## Test Plan

- [x] `./gradlew test` — 기존 테스트 + 신규 테스트 전부 통과
- [x] 인터셉터 단위 테스트: 헤더 없음 → 401, 값 불일치 → 401, 정상 → 다음 핸들러 실행
- [x] `@ConfigurationProperties` 검증: `admin.api.key` 미설정 시 `BindValidationException`

## 후속 PR 스택

이 PR 위에 PR-2 (Flyway 도입), PR-3 (env 외부화 + graceful shutdown), PR-4 (로그 마스킹) 가 순차로 쌓입니다.