### PR TITLE
feat: Flyway 도입 + prod ddl-auto validate 전환

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ dependencies {
 	implementation 'io.github.cdimascio:dotenv-java:3.0.0'
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'io.micrometer:micrometer-registry-prometheus'
-	implementation 'org.flywaydb:flyway-core'
+	implementation 'org.springframework.boot:spring-boot-starter-flyway'
 	runtimeOnly 'org.flywaydb:flyway-database-postgresql'
 	compileOnly 'org.projectlombok:lombok'
 //	developmentOnly 'org.springframework.boot:spring-boot-docker-compose'

--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,8 @@ dependencies {
 	implementation 'io.github.cdimascio:dotenv-java:3.0.0'
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'io.micrometer:micrometer-registry-prometheus'
+	implementation 'org.flywaydb:flyway-core'
+	runtimeOnly 'org.flywaydb:flyway-database-postgresql'
 	compileOnly 'org.projectlombok:lombok'
 //	developmentOnly 'org.springframework.boot:spring-boot-docker-compose'
 	runtimeOnly 'org.postgresql:postgresql'

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -18,7 +18,7 @@ spring:
 #      hibernate.order_inserts: true
 #      hibernate.order_updates: true
     hibernate:
-      ddl-auto: update
+      ddl-auto: validate
 
 logging:
   level:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,6 +15,12 @@ spring:
     hibernate:
       ddl-auto: update
 
+  flyway:
+    enabled: true
+    baseline-on-migrate: true
+    baseline-version: 1
+    locations: classpath:db/migration
+
 logging:
   level:
     org.hibernate.SQL: DEBUG

--- a/src/main/resources/db/migration/V1__baseline.sql
+++ b/src/main/resources/db/migration/V1__baseline.sql
@@ -1,0 +1,4 @@
+-- V1 baseline marker
+-- 실제 스키마는 기존 프로덕션 DB가 이미 보유하고 있으며(ddl-auto: update 로 생성된 상태),
+-- spring.flyway.baseline-on-migrate=true 설정에 의해 Flyway 가 이 버전을 baseline 으로 기록하고 건너뜁니다.
+-- 이후 모든 스키마 변경은 V2 부터 Flyway 마이그레이션으로만 관리합니다.

--- a/src/main/resources/db/migration/V2__drop_and_recreate_summoner_and_match_queue.sql
+++ b/src/main/resources/db/migration/V2__drop_and_recreate_summoner_and_match_queue.sql
@@ -1,0 +1,47 @@
+-- V2: summoner, match_queue 두 테이블을 drop 후 재생성한다.
+--
+-- 배경:
+--   운영 DB 의 summoner / match_queue 데이터를 초기화하면서, 동시에 Flyway 로
+--   스키마를 명시적으로 기술한 첫 마이그레이션을 남기기 위한 스크립트.
+--   V1 은 비어있는 baseline marker 였고, 이 파일부터 실제 스키마가 코드로 관리된다.
+--
+-- 대상 환경:
+--   - 운영(Railway): V1 baseline 이후 이 스크립트가 실행되어 두 테이블을 재생성한다.
+--   - 새 환경(fresh DB): DROP IF EXISTS 덕분에 안전하게 CREATE 까지 이어진다.
+--   - 테스트(H2): spring.flyway.enabled=false 이므로 이 파일은 실행되지 않는다.
+--
+-- 컬럼 타입은 Hibernate 6.x PostgreSQL Dialect 의 기본 매핑을 따른다.
+--   String             -> varchar(255)
+--   Long               -> bigint
+--   int                -> integer
+--   OffsetDateTime     -> timestamp(6) with time zone
+--   @Enumerated(STRING)-> varchar(255)
+
+DROP TABLE IF EXISTS summoner;
+DROP TABLE IF EXISTS match_queue;
+
+CREATE TABLE summoner (
+    puuid                   varchar(255)                    NOT NULL,
+    last_match_start_time   bigint,
+    last_known_tier         varchar(255),
+    tier_observed_at        timestamp(6) with time zone,
+    seeded_at               timestamp(6) with time zone,
+    match_ids_collected_at  timestamp(6) with time zone,
+    created_at              timestamp(6) with time zone     NOT NULL,
+    updated_at              timestamp(6) with time zone     NOT NULL,
+    PRIMARY KEY (puuid)
+);
+
+CREATE TABLE match_queue (
+    match_id         varchar(255)                 NOT NULL,
+    status           varchar(255)                 NOT NULL,
+    priority         integer                      NOT NULL,
+    collection_tier  varchar(255)                 NOT NULL,
+    patch            varchar(255),
+    retry_count      integer                      NOT NULL,
+    last_error       varchar(255),
+    locked_at        timestamp(6) with time zone,
+    created_at       timestamp(6) with time zone  NOT NULL,
+    updated_at       timestamp(6) with time zone  NOT NULL,
+    PRIMARY KEY (match_id)
+);

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -8,6 +8,8 @@ spring:
     hibernate:
       ddl-auto: create-drop
     show-sql: false
+  flyway:
+    enabled: false
 
 external:
   riot:


### PR DESCRIPTION
## 배경

Phase 1 운영 준비 4개 PR 중 두 번째. 스택 PR — base 는 #40 (`feat/admin-api-key-auth`).

현재 운영 배포(Railway)에서 Hibernate `ddl-auto: update` 로 스키마가 애플리케이션 시작 시점에 자동 변경됨. 변경 이력이 코드로 남지 않고 재현 불가능하며, 엔티티 변경이 곧 무검증 프로덕션 DDL 이 되는 상태. Flyway 로 스키마 변경을 명시적으로 코드화하고, prod 프로파일은 `ddl-auto: validate` 로 전환해 엔티티 ↔ 스키마 불일치를 시작 단계에서 차단하는 것이 목적.

## 변경 사항

### Flyway 도입 (`7c6dd7d`)
- `build.gradle`: Flyway 의존성 추가, `application.yml` 에 `spring.flyway.*` 설정
  - `enabled: true`, `locations: classpath:db/migration`
  - `baseline-on-migrate: true`, `baseline-version: 1` — 기존 운영 DB(스키마 있음)와 신규 환경 모두 호환
- `application-prod.yml`: `spring.jpa.hibernate.ddl-auto: validate` 로 전환
- `V1__baseline.sql`: 빈 파일(주석만). 기존 운영 DB 의 baseline marker 역할
- 테스트(`spring.flyway.enabled=false` 기본) 는 기존 H2 경로 그대로 유지

### V2 마이그레이션: summoner / match_queue 재생성 (`0addff6`)
- 사용자 요청으로 운영 DB 의 `summoner` / `match_queue` 두 테이블을 초기화 후 재생성
- `V2__drop_and_recreate_summoner_and_match_queue.sql`:
  - `DROP TABLE IF EXISTS summoner; DROP TABLE IF EXISTS match_queue;`
  - 이후 `CREATE TABLE` 을 Hibernate 6.x PostgreSQL Dialect 기본 매핑에 맞춰 명시적으로 작성
    - `String` → `varchar(255)`, `Long` → `bigint`, `int` → `integer`, `OffsetDateTime` → `timestamp(6) with time zone`, `@Enumerated(STRING)` → `varchar(255)`
  - 신규 환경에서도 `DROP IF EXISTS` 덕분에 안전하게 `CREATE` 까지 진행

### Spring Boot 4.0 Flyway starter 교체 (`31b19df`)
- `org.flywaydb:flyway-core` → `org.springframework.boot:spring-boot-starter-flyway`
- Spring Boot 4.0 에서 `FlywayAutoConfiguration` 이 `spring-boot-autoconfigure` 에서 별도 모듈(`spring-boot-flyway`) 로 분리됨. starter 가 없으면 Flyway 빈 자체가 등록되지 않아 migrate 가 **조용히 no-op** 로 스킵됨.
- 이 커밋 없이는 Railway 에서도 Flyway 가 동작하지 않으므로 이 PR 에 반드시 포함.

## 로컬 검증

PostgreSQL 16 컨테이너(`bestduo-pg-verify`, port 5434) 로 엔드투엔드 검증:

1. **빈 스키마 → V1/V2 적용**: `flyway_schema_history` 에 V1(success=t) / V2(success=t) 기록, `summoner` / `match_queue` 컬럼 정의가 V2 SQL 과 일치
2. **prod 프로파일 재기동 (ddl-auto: validate)**:
   ```
   o.f.core.internal.command.DbMigrate: Schema "public" is up to date. No migration necessary.
   o.s.boot.tomcat.TomcatWebServer: Tomcat started on port 8081 (http)
   com.bestduo_BE.BestduoBeApplication: Started BestduoBeApplication in 4.183 seconds
   ```
   Hibernate validate 통과, 부팅 정상 완료

## Test Plan

- [x] `./gradlew test` — 기존 테스트 전부 통과 (Flyway 는 테스트 프로파일에서 비활성화)
- [x] 로컬 PostgreSQL 에서 V1/V2 정상 적용
- [x] prod 프로파일 + ddl-auto: validate 로 재기동 통과
- [ ] Railway 배포 후 기동 로그에서 `flyway_schema_history` 생성·V1/V2 적용 확인 (머지 후 수행)

## 롤백 계획

- Flyway migrate 가 실패하면 Spring 부팅이 실패하므로 배포 차단 — 기존 데이터 손상 없음
- V2 는 `summoner` / `match_queue` 를 drop 하지만, 사용자가 명시적으로 요청한 초기화. 되돌리려면 별도 백업 필요
- prod 프로파일 `ddl-auto: validate` 전환이 문제가 되면 `application-prod.yml` 에서 `update` 로 되돌리는 단일 변경으로 복구 가능

## 후속 PR

이 PR 머지 후 PR-3(env 외부화 + @Validated + graceful shutdown), PR-4(로그 민감값 마스킹) 이어짐.