### PR TITLE
feat: Pipeline 설정 env 외부화 + @Validated + graceful shutdown

### DIFF
--- a/src/main/java/com/bestduo_BE/config/PipelineProperties.java
+++ b/src/main/java/com/bestduo_BE/config/PipelineProperties.java
@@ -1,74 +1,105 @@
 package com.bestduo_BE.config;
 
 import com.bestduo_BE.common.domain.model.Tier;
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
+import org.springframework.validation.annotation.Validated;
 
 /**
  * 파이프라인 공통 설정.
  * <p>Stage별 일일 API 예산, 배치 크기, polling 간격, tier별 matchIds 수집 수를 관리한다.
+ * <p>범위를 벗어난 env 주입 시 앱 시작이 거부된다 (운영 안전장치).
  */
 @Component
 @ConfigurationProperties(prefix = "pipeline")
+@Validated
 @Getter
 @Setter
 public class PipelineProperties {
 
   /** Stage 1(SEED) 일일 API 호출 상한 */
+  @Min(1)
+  @Max(50_000)
   private int seedDailyBudget = 2000;
 
   /** Stage 2(COLLECT_MATCH_IDS) 일일 API 호출 상한 */
+  @Min(1)
+  @Max(50_000)
   private int collectDailyBudget = 8000;
 
   /** Stage 2 한 번에 처리할 summoner 수 */
+  @Min(1)
+  @Max(500)
   private int collectBatchSize = 20;
 
   /** Stage 3 한 번에 처리할 match 수 */
+  @Min(1)
+  @Max(500)
   private int ingestBatchSize = 10;
 
   /** match_queue가 빌 때 대기 시간 (ms) */
+  @Min(100)
+  @Max(600_000)
   private long pollingIntervalMs = 5000;
 
   /** 예기치 않은 오류 발생 시 재시도 전 대기 시간 (ms) */
+  @Min(100)
+  @Max(600_000)
   private long errorBackoffMs = 5000;
 
   /** Stage 2에서 match_queue에 enqueue할 때 사용하는 기본 우선순위 */
+  @Min(0)
+  @Max(1000)
   private int collectPriority = 50;
 
   /**
    * DIA/EME CoverageBucket에서 한 division 내 최대 page 수.
    * 이 수에 도달하면 다음 division으로 이동한다.
    */
+  @Min(1)
+  @Max(10_000)
   private int maxPagesPerDivision = 5;
 
   /**
    * 자동 생성되는 DIA/EME CoverageBucket의 목표 매치 수.
    * 버킷 status(COLLECTING/SUFFICIENT) 판단 기준으로만 사용된다.
    */
+  @Min(1)
   private long diaEmeCoverageTarget = 500_000L;
 
   /** DIA/EME 버킷당 하루에 처리할 최대 페이지 수 (per-bucket). */
+  @Min(1)
+  @Max(10_000)
   private int diaEmeDailyPageQuota = 10;
 
   /** Stage 3(INGEST)에서 그날 먼저 처리할 tier. null이면 기존 우선순위(CHALLENGER→…→기타) 유지. */
   private Tier stage3PriorityTier = null;
 
-  private Ingest ingest = new Ingest();
+  @Valid private Ingest ingest = new Ingest();
 
-  private TierMatchCount tierMatchCount = new TierMatchCount();
+  @Valid private TierMatchCount tierMatchCount = new TierMatchCount();
 
   @Getter
   @Setter
   public static class Ingest {
     /** RUNNING 상태가 이 분 이상 지속되면 stale로 복구 */
+    @Min(1)
+    @Max(1440)
     private int staleMinutes = 10;
 
     /** ERROR 상태 재시도 쿨다운 (분) */
+    @Min(1)
+    @Max(1440)
     private int errorCooldownMinutes = 10;
 
     /** 최대 재시도 횟수 */
+    @Min(0)
+    @Max(100)
     private int maxRetry = 2;
   }
 
@@ -76,9 +107,13 @@ public class PipelineProperties {
   @Setter
   public static class TierMatchCount {
     /** CHALLENGER / GRANDMASTER / MASTER 티어 summoner당 수집할 matchIds 수 */
+    @Min(1)
+    @Max(100)
     private int apexTiers = 30;
 
     /** DIAMOND / EMERALD 티어 summoner당 수집할 matchIds 수 */
+    @Min(1)
+    @Max(100)
     private int diamondEmerald = 10;
   }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,4 +1,10 @@
+server:
+  shutdown: graceful
+
 spring:
+  lifecycle:
+    timeout-per-shutdown-phase: 30s
+
   datasource:
     url: ${SPRING_DATASOURCE_URL:}
     username: ${SPRING_DATASOURCE_USERNAME:}
@@ -40,20 +46,20 @@ patch-sync:
 pipeline:
   runner:
     enabled: ${PIPELINE_RUNNER_ENABLED:true}
-  seed-daily-budget: 2000
-  collect-daily-budget: 8000
-  collect-batch-size: 20
-  ingest-batch-size: 10
-  polling-interval-ms: 5000
-  max-pages-per-division: 100
+  seed-daily-budget: ${PIPELINE_SEED_DAILY_BUDGET:2000}
+  collect-daily-budget: ${PIPELINE_COLLECT_DAILY_BUDGET:8000}
+  collect-batch-size: ${PIPELINE_COLLECT_BATCH_SIZE:20}
+  ingest-batch-size: ${PIPELINE_INGEST_BATCH_SIZE:10}
+  polling-interval-ms: ${PIPELINE_POLLING_INTERVAL_MS:5000}
+  max-pages-per-division: ${PIPELINE_MAX_PAGES_PER_DIVISION:100}
   tier-match-count:
-    apex-tiers: 100
-    diamond-emerald: 100
+    apex-tiers: ${PIPELINE_TIER_APEX:100}
+    diamond-emerald: ${PIPELINE_TIER_DIA_EME:100}
   stage3-priority-tier: ${PIPELINE_STAGE3_PRIORITY_TIER:DIAMOND}
   ingest:
-    stale-minutes: 10
-    error-cooldown-minutes: 10
-    max-retry: 2
+    stale-minutes: ${PIPELINE_INGEST_STALE_MINUTES:10}
+    error-cooldown-minutes: ${PIPELINE_INGEST_ERROR_COOLDOWN_MINUTES:10}
+    max-retry: ${PIPELINE_INGEST_MAX_RETRY:2}
 
 management:
   endpoints:

--- a/src/test/java/com/bestduo_BE/config/PipelinePropertiesTest.java
+++ b/src/test/java/com/bestduo_BE/config/PipelinePropertiesTest.java
@@ -1,0 +1,117 @@
+package com.bestduo_BE.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import java.util.Set;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class PipelinePropertiesTest {
+
+  private static ValidatorFactory factory;
+  private static Validator validator;
+
+  @BeforeAll
+  static void setUp() {
+    factory = Validation.buildDefaultValidatorFactory();
+    validator = factory.getValidator();
+  }
+
+  @AfterAll
+  static void tearDown() {
+    factory.close();
+  }
+
+  @Test
+  @DisplayName("기본값은 검증을 통과한다")
+  void validate_defaults_passes() {
+    PipelineProperties properties = new PipelineProperties();
+
+    Set<ConstraintViolation<PipelineProperties>> violations = validator.validate(properties);
+
+    assertThat(violations).isEmpty();
+  }
+
+  @Test
+  @DisplayName("seedDailyBudget이 0이면 검증 위반이 발생한다")
+  void validate_zeroSeedBudget_violates() {
+    PipelineProperties properties = new PipelineProperties();
+    properties.setSeedDailyBudget(0);
+
+    Set<ConstraintViolation<PipelineProperties>> violations = validator.validate(properties);
+
+    assertThat(violations).isNotEmpty();
+  }
+
+  @Test
+  @DisplayName("seedDailyBudget이 상한을 초과하면 검증 위반이 발생한다")
+  void validate_tooLargeSeedBudget_violates() {
+    PipelineProperties properties = new PipelineProperties();
+    properties.setSeedDailyBudget(50_001);
+
+    Set<ConstraintViolation<PipelineProperties>> violations = validator.validate(properties);
+
+    assertThat(violations).isNotEmpty();
+  }
+
+  @Test
+  @DisplayName("collectBatchSize가 음수면 검증 위반이 발생한다")
+  void validate_negativeBatchSize_violates() {
+    PipelineProperties properties = new PipelineProperties();
+    properties.setCollectBatchSize(-1);
+
+    Set<ConstraintViolation<PipelineProperties>> violations = validator.validate(properties);
+
+    assertThat(violations).isNotEmpty();
+  }
+
+  @Test
+  @DisplayName("pollingIntervalMs가 하한 미만이면 검증 위반이 발생한다")
+  void validate_tooShortPollingInterval_violates() {
+    PipelineProperties properties = new PipelineProperties();
+    properties.setPollingIntervalMs(50);
+
+    Set<ConstraintViolation<PipelineProperties>> violations = validator.validate(properties);
+
+    assertThat(violations).isNotEmpty();
+  }
+
+  @Test
+  @DisplayName("ingest.staleMinutes가 상한을 초과하면 검증 위반이 발생한다 (중첩 @Valid 확인)")
+  void validate_tooLargeIngestStaleMinutes_violates() {
+    PipelineProperties properties = new PipelineProperties();
+    properties.getIngest().setStaleMinutes(2000);
+
+    Set<ConstraintViolation<PipelineProperties>> violations = validator.validate(properties);
+
+    assertThat(violations).isNotEmpty();
+  }
+
+  @Test
+  @DisplayName("tierMatchCount.apexTiers가 Riot API 상한(100)을 초과하면 검증 위반이 발생한다")
+  void validate_tooLargeApexTierMatchCount_violates() {
+    PipelineProperties properties = new PipelineProperties();
+    properties.getTierMatchCount().setApexTiers(101);
+
+    Set<ConstraintViolation<PipelineProperties>> violations = validator.validate(properties);
+
+    assertThat(violations).isNotEmpty();
+  }
+
+  @Test
+  @DisplayName("ingest.maxRetry는 0을 허용한다 (재시도 금지 설정)")
+  void validate_zeroMaxRetry_passes() {
+    PipelineProperties properties = new PipelineProperties();
+    properties.getIngest().setMaxRetry(0);
+
+    Set<ConstraintViolation<PipelineProperties>> violations = validator.validate(properties);
+
+    assertThat(violations).isEmpty();
+  }
+}


### PR DESCRIPTION
## Summary

Phase 1 운영 준비 Plan 중 항목 1.4 (env 외부화) + 1.5 (@Validated) + 1.6 (graceful shutdown) 를 구현합니다.

- **`PipelineProperties`**: 클래스 레벨 `@Validated` + 모든 수치 필드에 `@Min`/`@Max` 적용, 중첩 `Ingest`/`TierMatchCount` 에는 `@Valid` 캐스케이드. 범위를 벗어난 env 주입 시 앱이 기동 단계에서 거부됩니다.
- **`application.yml`**: `pipeline.*` 12개 설정값을 `\${ENV:default}` 형식으로 외부화 (운영에서는 env 로 오버라이드, 로컬은 default 그대로 사용).
- **Graceful shutdown**: `server.shutdown: graceful` + `spring.lifecycle.timeout-per-shutdown-phase: 30s` 추가 — 진행 중인 파이프라인 stage 가 중단되지 않고 정리됩니다.
- **Test**: 기본값 통과 + seed/batch/polling/ingest.staleMinutes/tierMatchCount.apexTiers 경계 위반 + `ingest.maxRetry=0` 허용(재시도 금지 설정) 등 8 케이스.

## Stacked on

`feat/flyway-migration` (#41). Merge PR #41 후 이 PR 을 머지하면 됩니다.

## Test plan

- [x] `./gradlew test --tests "com.bestduo_BE.config.PipelinePropertiesTest"` → BUILD SUCCESSFUL
- [x] `./gradlew test` 전체 통과 (SpringBootTest 컨텍스트 로딩 → 기본값으로 @Validated 통과 확인)
- [ ] 운영 배포 전 env 치환 리스트 (`docs/operations_env_config.md` Table A) 와 실제 주입 값 일치 여부 재확인