### PR TITLE
chore: HTTP wire-level 로거 lockdown + Riot API Key 유출 회귀 테스트 (PR-4)

### DIFF
--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -27,6 +27,11 @@ logging:
     com.bestduo_BE.SQL: WARN          # datasource-proxy / SqlExecutionLoggingListener 로깅 비활성화
     org.hibernate.SQL: WARN
     org.hibernate.orm.jdbc.bind: WARN
+    # HTTP wire-level 로거는 절대 DEBUG 이상 금지 — X-Riot-Token 헤더 유출 방지
+    org.apache.hc: WARN
+    org.apache.http: WARN
+    jdk.internal.httpclient: WARN
+    org.springframework.web.client.RestTemplate: INFO
 
 monitoring:
   datasource:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -32,6 +32,11 @@ logging:
     org.hibernate.SQL: DEBUG
     org.hibernate.orm.jdbc.bind: DEBUG
     com.bestduo_BE.SQL: DEBUG
+    # HTTP wire-level 로거는 절대 DEBUG 이상 금지 — X-Riot-Token 헤더 유출 방지
+    org.apache.hc: WARN
+    org.apache.http: WARN
+    jdk.internal.httpclient: WARN
+    org.springframework.web.client.RestTemplate: INFO
 
 external:
   riot:

--- a/src/test/java/com/bestduo_BE/common/infra/riot/RiotApiSecretRedactionTest.java
+++ b/src/test/java/com/bestduo_BE/common/infra/riot/RiotApiSecretRedactionTest.java
@@ -1,0 +1,119 @@
+package com.bestduo_BE.common.infra.riot;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.springframework.test.web.client.ExpectedCount.once;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withServerError;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.classic.spi.IThrowableProxy;
+import ch.qos.logback.core.read.ListAppender;
+import com.bestduo_BE.common.infra.riot.exception.RiotApiException;
+import java.time.Clock;
+import java.time.Duration;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestTemplate;
+
+/**
+ * 회귀 테스트 — 에러 경로에서 X-Riot-Token API Key 리터럴이 로그에 유출되지 않는지 검증한다.
+ *
+ * <p>PR-4(로그 민감값 마스킹 점검)의 일환: RiotApiHttpAdapter는 현재 key를 참조하지 않지만,
+ * 미래 회귀(메시지 포맷에 헤더 덤프를 추가하거나 wire-level DEBUG 로거를 켜는 등)를 막기 위해
+ * 실제 에러 흐름을 돌려서 ROOT logger 캡처본에 key 리터럴이 들어가지 않음을 확인한다.
+ */
+class RiotApiSecretRedactionTest {
+
+  private static final String SECRET_KEY = "RGAPI-redaction-test-000000000000";
+
+  private Logger rootLogger;
+  private ListAppender<ILoggingEvent> logAppender;
+  private RiotRateLimitInterceptor interceptor;
+  private RestTemplate restTemplate;
+  private MockRestServiceServer mockServer;
+  private RiotApiHttpAdapter adapter;
+
+  @BeforeEach
+  void setUp() {
+    rootLogger = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
+    logAppender = new ListAppender<>();
+    logAppender.start();
+    rootLogger.addAppender(logAppender);
+
+    interceptor = new RiotRateLimitInterceptor(
+        SECRET_KEY,
+        new DualWindowRateLimiter(10, Duration.ofSeconds(1), 60, Duration.ofMinutes(2)),
+        Clock.systemUTC()
+    );
+    restTemplate = new RestTemplate();
+    restTemplate.setInterceptors(List.of(interceptor));
+    mockServer = MockRestServiceServer.bindTo(restTemplate).build();
+
+    adapter = new RiotApiHttpAdapter(restTemplate, restTemplate);
+  }
+
+  @AfterEach
+  void tearDown() {
+    rootLogger.detachAppender(logAppender);
+    logAppender.stop();
+  }
+
+  @Test
+  @DisplayName("Riot API 에러 경로 — log 출력에 X-Riot-Token 값이 포함되지 않는다")
+  void errorPath_doesNotLeakApiKey() {
+    mockServer.expect(once(), requestTo(
+            "/lol/match/v5/matches/by-puuid/some-puuid/ids?count=5"))
+        .andRespond(withServerError());
+
+    assertThatThrownBy(() -> adapter.findRecentMatchIds("some-puuid", 5))
+        .isInstanceOf(RiotApiException.class);
+
+    assertLogsDoNotContain(SECRET_KEY);
+  }
+
+  private void assertLogsDoNotContain(String secret) {
+    assertThat(logAppender.list)
+        .as("적어도 하나 이상의 로그가 캡처되어야 의미 있는 검증이다")
+        .isNotEmpty();
+
+    for (ILoggingEvent event : logAppender.list) {
+      assertThat(event.getFormattedMessage())
+          .as("formatted message at level %s", event.getLevel())
+          .doesNotContain(secret);
+
+      Object[] args = event.getArgumentArray();
+      if (args != null) {
+        assertThat(Arrays.toString(args))
+            .as("log argument array at level %s", event.getLevel())
+            .doesNotContain(secret);
+      }
+
+      IThrowableProxy throwable = event.getThrowableProxy();
+      while (throwable != null) {
+        assertThat(throwable.getMessage() == null ? "" : throwable.getMessage())
+            .as("throwable message")
+            .doesNotContain(secret);
+        throwable = throwable.getCause();
+      }
+    }
+  }
+
+  @Test
+  @DisplayName("캡처 appender 동작 확인 — SECRET_KEY를 직접 로깅하면 검증이 실패한다 (negative control)")
+  void negativeControl_directSecretLogIsDetected() {
+    rootLogger.setLevel(Level.INFO);
+    rootLogger.info("leaking {} for control check", SECRET_KEY);
+
+    assertThatThrownBy(() -> assertLogsDoNotContain(SECRET_KEY))
+        .isInstanceOf(AssertionError.class);
+  }
+}


### PR DESCRIPTION
## Summary

Phase 1 Item 1.7 — 로그 민감값 마스킹 점검. 코드 감사 결과 현재 런타임에서 `X-Riot-Token`이나 Admin API Key가 로그로 유출되는 경로는 없었다. 미래 회귀(예: wire-level DEBUG 로거 활성화)를 막는 방어 설정과 회귀 테스트를 추가한다.

## 감사 요약

- `RiotApiHttpAdapter` 로그 문장들은 key를 참조하지 않음 (puuid/matchId/tier만 포함)
- `RiotRateLimitInterceptor`는 `X-Riot-Token` 헤더를 세팅하지만 로그하지 않음 (예외 메시지에 URI만 포함 — Riot API는 query 아닌 헤더 방식이라 안전)
- `RiotApiProperties` / `AdminApiKeyProperties`: `@Getter @Setter`만 사용 — Lombok toString 미생성
- `CommonsRequestLoggingFilter` 등 요청 로깅 필터 미등록
- Spring Actuator는 configprops에서 `key`/`apiKey` 속성을 자동 sanitize하며 노출도 `health,prometheus`로 제한됨

## 방어 조치

**`application.yml` / `application-prod.yml`**: HTTP wire-level 로거를 명시적으로 WARN/INFO로 고정.

```yaml
logging:
  level:
    # HTTP wire-level 로거는 절대 DEBUG 이상 금지 — X-Riot-Token 헤더 유출 방지
    org.apache.hc: WARN
    org.apache.http: WARN
    jdk.internal.httpclient: WARN
    org.springframework.web.client.RestTemplate: INFO
```

**`RiotApiSecretRedactionTest`** (신규): Logback `ListAppender`를 ROOT logger에 붙여 에러 경로(`MockRestServiceServer`로 500 응답 시뮬레이션) 실행 후 캡처된 모든 이벤트(메시지/인자/예외 체인)에 API Key 리터럴이 없음을 검증. negative control 케이스로 appender 동작도 확인.

## Stacked PR

- Base: `feat/pipeline-config-externalization` (PR #42)
- Merge 순서: #40 → #41 → #42 → **이 PR**

## Test plan

- [x] `./gradlew test --tests RiotApiSecretRedactionTest` 통과
- [x] `./gradlew test --tests "com.bestduo_BE.common.infra.riot.*"` 회귀 없음
- [x] `./gradlew test --tests "com.bestduo_BE.config.*"` 회귀 없음
- [ ] CI green