### PR TITLE
feat: 관측성 스택 (구조화 로깅 + 메트릭 + Sentry + 운영 가이드)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,7 @@ dependencies {
 	implementation 'io.github.cdimascio:dotenv-java:3.0.0'
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'io.micrometer:micrometer-registry-prometheus'
+	implementation 'net.logstash.logback:logstash-logback-encoder:8.0'
 	compileOnly 'org.projectlombok:lombok'
 //	developmentOnly 'org.springframework.boot:spring-boot-docker-compose'
 	runtimeOnly 'org.postgresql:postgresql'

--- a/build.gradle
+++ b/build.gradle
@@ -36,6 +36,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'io.micrometer:micrometer-registry-prometheus'
 	implementation 'net.logstash.logback:logstash-logback-encoder:8.0'
+	implementation 'io.sentry:sentry-spring-boot-starter-jakarta:8.16.0'
+	implementation 'io.sentry:sentry-logback:8.16.0'
 	compileOnly 'org.projectlombok:lombok'
 //	developmentOnly 'org.springframework.boot:spring-boot-docker-compose'
 	runtimeOnly 'org.postgresql:postgresql'

--- a/docs/decisions/observability_tradeoffs.md
+++ b/docs/decisions/observability_tradeoffs.md
@@ -1,0 +1,180 @@
+---
+title: 관측성 스택 선정 — Trade-off 분석
+status: accepted
+last_updated: 2026-04-17
+related:
+  - ../operations_readiness_plan.md
+  - ../operations_env_config.md
+---
+
+# 관측성 스택 선정 — Trade-off 분석
+
+[운영 전환 준비 계획 §3 (Phase 2)](../operations_readiness_plan.md#3-phase-2--관측성--알림) 에서 도입할 관측성 스택을 선정한 근거를 기록한다.
+
+## 요약 (결정)
+
+| 영역 | 선정 | 비고 |
+|---|---|---|
+| 에러 추적 | **Sentry** (Developer free) | `sentry-spring-boot-starter-jakarta` |
+| 메트릭 원격 저장 | **Grafana Cloud Prometheus `remote_write`** (Free) | 이미 `micrometer-registry-prometheus` 사용 중 |
+| 알림 채널 | Discord Webhook | Grafana Alert → Webhook |
+| 외부 헬스체크 | UptimeRobot | 5분 간격 `/actuator/health` |
+
+관측성의 세 축(**로그 / 메트릭 / 에러**)을 한 벤더로 묶지 않고 **특화 도구를 병행**한다.
+
+---
+
+## 1. 배경 및 제약
+
+| 항목 | 현재 상태 |
+|---|---|
+| 인프라 | Railway Hobby plan (단일 인스턴스, $5 크레딧/월) |
+| 런타임 | Spring Boot 4 / Java 21 |
+| 이미 연결된 의존성 | `spring-boot-starter-actuator`, `micrometer-registry-prometheus` |
+| 네트워킹 | [Phase 1](../operations_readiness_plan.md#2-phase-1--보안--스키마-안전장치-최우선)에서 Public 노출 축소 예정 |
+| 프론트엔드 | Next.js / Vercel (별도) |
+| 예산 | 월 $10 이하 유지 |
+
+**해결해야 할 핵심 문제**
+- 장애를 **알아차리고(detection)** — 알림
+- 원인을 **추적할(diagnosis)** 수 있어야 — 에러 스택 / 메트릭 / 로그
+- APM(분산 트레이싱, DB 쿼리 프로파일)까지는 현 단계 불필요 (YAGNI)
+
+---
+
+## 2. 평가 기준
+
+1. **Spring Boot / Micrometer 통합 품질** — 공식 starter, 자동계측 범위
+2. **무료 tier의 실질 용량** — 현재 트래픽에서 overshoot 없이 수용 가능한가
+3. **Railway 네트워킹 적합성** — 인바운드 노출 없이 동작(push 기반) 가능한가
+4. **운영 부담** — self-host 시 "모니터링 인프라가 먼저 죽는" meta-monitoring 문제
+5. **벤더 lock-in과 exit 비용** — 표준 프로토콜 / 데이터 이전 가능성
+
+---
+
+## 3. 에러 추적 — Sentry
+
+### 3-1. 후보 비교
+
+| 옵션 | Pros | Cons | 결론 |
+|---|---|---|---|
+| **Sentry (Developer free)** | 공식 Spring Boot starter, 5K events/월 + 30일 보관, issue grouping·release tracking·source map 1급, 프론트(Next.js)와 **동일 프로젝트로 trace 연결** | 초과 시 Team $26/mo, 메트릭/대시보드 약함 | ✅ 채택 |
+| Datadog APM | APM + 로그 + 메트릭 한 벤더 | 호스트당 $31/mo, trace/log volume 기반으로 **비용 예측 불가**. APM은 현 단계 overkill | ❌ |
+| New Relic | 무료 100GB/월로 관대 | 100GB 초과 시 GB당 $0.30, 에러 전용 UX(issue grouping, release health) 정제도가 Sentry보다 약함 | ❌ |
+| Rollbar | Free 5K occurrences/월 | Spring 통합 레시피·커뮤니티 자료 부족, 프론트-백 통합 이슈 뷰 약함 | ❌ |
+| Bugsnag | Free 7.5K events | Spring Boot starter가 커뮤니티판 → 버전 호환성 리스크 | ❌ |
+| GlitchTip (Sentry API 호환 OSS, self-host) | 라이선스 비용 0 | Railway Hobby에 컨테이너 추가 → 메모리 압박, **meta-monitoring 공백** | ❌ |
+| 로그만 (Loki/ELK + grep) | 추가 비용 0 | fingerprinting·dedup·release tracking·알림 라우팅을 **직접 구현**해야 함 (YAGNI 위반) | ❌ |
+
+### 3-2. 결정 근거
+
+- **통합 비용이 가장 낮음**: `application.yml`에 DSN 한 줄 + starter 의존성으로 `@ExceptionHandler` 누락 예외, ERROR 레벨 로그, HTTP breadcrumb, release 정보가 자동 캡처됨.
+- **무료 tier가 실제 사용량을 상회함**: 배치 파이프라인 1시간 간격, 스테이지 실패율 1% 가정 시 월 수십~수백 이벤트 — 5K 한도에 여유가 큼.
+- **Exit 경로 존재**: Sentry 중단이 필요하면 GlitchTip(Sentry API 호환)으로 **SDK 교체 없이 DSN만 변경**해 self-host 가능. 에러 이벤트는 장기 보존 가치가 낮아 이전 비용이 작음.
+- **프론트·백 단일 프로젝트 trace** 연결이 가능하여 End-to-end 원인 추적에 유리.
+
+### 3-3. 수용한 한계
+
+- 5K events/월 초과 시 다음 플랜 $26 — 빈번히 넘으면 재검토 필요.
+- Sentry 자체 장애 시 에러 가시성이 단절되므로, **알림 경로는 Grafana Alert → Discord와 이중화**하여 단일 장애점을 피한다.
+
+---
+
+## 4. 메트릭 원격 저장 — Grafana Cloud Prometheus `remote_write`
+
+### 4-1. Pull vs Push — Railway 환경에서의 결정적 차이
+
+| 방식 | Railway Hobby에서의 현실 |
+|---|---|
+| Pull (Prometheus scrape) | 외부 수집기가 `/actuator/prometheus`에 접근해야 함. Private Networking은 동일 프로젝트 내부만 가능 → 외부 scrape는 **Public Networking을 열어야 함**. [Phase 1의 Actuator 축소 방침](../operations_readiness_plan.md#2-phase-1--보안--스키마-안전장치-최우선)과 충돌 |
+| **Push (`remote_write`)** | 앱이 아웃바운드로 지표를 밀어냄. 인바운드 노출 0 — Phase 1 보안 방향과 일관 |
+
+Push 방식이 **단순 선호가 아니라 보안 아키텍처 결정과 묶여 있다**는 점이 핵심.
+
+### 4-2. 후보 비교
+
+| 옵션 | Pros | Cons | 결론 |
+|---|---|---|---|
+| **Grafana Cloud Prometheus `remote_write`** | 이미 `micrometer-registry-prometheus` 사용 중 — 설정만 추가, 10K active series + 14일 보관 무료, `remote_write`는 **Prometheus 표준 프로토콜(Protobuf + Snappy/HTTP)** 로 lock-in 최소 | Free 사용자 3명 cap, 10K series 초과 시 $8/1K series | ✅ 채택 |
+| Self-host Prometheus + Grafana (Railway 컨테이너) | 비용 0, 완전 제어 | 컨테이너 2개 + 디스크 → Hobby 리소스 초과, **meta-monitoring 공백**, 운영 대상을 늘리는 결정은 Phase 2 방향과 역행 | ❌ |
+| Datadog | APM/로그/메트릭 통합 | 호스트당 $15/mo, custom metric 100개/host 초과 시 $0.05/metric — **예산 즉시 초과**, 보관 1.5일 | ❌ |
+| New Relic | 무료 100GB/월 관대 | OTLP 경유가 주류 → `micrometer-registry-otlp` 추가 필요, Prometheus 커뮤니티 대시보드 템플릿 재사용 불가 | ❌ |
+| InfluxDB Cloud | 시계열 전용 성능 우수 | Flux/InfluxQL 학습 필요, Prometheus 생태계 단절 | ❌ |
+| AWS CloudWatch | AWS 인프라와 통합 | Railway 네트워크/IAM 불일치, metric당 과금이 Micrometer 다수 지표에 불리 | ❌ |
+| Railway 내장 Observability | 추가 인프라 0 | CPU/메모리/네트워크만 제공 — **애플리케이션 커스텀 메트릭**(stage별 처리량, 큐 길이 등) 계측 불가 | ❌ |
+
+### 4-3. 결정 근거
+
+- **코드 변경 최소**: 이미 의존성이 깔려 있고 `remote_write` URL/credential만 설정하면 됨.
+- **Free tier 여유**: Spring Boot 기본 JVM/HTTP 지표 약 300~500 series + 커스텀 메트릭 수십 개 ≪ 10K.
+- **Lock-in이 기술적으로 낮음**: `remote_write`는 공개 스펙 → 이전 경로가 구체적임.
+  - self-host Prometheus / Grafana 로 이전 → `remote_write` URL만 변경
+  - VictoriaMetrics Cloud / Mimir / Thanos 로도 동일한 protocol로 이전 가능
+  - 즉, **Grafana Cloud가 아니라 Prometheus 생태계에 락인**되는 구조. Prometheus 생태계는 사실상 산업 표준.
+- **Push 방식이 Phase 1 보안 방향과 일관** (§4-1 참조).
+
+### 4-4. 수용한 한계
+
+- 10K active series 초과 시 과금 → **cardinality 설계 규율 필수**.
+  - `user_id`, `request_id` 같은 고유값을 label로 사용 금지.
+  - tag는 enum 성격(stage, region, outcome)으로 제한.
+- Free tier 3 user 상한 — 팀 확장 시 Pro $8/user/mo 재검토.
+
+---
+
+## 5. 왜 단일 벤더로 묶지 않았는가
+
+Datadog / New Relic 처럼 로그·메트릭·에러·APM을 하나로 묶는 선택지가 있음에도 특화 도구 병행을 택한 이유:
+
+1. **관측성 세 축의 특성이 다름**
+   - 로그: 고볼륨, 단기 보존
+   - 메트릭: 저볼륨, 장기 보존
+   - 에러/트레이스: 중간 볼륨, 구조화
+   - 한 벤더가 세 영역 모두 잘하는 경우는 유료 구간에서만 성립. **무료 tier는 특화 벤더가 우위**.
+2. **장애 반경이 분리됨**
+   - Sentry 장애 → 에러 가시성 상실, 메트릭/알림 유지
+   - Grafana 장애 → 메트릭 가시성 상실, 에러/Discord 알림 유지
+   - 단일 벤더 통합은 **단일 장애점(SPOF)** 이 됨.
+3. **현재 규모에선 통합(correlation) 이득 < 비용 절감**
+   - 규모가 커져 단일 이슈에서 "메트릭 이상 → 관련 로그 → 관련 트레이스"를 즉시 연결해야 하는 단계가 오면 Datadog/NR로 재검토.
+
+---
+
+## 6. 결과 (Consequences)
+
+### Positive
+- 월 비용 0 유지.
+- 기존 의존성(Micrometer + Prometheus)에 얹는 형태로 코드 변경 최소.
+- Prometheus 표준 덕분에 **벤더 이전 경로가 명시적**.
+- Phase 1의 "Admin/Actuator 공격면 축소"와 일관된 push 기반 아키텍처.
+
+### Negative
+- 벤더 2곳(Sentry + Grafana Cloud) 계정/시크릿 관리 부담.
+- Free tier 상한(5K events, 10K series, 3 user) 각각 모니터링 필요.
+- Cardinality 설계 규율이 개발자 책임으로 남음.
+
+### Neutral
+- 알림 경로는 Sentry → Discord, Grafana Alert → Discord **이중화**하여 단일 장애점 회피.
+
+---
+
+## 7. 재검토 트리거
+
+| 트리거 | 재검토 후보 |
+|---|---|
+| 월 error > 50K, Sentry Team plan 유료 구간 고착 | Sentry Team 유지 또는 GlitchTip self-host |
+| active series > 10K, custom metric cardinality 증가 | VictoriaMetrics Cloud 또는 self-host |
+| 팀원 > 3명 또는 보안 감사 요구 | Grafana Cloud Pro 또는 자체 stack |
+| 멀티 인스턴스 전환 | pull 방식 + 서비스 디스커버리 재검토 |
+| APM(분산 트레이싱, DB 쿼리 프로파일) 요구 | Datadog APM / Elastic APM |
+| 규제(PII, 국내 저장) 요구 | self-host 강제 |
+
+---
+
+## 8. 참고
+
+- [운영 전환 준비 계획 §3](../operations_readiness_plan.md#3-phase-2--관측성--알림)
+- [운영 환경변수 설정 전략](../operations_env_config.md)
+- Sentry Spring Boot: <https://docs.sentry.io/platforms/java/guides/spring-boot/>
+- Grafana Cloud `remote_write`: <https://grafana.com/docs/grafana-cloud/monitor-infrastructure/integrations/integration-reference/integration-prometheus/>
+- Prometheus `remote_write` spec: <https://prometheus.io/docs/concepts/remote_write_spec/>

--- a/docs/operations_env_config.md
+++ b/docs/operations_env_config.md
@@ -1,0 +1,168 @@
+---
+title: 운영 환경변수 설정 전략
+status: active
+last_updated: 2026-04-17
+---
+
+# 운영 환경변수 설정 전략
+
+BestDuo 백엔드는 Railway에 배포되며, 운영 중 튜닝이 필요한 값은 **Railway 환경변수 덮어쓰기 + 자동 재배포** 방식으로 관리한다. Spring Cloud Config, DB 설정 테이블 같은 별도 런타임 설정 인프라는 도입하지 않는다 (YAGNI — 서비스 규모 대비 오버엔지니어링).
+
+---
+
+## 1. 기본 원칙
+
+- **yml = 기본값, env var = 운영 오버라이드.**
+  - `application.yml`의 값은 로컬/기본 실행 시에만 사용되는 fallback.
+  - 운영(`prod` 프로파일)에서 튜닝이 필요한 모든 값은 `${ENV_VAR:기본값}` 형태로 외부화한다.
+- **env 변경 = 재배포 = 짧은 다운타임.**
+  - Railway는 env 저장 시 자동으로 컨테이너를 재시작한다 (약 20~60초 소요).
+  - 트래픽/배치 적은 시간대에 변경하는 것을 원칙으로 한다.
+- **값 범위는 `@Validated`로 시작 시 검증한다.**
+  - 잘못된 값이 주입되면 앱이 **시작을 거부**하도록 하여 조용한 오작동을 방지한다.
+
+---
+
+## 2. 환경변수 네이밍 컨벤션
+
+- 대문자 + 언더스코어 사용: `PIPELINE_COLLECT_DAILY_BUDGET`
+- Spring Boot의 Relaxed Binding이 자동으로 `pipeline.collect-daily-budget`과 매핑한다.
+- 접두사는 yml의 property prefix를 따른다 (`pipeline.*` → `PIPELINE_*`, `external.riot.*` → `EXTERNAL_RIOT_*`).
+
+---
+
+## 3. 값 분류
+
+### (A) env var로 운영 중 튜닝 가능한 값
+
+파이프라인 처리량, 예산, 재시도 정책처럼 운영 피드백을 보며 주기적으로 조정하는 값.
+
+| 키 | Env Var | 기본값 | 용도 |
+|---|---|---|---|
+| `pipeline.seed-daily-budget` | `PIPELINE_SEED_DAILY_BUDGET` | 2000 | Stage 1 SEED 일일 API 호출 상한 |
+| `pipeline.collect-daily-budget` | `PIPELINE_COLLECT_DAILY_BUDGET` | 8000 | Stage 2 COLLECT 일일 API 호출 상한 |
+| `pipeline.collect-batch-size` | `PIPELINE_COLLECT_BATCH_SIZE` | 20 | Stage 2 한 번에 처리할 summoner 수 |
+| `pipeline.ingest-batch-size` | `PIPELINE_INGEST_BATCH_SIZE` | 10 | Stage 3 한 번에 처리할 match 수 |
+| `pipeline.polling-interval-ms` | `PIPELINE_POLLING_INTERVAL_MS` | 5000 | 큐가 빌 때 대기 시간 (ms) |
+| `pipeline.max-pages-per-division` | `PIPELINE_MAX_PAGES_PER_DIVISION` | 100 | DIA/EME 1 division 최대 page 수 |
+| `pipeline.tier-match-count.apex-tiers` | `PIPELINE_TIER_APEX` | 100 | Apex 티어 summoner당 matchIds 수 |
+| `pipeline.tier-match-count.diamond-emerald` | `PIPELINE_TIER_DIA_EME` | 100 | DIA/EME 티어 summoner당 matchIds 수 |
+| `pipeline.ingest.stale-minutes` | `PIPELINE_INGEST_STALE_MINUTES` | 10 | RUNNING 상태 stale 복구 시간 (분) |
+| `pipeline.ingest.error-cooldown-minutes` | `PIPELINE_INGEST_ERROR_COOLDOWN_MINUTES` | 10 | ERROR 재시도 쿨다운 (분) |
+| `pipeline.ingest.max-retry` | `PIPELINE_INGEST_MAX_RETRY` | 2 | 최대 재시도 횟수 |
+| `pipeline.stage3-priority-tier` | `PIPELINE_STAGE3_PRIORITY_TIER` | (null) | Stage 3 우선 처리 티어 |
+
+### (B) Kill-switch (긴급 제어)
+
+서비스 긴급 중지/재개 스위치. 재배포 없이 빠르게 끄기 위해 **Boolean env var**로 유지한다.
+
+| 키 | Env Var | 기본값 | 용도 |
+|---|---|---|---|
+| `patch-sync.enabled` | `PATCH_SYNC_ENABLED` | true | 패치 버전 동기화 스케줄러 on/off |
+| `pipeline.runner.enabled` | `PIPELINE_RUNNER_ENABLED` | true | 파이프라인 러너 전체 on/off |
+
+**사용 시나리오:**
+- Riot API 장애 / rate limit 폭주 → `PIPELINE_RUNNER_ENABLED=false`
+- 패치 동기화 문제 → `PATCH_SYNC_ENABLED=false`
+
+### (C) 환경/보안 값 (변경 빈도 낮음)
+
+| 키 | Env Var | 설명 |
+|---|---|---|
+| DataSource | `SPRING_DATASOURCE_URL`, `SPRING_DATASOURCE_USERNAME`, `SPRING_DATASOURCE_PASSWORD` | DB 연결 정보 |
+| Riot API | `EXTERNAL_RIOT_API_KEY` | Riot API 키 (월 1회 갱신) |
+| 프로파일 | `SPRING_PROFILES_ACTIVE` | `prod` 고정 |
+
+---
+
+## 4. 운영 절차
+
+### 4.1 튜닝 변경 절차
+
+1. **변경 전**: 파이프라인/트래픽 상태 확인 (Grafana, `/admin/queue` 상태).
+2. **Railway Dashboard → Service → Variables**에서 env 수정 후 Save.
+3. 자동 재배포 대기 (약 20~60초).
+4. `/actuator/health` 및 Grafana로 정상 확인.
+5. `docs/operations_tuning_log.md`에 변경 기록 (일시, 키, before → after, 사유, 관찰된 효과).
+
+### 4.2 Kill-switch 발동 절차
+
+1. 이상 감지 (Riot API 5xx 폭주, rate limit 초과 알림 등).
+2. `PIPELINE_RUNNER_ENABLED=false`로 변경.
+3. 재배포 완료 후 파이프라인이 실제로 멈췄는지 로그/Grafana로 확인.
+4. 근본 원인 해결 후 `true`로 복구.
+
+### 4.3 배포 중 유의사항
+
+- env 변경 → 재배포 과정에서 **진행 중인 배치가 강제 종료될 수 있다**.
+- `MatchQueue.status = RUNNING`으로 남은 row는 `stale-minutes` 경과 후 자동 복구된다.
+- 이를 위해 `server.shutdown: graceful` 설정 및 in-flight 배치의 shutdown hook 대응이 필요하다 (미적용 시 별도 작업 항목).
+
+---
+
+## 5. 구현 규칙
+
+### 5.1 yml 작성 규칙
+
+모든 튜닝 대상 값은 다음 형태로 외부화한다:
+
+```yaml
+pipeline:
+  seed-daily-budget: ${PIPELINE_SEED_DAILY_BUDGET:2000}
+  collect-batch-size: ${PIPELINE_COLLECT_BATCH_SIZE:20}
+```
+
+기본값은 yml에 그대로 남겨두어 **env 없이도 실행 가능**하게 한다.
+
+### 5.2 값 범위 검증
+
+`@ConfigurationProperties` 클래스에 `@Validated` + Bean Validation을 적용한다.
+
+```java
+@Component
+@ConfigurationProperties(prefix = "pipeline")
+@Validated
+public class PipelineProperties {
+  @Min(1) @Max(50000)
+  private int seedDailyBudget = 2000;
+
+  @Min(1) @Max(500)
+  private int collectBatchSize = 20;
+  // ...
+}
+```
+
+범위를 벗어난 값이 주입되면 앱 시작 시 예외 발생 → Railway 헬스체크 실패 → 이전 배포 유지.
+
+### 5.3 `@Scheduled` 주기 설정
+
+- `fixedRate`(long)는 컴파일 타임 상수만 허용 → env로 못 바꾼다.
+- 주기를 env로 바꾸려면 `fixedRateString`을 쓴다:
+
+```java
+@Scheduled(fixedRateString = "${pipeline.polling-interval-ms:5000}")
+```
+
+### 5.4 로그에 민감값 노출 금지
+
+- `EXTERNAL_RIOT_API_KEY`, DB 패스워드는 로그/예외 메시지에 절대 포함하지 않는다.
+- `RiotApiHttpAdapter` 등 외부 호출 로깅 시 URL/헤더 마스킹 필수.
+
+---
+
+## 6. 이 방식의 한계 (수용)
+
+- **변경마다 재배포 필요** → 분 단위 변경이 필요한 A/B 테스트에는 부적합.
+- **Railway env 변경 이력이 부실** → 감사 목적이라면 `docs/operations_tuning_log.md`를 성실히 운영해야 한다.
+- **다중 인스턴스 동시 반영 보장 안 됨** → Railway 배포 순서에 따라 일시적으로 구/신 설정이 혼재할 수 있다. 현재는 단일 인스턴스이므로 문제 없음.
+
+이 한계가 실제 운영에서 불편해지면 DB 기반 설정 테이블 도입을 재검토한다 (별도 ADR 필요).
+
+---
+
+## 7. 참고
+
+- [architecture.md](./architecture.md) — 전체 아키텍처
+- `src/main/resources/application.yml` — 기본값
+- `src/main/resources/application-prod.yml` — prod 프로파일 오버라이드
+- `src/main/java/com/bestduo_BE/config/PipelineProperties.java` — 파이프라인 설정 바인딩

--- a/docs/operations_external_services.md
+++ b/docs/operations_external_services.md
@@ -1,0 +1,316 @@
+---
+title: 외부 관측 서비스 연동 운영 가이드
+status: active
+last_updated: 2026-04-17
+---
+
+# 외부 관측 서비스 연동 운영 가이드
+
+[operations_readiness_plan.md](./operations_readiness_plan.md) Phase 2 / PR-7 의 운영 작업을 다룬다. 코드 변경 없이 외부 서비스를 연결하여 **메트릭 시각화 / 에러 추적 / 알림 / 외부 헬스체크**를 가동한다.
+
+대상 서비스:
+
+| 용도 | 서비스 | 비용 |
+|---|---|---|
+| 메트릭 원격 저장 + 대시보드 | Grafana Cloud (Free) | 10K series, 14일 보존 |
+| 에러 추적 | Sentry (Developer 플랜) | 5K events/month |
+| 알림 채널 | Discord Webhook | 무료 |
+| 외부 헬스체크 | UptimeRobot (Free) | 5분 간격, 50개 모니터 |
+
+코드 측 준비 상태 (PR-5 / PR-6 머지 완료 가정):
+- `/actuator/prometheus` 노출 (Spring Boot Actuator + Micrometer Prometheus)
+- 구조화 JSON 로그 (`logback-spring.xml`, `prod` 프로파일에서 `LogstashEncoder`)
+- 커스텀 메트릭: `pipeline.stage.completed`, `pipeline.match_queue.size`, `riot.api.request`
+- Sentry SDK 설치 (`SENTRY_DSN` 비어 있으면 자동 no-op)
+
+---
+
+## 1. Sentry (PR-6 후속 운영 작업)
+
+### 1.1 프로젝트 생성
+
+1. https://sentry.io/signup/ 가입 → 무료 Developer 플랜 선택.
+2. **Create Project** → Platform: **Java / Spring Boot**.
+3. 프로젝트명 예시: `bestduo-be-prod`.
+4. 생성 후 표시되는 **DSN** 값을 복사 (`https://<key>@oXXXX.ingest.sentry.io/YYYY` 형태).
+
+### 1.2 Railway 환경변수 등록
+
+Railway Dashboard → Service → **Variables**에서 추가:
+
+| Env Var | 값 | 비고 |
+|---|---|---|
+| `SENTRY_DSN` | (복사한 DSN) | 비어 있으면 SDK가 no-op |
+| `SENTRY_ENVIRONMENT` | `prod` | 로컬은 미설정 → `local` 기본값 |
+| `SENTRY_RELEASE` | `0.0.1-SNAPSHOT` | 배포마다 변경. 가능하면 git SHA 자동 주입 |
+| `SENTRY_TRACES_SAMPLE_RATE` | `0.05` | 트레이싱 샘플링 비율 (5%) |
+
+저장 후 자동 재배포 → `/actuator/health` 확인.
+
+### 1.3 검증
+
+1. Railway 콘솔 → Logs에서 `Sentry` 초기화 로그 확인 (`Initializing SDK ... environment=prod`).
+2. 의도적 에러 발생 (예: 임시로 `/admin/queue/error-test` 같은 트리거를 만들거나, 운영 중 자연 발생을 기다림).
+3. Sentry 프로젝트 → Issues에서 새 이슈 표시 확인.
+
+### 1.4 알림 통합
+
+Sentry → **Settings → Integrations → Discord** → Connect Workspace → 알림을 받을 채널 선택.
+또는 Sentry **Alerts → Notifications** 에서 Discord webhook 직접 등록 (다음 §3 참고).
+
+기본 룰 권장:
+- **이슈 발생 빈도 ≥ 10 events/min** → 즉시 Discord
+- **새로운 이슈 등장** → 즉시 Discord
+- **Regression (해결된 이슈 재발)** → 즉시 Discord
+
+### 1.5 노이즈 관리
+
+`application.yml`에 이미 등록:
+
+```yaml
+sentry:
+  ignored-exceptions-for-type:
+    - com.bestduo_BE.common.infra.riot.exception.RiotRateLimitedException
+```
+
+운영하며 노이즈 예외가 추가되면 같은 리스트에 패키지 경로로 추가한다 (예: 일시적 외부 5xx 래퍼 등).
+
+---
+
+## 2. Grafana Cloud (Prometheus remote_write + 대시보드)
+
+### 2.1 계정 / 스택 생성
+
+1. https://grafana.com/auth/sign-up/create-user → 무료 가입.
+2. 자동으로 stack 1개 생성됨 (`<account>.grafana.net`).
+3. **Connections → Add new connection → Hosted Prometheus metrics → Prometheus**.
+4. **Forward metrics from a Prometheus server**가 아닌 **By an agent / scrape 외부에서 push**가 필요 없으므로 → **Prometheus remote_write 엔드포인트** 정보를 저장한다:
+   - URL: `https://prometheus-prod-XX-prod-eu-west-X.grafana.net/api/prom/push`
+   - Username: 숫자 ID
+   - Password: API Token (Write 권한)
+
+### 2.2 수집 방식 선택
+
+Spring Boot 앱은 `/actuator/prometheus`를 **노출**(pull)할 뿐 push 하지 않는다. Grafana Cloud로 데이터를 보내는 방법은 두 가지:
+
+**(A) Grafana Agent (또는 Alloy) — 권장**
+
+별도 Railway 서비스로 Grafana Agent 컨테이너를 1개 띄워서 내부 네트워크로 백엔드를 scrape → Grafana Cloud로 remote_write.
+
+장점: Spring Boot 앱은 변경 없음. Agent의 scrape interval만 운영.
+단점: Railway에 컨테이너 1개 추가 (Hobby plan 한 서비스 슬롯 소비).
+
+설정 예 (`agent-config.yaml`):
+
+```yaml
+metrics:
+  global:
+    scrape_interval: 30s
+  configs:
+    - name: bestduo
+      remote_write:
+        - url: https://prometheus-prod-XX-prod-eu-west-X.grafana.net/api/prom/push
+          basic_auth:
+            username: ${GRAFANA_CLOUD_PROM_USER}
+            password: ${GRAFANA_CLOUD_PROM_TOKEN}
+      scrape_configs:
+        - job_name: bestduo-backend
+          metrics_path: /actuator/prometheus
+          static_configs:
+            - targets: ['bestduo-be.railway.internal:8080']
+```
+
+Railway에 Agent 서비스 추가 → 위 yaml을 마운트 → 환경변수 주입.
+
+**(B) Grafana Cloud Synthetic / Prometheus 외부 scrape**
+
+Grafana Cloud가 인터넷 노출된 `/actuator/prometheus`를 직접 scrape. 이 경우 엔드포인트가 공개되므로 **Basic Auth 또는 IP allowlist**가 필요 → Spring Security 설정 변경이 코드 PR로 필요. 지금 단계에서는 (A)를 채택.
+
+### 2.3 데이터 도착 확인
+
+Grafana Cloud → **Explore → Prometheus data source** → `up{job="bestduo-backend"}` 쿼리 → `1` 반환 확인.
+
+샘플 쿼리:
+- `pipeline_stage_completed_total` — Stage별 누적 처리량
+- `pipeline_match_queue_size` — 큐 길이
+- `riot_api_request_seconds_count` — Riot API 호출 수
+
+(Micrometer는 `.` 을 `_` 로 변환하여 Prometheus 노출한다.)
+
+### 2.4 대시보드 패널 (1개 대시보드 / 4개 row)
+
+**Row 1 — 파이프라인 처리량**
+
+| 패널 | 쿼리 | 시각화 |
+|---|---|---|
+| Stage별 success rate (5분) | `sum by (stage) (rate(pipeline_stage_completed_total{outcome="success"}[5m]))` | Time series |
+| Stage별 error rate (5분) | `sum by (stage) (rate(pipeline_stage_completed_total{outcome="error"}[5m]))` | Time series |
+| 에러율 % | `sum by (stage) (rate(pipeline_stage_completed_total{outcome="error"}[5m])) / sum by (stage) (rate(pipeline_stage_completed_total[5m]))` | Stat (red>5%) |
+
+**Row 2 — 큐 / Riot API**
+
+| 패널 | 쿼리 | 시각화 |
+|---|---|---|
+| Match queue size | `pipeline_match_queue_size` | Time series |
+| Riot API 응답시간 p95 | `histogram_quantile(0.95, sum by (le, endpoint) (rate(riot_api_request_seconds_bucket[5m])))` | Time series |
+| Riot API 실패율 | `sum by (endpoint) (rate(riot_api_request_seconds_count{outcome="error"}[5m])) / sum by (endpoint) (rate(riot_api_request_seconds_count[5m]))` | Stat |
+
+**Row 3 — JVM / HTTP**
+
+| 패널 | 쿼리 | 시각화 |
+|---|---|---|
+| Heap 사용량 | `jvm_memory_used_bytes{area="heap"}` | Time series |
+| GC pause | `rate(jvm_gc_pause_seconds_sum[5m])` | Time series |
+| HTTP 요청 RPS | `sum by (uri) (rate(http_server_requests_seconds_count[5m]))` | Time series |
+| HTTP 5xx | `sum by (uri) (rate(http_server_requests_seconds_count{status=~"5.."}[5m]))` | Stat (red>0) |
+
+**Row 4 — 시스템**
+
+| 패널 | 쿼리 | 시각화 |
+|---|---|---|
+| Process CPU | `process_cpu_usage` | Gauge |
+| File descriptor | `process_files_open_files` | Time series |
+| DB 커넥션 active | `hikaricp_connections_active` | Time series |
+
+대시보드는 **Grafana → Dashboards → New → Import**로 위 패널을 직접 구성하거나, 추후 JSON으로 export하여 `docs/grafana-dashboard.json`에 커밋한다 (재현성).
+
+### 2.5 알림 룰 (Grafana Alerting)
+
+| 룰 | 조건 | 채널 | 심각도 |
+|---|---|---|---|
+| Pipeline error rate high | `error_rate > 0.2` 5분 지속 | Discord | warning |
+| Match queue 폭증 | `pipeline_match_queue_size > 5000` 10분 지속 | Discord | warning |
+| Riot API 실패율 | `riot 5xx rate > 0.1` 5분 지속 | Discord | warning |
+| Heap 위험 | `heap used / max > 0.9` 5분 지속 | Discord | critical |
+| Service down | `up{job="bestduo-backend"} == 0` 1분 지속 | Discord | critical |
+
+Grafana → **Alerting → Contact points → New** → Discord webhook 등록 (다음 §3에서 만든 webhook URL 입력).
+
+---
+
+## 3. Discord Webhook
+
+### 3.1 채널 / 웹훅 생성
+
+1. Discord 서버에서 알림 전용 채널 생성 (예: `#bestduo-alerts`).
+2. 채널 톱니바퀴 → **Integrations → Webhooks → New Webhook**.
+3. 이름/아이콘 설정 후 **Copy Webhook URL**.
+
+### 3.2 사용처
+
+| 사용처 | 등록 위치 |
+|---|---|
+| Grafana Alerting | Contact points → Discord → URL 붙여넣기 |
+| Sentry Alerts | Settings → Integrations → Discord (또는 Alert Rule → Webhook URL 직접 입력) |
+| UptimeRobot 알림 | My Settings → Alert Contacts → Add Webhook |
+
+### 3.3 보안
+
+- Webhook URL은 사실상 **비밀**(누구나 채널에 글을 쓸 수 있음). git에 커밋 금지. Railway / Grafana / Sentry / UptimeRobot 각 서비스의 secret 저장소에만 저장.
+- 노출 의심 시 Discord 채널에서 Webhook 삭제 후 재발급.
+
+### 3.4 알림 형식
+
+기본 페이로드(`content`/`embeds`)는 각 발신 서비스가 자동 구성한다. Grafana는 alert rule에서 **message template**으로 한국어/요약 형식을 커스터마이즈할 수 있다.
+
+권장 템플릿(Grafana):
+
+```
+[{{ .Status | toUpper }}] {{ .CommonLabels.alertname }}
+- 환경: {{ .CommonLabels.env }}
+- 시작: {{ .StartsAt.Format "2006-01-02 15:04:05" }}
+- 값: {{ range .Alerts }}{{ .ValueString }}{{ end }}
+- 대시보드: {{ .CommonAnnotations.dashboardURL }}
+```
+
+---
+
+## 4. UptimeRobot (외부 헬스체크)
+
+### 4.1 모니터 등록
+
+1. https://uptimerobot.com/signUp → 무료 가입.
+2. **Add New Monitor** → Type: **HTTP(s)**.
+3. URL: `https://<railway-public-domain>/actuator/health`
+4. Monitoring Interval: **5분** (free 플랜 최소).
+5. Monitor Timeout: **30초**.
+6. Alert Contacts: 다음 §4.2.
+
+### 4.2 알림 채널 연결
+
+**My Settings → Alert Contacts → Add Alert Contact**:
+
+| Type | 값 |
+|---|---|
+| Webhook | Discord webhook URL (§3에서 생성한 것) + POST + Content-Type `application/json` |
+| (선택) Email | 운영자 메일 (백업용) |
+
+Discord webhook은 UptimeRobot 기본 페이로드와 직접 호환되지 않으므로 **Webhook URL 끝에 `/slack` 추가** 가 가장 간편하다 (Discord가 Slack-호환 페이로드를 받아준다).
+
+예: `https://discord.com/api/webhooks/XXX/YYY/slack`
+
+### 4.3 검증
+
+- 등록 직후 모니터 status가 5분 내 **Up** 으로 표시되는지 확인.
+- 임시로 Railway 서비스를 stop → 5~10분 내 Discord 알림 도착 확인 → 다시 start.
+
+### 4.4 한계
+
+- Free 플랜은 **5분 간격**이 최소 → 최대 ~10분의 감지 지연을 수용한다.
+- `/actuator/health`는 `show-details: never`로 단순 UP/DOWN 만 반환하므로 컴포넌트별 상세 진단은 Grafana로 본다.
+
+---
+
+## 5. 환경변수 / Secret 관리 정리
+
+운영자가 보유해야 할 secret 일람. 모두 **Railway env var** 또는 외부 SaaS 콘솔에 저장하며 git에는 절대 커밋하지 않는다.
+
+| Secret | 저장 위치 | 갱신 주기 | 비고 |
+|---|---|---|---|
+| `EXTERNAL_RIOT_API_KEY` | Railway | 월 1회 | Riot Developer Portal에서 발급 |
+| `ADMIN_API_KEY` | Railway | 분기 1회 | 32자 이상 무작위 |
+| `SPRING_DATASOURCE_PASSWORD` | Railway (DB plugin이 주입) | DB 회전 시 | Railway가 자동 관리 |
+| `SENTRY_DSN` | Railway | 프로젝트 재생성 시 | Sentry → Project Settings → Client Keys |
+| `SENTRY_RELEASE` | Railway (배포 스크립트) | 배포마다 | git SHA 권장 |
+| `SENTRY_TRACES_SAMPLE_RATE` | Railway | 비용 조정 시 | 기본 0.05 |
+| `GRAFANA_CLOUD_PROM_USER` | Grafana Agent 서비스 env | 토큰 회전 시 | 숫자 ID |
+| `GRAFANA_CLOUD_PROM_TOKEN` | Grafana Agent 서비스 env | 분기 1회 | Write-only 권한 토큰 |
+| Discord Webhook URL | Grafana / Sentry / UptimeRobot | 노출 의심 시 | Discord 채널 → Webhook 재발급 |
+| UptimeRobot API Key | UptimeRobot 콘솔 | 필요 시 | 모니터 자동화 시에만 |
+
+### 5.1 회전 절차 (예: Riot API Key)
+
+1. Riot Developer Portal에서 신규 키 발급.
+2. Railway env `EXTERNAL_RIOT_API_KEY` 갱신 → 자동 재배포.
+3. `/actuator/health` 정상 확인 + Grafana에서 `riot_api_request_seconds_count` 증가 확인.
+4. 구 키는 발급처에서 폐기.
+
+### 5.2 노출 사고 대응
+
+1. 즉시 해당 secret을 발급처에서 폐기/재발급.
+2. Railway env에 신규 값 주입 → 재배포.
+3. git history에 누출되었다면 BFG/`git filter-repo`로 제거 + force-push 결정 (별도 검토 필요).
+4. `docs/operations_tuning_log.md` 또는 별도 incident 로그에 사건 기록.
+
+---
+
+## 6. 완료 기준 (Phase 2 — PR-7)
+
+다음을 모두 충족하면 Phase 2 종료:
+
+- [ ] Sentry: prod 환경에서 의도적 에러 발생 → Sentry Issue 자동 생성 → Discord 알림 도착.
+- [ ] Grafana Cloud: 대시보드 1개에서 Stage별 처리량 / 큐 길이 / Riot API 실패율 / JVM heap / HTTP 5xx 실시간 확인 가능.
+- [ ] Grafana Alerting: 위 5개 룰 활성화 + Discord contact point 동작 확인.
+- [ ] UptimeRobot: `/actuator/health` 5분 간격 모니터 Up 상태 + 강제 다운 시 5~10분 내 Discord 알림 수신.
+- [ ] 본 문서의 모든 secret이 Railway 또는 각 SaaS 콘솔에 저장되어 있고, 저장소에는 어떤 형태로도 커밋되지 않음.
+
+---
+
+## 7. 참고
+
+- [operations_readiness_plan.md](./operations_readiness_plan.md) — 전체 로드맵 (Phase 1~3)
+- [operations_env_config.md](./operations_env_config.md) — 환경변수 운영 전략
+- [decisions/observability_tradeoffs.md](./decisions/observability_tradeoffs.md) — 도구 선정 trade-off
+- `src/main/resources/application.yml` — Sentry / Actuator 기본 설정
+- `src/main/resources/application-prod.yml` — prod 오버라이드
+- `src/main/resources/logback-spring.xml` — 구조화 로그 설정

--- a/docs/operations_readiness_plan.md
+++ b/docs/operations_readiness_plan.md
@@ -1,0 +1,166 @@
+---
+title: 운영 전환 준비 계획
+status: active
+last_updated: 2026-04-17
+---
+
+# 운영 전환 준비 계획
+
+BestDuo 백엔드를 Railway(Hobby plan) 위에서 안정적으로 운영하기 위한 변경 로드맵. 현재 `main` 브랜치는 이미 배포되어 있고 Vercel에 프론트엔드(Next.js App Router, Server Component 기반)가 연결된 상태다.
+
+본 문서는 **무엇을 / 왜 / 어떤 순서로** 바꿀지에 대한 합의 문서이며, 상세 구현은 각 단계에서 별도 PR로 진행한다.
+
+---
+
+## 0. 현재 운영 상황 스냅샷
+
+| 항목 | 현재 |
+|---|---|
+| 백엔드 | Spring Boot 4.0.0 / Java 21, Railway Hobby plan 단일 인스턴스 |
+| 프론트엔드 | Next.js App Router, Vercel 배포, Server Component에서 Railway로 서버-간 fetch |
+| Railway 노출 방식 | **Public Networking** (인터넷에서 직접 접근 가능) |
+| DB 마이그레이션 | `ddl-auto: update` (prod 포함) |
+| Admin 엔드포인트 | `/admin/queue`, `/admin/patch`, `/admin/coverage` **인증 없이 공개** |
+| Actuator | `/health,/metrics,/prometheus` 전부 공개, `health.show-details=always` |
+| 설정 튜닝 | `application.yml` 하드코딩 값 다수, env 외부화 미완 |
+| 관측성 | Actuator + Micrometer + Prometheus registry 의존성만 추가된 상태, 수집기/대시보드 없음 |
+| 알림 | 없음 |
+| 부하 테스트 | 없음 |
+| 종료 처리 | graceful shutdown 미적용 |
+
+### 이미 결정된 운영 전략
+- 환경변수 튜닝 방식: [operations_env_config.md](./operations_env_config.md) 참조 (Railway env var 덮어쓰기 → 자동 재배포)
+- Admin 엔드포인트는 **제거하지 않고 인증을 붙여 유지** (운영 중 비상 도구로 사용)
+
+---
+
+## 1. 위험도 평가
+
+### 🔴 Critical — 인터넷에 공격면이 열려 있음
+1. **Admin API 무인증 노출** — 외부에서 큐 조작(`POST /admin/queue/work`), 패치 강제 등록 가능.
+2. **Actuator 정보 유출** — `/actuator/health?show-details=always` → DB 커넥션, 디스크 상태, 구성요소 내부가 그대로 노출.
+3. **`ddl-auto: update` in prod** — 앱 재시작 시 엔티티 변경 내용이 DB에 자동 반영. 실수로 `@Column` 삭제 → 프로덕션 컬럼 drop 위험.
+
+### 🟠 High — 운영 안정성 저해
+4. 하드코딩된 파이프라인 수치. env 오버라이드 없음 → 튜닝할 때마다 코드 수정/배포 필요.
+5. `@ConfigurationProperties`에 값 범위 검증 부재 → 잘못된 env 주입 시 조용히 동작(음수 budget 등).
+6. Graceful shutdown 부재 → 재배포 시 in-flight 배치 강제 종료, `RUNNING` stale row 발생.
+
+### 🟡 Medium — 장기적으로 필요
+7. 관측성 부재(로그/메트릭/에러 추적/알림) → 장애 발생 후 원인 파악 어려움.
+8. Resilience 패턴 부재 → Riot API 일시 장애가 파이프라인 전체 중단으로 번질 수 있음.
+9. 부하 특성 미측정 → Hobby plan 한계 예측 불가.
+
+### 🟢 Low — 현재는 문제 없음
+10. CORS가 `/v3/api-docs,/swagger-ui`에만 설정됨 — 프론트가 Server Component라 서버-간 호출로 bypass됨. 추후 Client Component fetch 도입 시 수정.
+11. 다중 인스턴스 동시성(ShedLock 등) — Hobby plan 단일 인스턴스라 해당 없음.
+
+---
+
+## 2. Phase 1 — 보안 & 스키마 안전장치 (최우선)
+
+**목표**: 인터넷 공격면을 닫고, 스키마 변경으로 데이터를 잃지 않도록 안전장치 설치.
+
+| # | 작업 | 변경 파일 | 비고 |
+|---|---|---|---|
+| 1.1 | **Admin API Key 인증** | 신규 `AdminApiKeyInterceptor` + `AdminApiKeyProperties`, `WebConfig`, yml | `X-Admin-Key` 헤더 검증, 불일치 시 401. `@Validated @NotBlank`로 빈 키면 앱 시작 거부 |
+| 1.2 | **Actuator 축소** | `application.yml`, `application-prod.yml` | exposure = `health,prometheus`, `show-details: never` |
+| 1.3 | **Flyway 도입** | `build.gradle`, 신규 `db/migration/V1__baseline.sql`, yml | `ddl-auto: validate`, 기존 DB는 `baselineOnMigrate: true`로 흡수 |
+| 1.4 | **Pipeline 값 env 외부화** | `application.yml`, `PipelineProperties` | 현재 [operations_env_config.md](./operations_env_config.md) (A) 표에 정의된 키 전부 `${ENV:default}` 형태로 |
+| 1.5 | **`@Validated` + `@Min/@Max`** | `PipelineProperties`, `AdminApiKeyProperties` | 잘못된 env 주입 시 앱 시작 거부 → Railway 헬스체크 실패 → 이전 배포 유지 |
+| 1.6 | **Graceful shutdown** | `application.yml` | `server.shutdown: graceful`, `spring.lifecycle.timeout-per-shutdown-phase: 30s` |
+| 1.7 | **로그 민감값 마스킹 점검** | `RiotApiHttpAdapter` 등 외부 호출 로깅 | API Key 헤더 마스킹 강제 |
+
+### PR 분할 제안
+- **PR-1**: 1.1 Admin 인증 + 1.2 Actuator 축소 (같은 보안 성격, 작은 범위)
+- **PR-2**: 1.3 Flyway (별도 — 스키마는 리스크가 달라서 분리)
+- **PR-3**: 1.4 + 1.5 + 1.6 (운영 튜닝 인프라 묶음)
+- **PR-4**: 1.7 로그 점검 (필요 시)
+
+### 완료 기준
+- 외부에서 `curl https://.../admin/queue/stats` → 401
+- `curl https://.../actuator/health` → `{"status":"UP"}` 만 반환
+- `ADMIN_API_KEY` 미설정 상태에서 앱 시작 시 즉시 실패
+- 신규 엔티티 추가 후 Flyway 마이그레이션 없이 재배포 → 앱 시작 실패(의도적)
+
+---
+
+## 3. Phase 2 — 관측성 & 알림
+
+**목표**: 장애를 "알아차리고 원인을 추적"할 수 있게 한다.
+
+> 도구 선정 근거: [관측성 스택 선정 — Trade-off 분석](./decisions/observability_tradeoffs.md)
+
+| # | 작업 | 도입 도구 | 비용 |
+|---|---|---|---|
+| 2.1 | **구조화 로그(JSON)** | `logstash-logback-encoder` + MDC 상관관계 ID | 무료 |
+| 2.2 | **에러 추적** | Sentry (Spring Boot starter) | Developer 무료 플랜 (5K events/month) |
+| 2.3 | **메트릭 원격 저장** | Grafana Cloud Prometheus remote_write (또는 Agent push) | Free tier (10K series) |
+| 2.4 | **커스텀 메트릭** | Micrometer `Counter`/`Timer` — 파이프라인 stage별 처리량, Riot API 응답시간, 큐 길이 | — |
+| 2.5 | **알림 채널** | Discord Webhook (Grafana Alert → Webhook) | 무료 |
+| 2.6 | **외부 헬스체크** | UptimeRobot (5분 간격 `/actuator/health`) | 무료 |
+| 2.7 | **대시보드** | Grafana Cloud 대시보드 1개 (파이프라인 지표 + JVM + HTTP) | 무료 |
+
+### PR 분할 제안
+- **PR-5**: 2.1 + 2.4 (로깅/메트릭 계측 — 코드 변경)
+- **PR-6**: 2.2 Sentry 도입
+- **PR-7**: Grafana Cloud / UptimeRobot / Discord 설정 (코드 변경 없음, 운영 작업)
+
+### 완료 기준
+- Grafana 대시보드에서 "Stage별 처리량 / 큐 길이 / Riot API 실패율" 실시간 확인 가능
+- 앱 에러 → Sentry 이슈 자동 생성 → Discord에 메시지
+- 서비스 다운 → UptimeRobot이 5분 내 감지 → Discord 알림
+
+---
+
+## 4. Phase 3 — 회복탄력성 & 용량 계획
+
+**목표**: 외부 의존성 장애 시 전체 중단을 막고, Hobby plan 한계를 미리 파악한다.
+
+| # | 작업 | 내용 |
+|---|---|---|
+| 3.1 | **Resilience4j Retry + CircuitBreaker** | Riot API 호출부에 적용. 5xx 연속 발생 시 차단, 점진적 복구 |
+| 3.2 | **Riot API rate limit 가드** | 현재 수동 관리 중인 budget을 Bucket4j / Resilience4j RateLimiter로 전환 검토 |
+| 3.3 | **k6 부하 테스트** | 조회 API(GetBottomDuoStats 등)에 대해 Hobby plan CPU/메모리 한계 측정 |
+| 3.4 | **DB 백업 전략** | Railway PostgreSQL 자동 백업 정책 확인 + 수동 덤프 스크립트 |
+| 3.5 | **운영 런북(Runbook)** | `docs/runbook.md` — 대표 장애 시나리오별 조치 순서 |
+
+### PR 분할 제안
+- **PR-8**: 3.1 Resilience4j (코드 변경)
+- **PR-9**: 3.3 k6 시나리오 (`/loadtest/*.js`)
+- 3.2 / 3.4 / 3.5 는 문서/운영 작업
+
+---
+
+## 5. 일정 감각 (참고)
+
+본 일정은 제안이며, 실제 속도에 맞춰 조정한다.
+
+| 구간 | 기간 감각 | 산출물 |
+|---|---|---|
+| Phase 1 | 1~2주 | PR-1 ~ PR-4 merge, 운영 환경에 보안/안전장치 적용 |
+| Phase 2 | 1~2주 | Grafana 대시보드 + Discord 알림 working |
+| Phase 3 | 필요 시 | Resilience4j, 부하테스트, 런북 |
+
+---
+
+## 6. 범위 밖 (현재 의사결정)
+
+다음 항목은 **의식적으로 지금 도입하지 않는다** (YAGNI):
+
+- Spring Cloud Config / DB 기반 설정 테이블 — Railway env var로 충분
+- ShedLock / 분산 락 — 단일 인스턴스
+- Kubernetes / 자체 인프라 — Railway로 충분
+- E2E 자동화 테스트 — 수동 smoke로 충당
+- CI/CD 고도화 — Railway 자동 배포로 충당
+
+상황이 바뀌면(멀티 인스턴스 필요, 분/초 단위 설정 반영 필요 등) 해당 시점에 ADR로 재검토.
+
+---
+
+## 7. 참고
+
+- [architecture.md](./architecture.md) — 전체 아키텍처
+- [operations_env_config.md](./operations_env_config.md) — 환경변수 전략
+- `src/main/resources/application.yml` — 기본 설정
+- `src/main/resources/application-prod.yml` — prod 오버라이드

--- a/src/main/java/com/bestduo_BE/common/infra/riot/RiotApiHttpAdapter.java
+++ b/src/main/java/com/bestduo_BE/common/infra/riot/RiotApiHttpAdapter.java
@@ -33,84 +33,95 @@ public class RiotApiHttpAdapter implements RiotApiPort {
 
   private final RestTemplate regionalRestTemplate;
   private final RestTemplate platformRestTemplate;
+  private final RiotApiMetrics metrics;
 
   public RiotApiHttpAdapter(
       @Qualifier("riotRegionalRestTemplate") RestTemplate regionalRestTemplate,
-      @Qualifier("riotPlatformRestTemplate") RestTemplate platformRestTemplate) {
+      @Qualifier("riotPlatformRestTemplate") RestTemplate platformRestTemplate,
+      RiotApiMetrics metrics) {
     this.regionalRestTemplate = regionalRestTemplate;
     this.platformRestTemplate = platformRestTemplate;
+    this.metrics = metrics;
   }
 
   // ── Match IDs ──────────────────────────────────────────────────────────
 
   @Override
   public List<String> findRecentMatchIds(String puuid, int count) {
-    try {
-      String[] matchIds = regionalRestTemplate.getForObject(
-          "/lol/match/v5/matches/by-puuid/{puuid}/ids?count={count}",
-          String[].class,
-          puuid,
-          count
-      );
-      return matchIds == null ? List.of() : Arrays.asList(matchIds);
-    } catch (RestClientException e) {
-      log.error("matchIds 조회 실패. puuid={}, count={}", puuid, count, e);
-      throw new RiotApiException("Failed to load match ids from Riot API", e);
-    }
+    return metrics.record("findRecentMatchIds", () -> {
+      try {
+        String[] matchIds = regionalRestTemplate.getForObject(
+            "/lol/match/v5/matches/by-puuid/{puuid}/ids?count={count}",
+            String[].class,
+            puuid,
+            count
+        );
+        return matchIds == null ? List.<String>of() : Arrays.asList(matchIds);
+      } catch (RestClientException e) {
+        log.error("matchIds 조회 실패. puuid={}, count={}", puuid, count, e);
+        throw new RiotApiException("Failed to load match ids from Riot API", e);
+      }
+    });
   }
 
   @Override
   public List<String> findMatchIdsSince(String puuid, long startTimeEpochSeconds, int count) {
-    try {
-      String[] matchIds = regionalRestTemplate.getForObject(
-          "/lol/match/v5/matches/by-puuid/{puuid}/ids?startTime={startTime}&count={count}",
-          String[].class,
-          puuid,
-          startTimeEpochSeconds,
-          count
-      );
-      return matchIds == null ? List.of() : Arrays.asList(matchIds);
-    } catch (RestClientException e) {
-      log.error("matchIds(since) 조회 실패. puuid={}, startTime={}, count={}",
-          puuid, startTimeEpochSeconds, count, e);
-      throw new RiotApiException("Failed to load match ids since startTime from Riot API", e);
-    }
+    return metrics.record("findMatchIdsSince", () -> {
+      try {
+        String[] matchIds = regionalRestTemplate.getForObject(
+            "/lol/match/v5/matches/by-puuid/{puuid}/ids?startTime={startTime}&count={count}",
+            String[].class,
+            puuid,
+            startTimeEpochSeconds,
+            count
+        );
+        return matchIds == null ? List.<String>of() : Arrays.asList(matchIds);
+      } catch (RestClientException e) {
+        log.error("matchIds(since) 조회 실패. puuid={}, startTime={}, count={}",
+            puuid, startTimeEpochSeconds, count, e);
+        throw new RiotApiException("Failed to load match ids since startTime from Riot API", e);
+      }
+    });
   }
 
   @Override
   public List<String> findMatchIdsBetween(
       String puuid, long startTimeEpochSeconds, long endTimeEpochSeconds, int count) {
-    try {
-      String[] matchIds = regionalRestTemplate.getForObject(
-          "/lol/match/v5/matches/by-puuid/{puuid}/ids?startTime={startTime}&endTime={endTime}&count={count}",
-          String[].class,
-          puuid,
-          startTimeEpochSeconds,
-          endTimeEpochSeconds,
-          count
-      );
-      return matchIds == null ? List.of() : Arrays.asList(matchIds);
-    } catch (RestClientException e) {
-      log.error("matchIds(between) 조회 실패. puuid={}, startTime={}, endTime={}, count={}",
-          puuid, startTimeEpochSeconds, endTimeEpochSeconds, count, e);
-      throw new RiotApiException("Failed to load match ids between timerange from Riot API", e);
-    }
+    return metrics.record("findMatchIdsBetween", () -> {
+      try {
+        String[] matchIds = regionalRestTemplate.getForObject(
+            "/lol/match/v5/matches/by-puuid/{puuid}/ids?startTime={startTime}&endTime={endTime}&count={count}",
+            String[].class,
+            puuid,
+            startTimeEpochSeconds,
+            endTimeEpochSeconds,
+            count
+        );
+        return matchIds == null ? List.<String>of() : Arrays.asList(matchIds);
+      } catch (RestClientException e) {
+        log.error("matchIds(between) 조회 실패. puuid={}, startTime={}, endTime={}, count={}",
+            puuid, startTimeEpochSeconds, endTimeEpochSeconds, count, e);
+        throw new RiotApiException("Failed to load match ids between timerange from Riot API", e);
+      }
+    });
   }
 
   // ── Match Detail ───────────────────────────────────────────────────────
 
   @Override
   public RiotMatchDto loadMatch(String matchId) {
-    try {
-      return regionalRestTemplate.getForObject(
-          "/lol/match/v5/matches/{matchId}",
-          RiotMatchDto.class,
-          matchId
-      );
-    } catch (RestClientException e) {
-      log.error("match 조회 실패. matchId={}", matchId, e);
-      throw new RiotApiException("Failed to load match from Riot API", e);
-    }
+    return metrics.record("loadMatch", () -> {
+      try {
+        return regionalRestTemplate.getForObject(
+            "/lol/match/v5/matches/{matchId}",
+            RiotMatchDto.class,
+            matchId
+        );
+      } catch (RestClientException e) {
+        log.error("match 조회 실패. matchId={}", matchId, e);
+        throw new RiotApiException("Failed to load match from Riot API", e);
+      }
+    });
   }
 
   // ── League Entries ─────────────────────────────────────────────────────
@@ -118,26 +129,28 @@ public class RiotApiHttpAdapter implements RiotApiPort {
   @Override
   public List<LeagueEntry> loadLeagueEntries(
       String queue, String tier, String division, int page) {
-    try {
-      Tier resolvedTier = resolveTier(tier);
-      if (isApexTier(resolvedTier)) {
-        return page > 1 ? List.of() : loadApexTierEntries(queue, resolvedTier);
-      }
+    return metrics.record("loadLeagueEntries", () -> {
+      try {
+        Tier resolvedTier = resolveTier(tier);
+        if (isApexTier(resolvedTier)) {
+          return page > 1 ? List.<LeagueEntry>of() : loadApexTierEntries(queue, resolvedTier);
+        }
 
-      LeagueEntry[] entries = platformRestTemplate.getForObject(
-          "/lol/league/v4/entries/{queue}/{tier}/{division}?page={page}",
-          LeagueEntry[].class,
-          queue,
-          tier,
-          division,
-          page
-      );
-      return entries == null ? List.of() : Arrays.asList(entries);
-    } catch (RestClientException e) {
-      log.error("league entries 조회 실패. queue={}, tier={}, division={}, page={}",
-          queue, tier, division, page, e);
-      throw new RiotApiException("Failed to load league entries from Riot API", e);
-    }
+        LeagueEntry[] entries = platformRestTemplate.getForObject(
+            "/lol/league/v4/entries/{queue}/{tier}/{division}?page={page}",
+            LeagueEntry[].class,
+            queue,
+            tier,
+            division,
+            page
+        );
+        return entries == null ? List.<LeagueEntry>of() : Arrays.asList(entries);
+      } catch (RestClientException e) {
+        log.error("league entries 조회 실패. queue={}, tier={}, division={}, page={}",
+            queue, tier, division, page, e);
+        throw new RiotApiException("Failed to load league entries from Riot API", e);
+      }
+    });
   }
 
   // ── private helpers ─────────────────────────────────────────────────────

--- a/src/main/java/com/bestduo_BE/common/infra/riot/RiotApiMetrics.java
+++ b/src/main/java/com/bestduo_BE/common/infra/riot/RiotApiMetrics.java
@@ -1,0 +1,30 @@
+package com.bestduo_BE.common.infra.riot;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import java.util.function.Supplier;
+import org.springframework.stereotype.Component;
+
+@Component
+public class RiotApiMetrics {
+
+  private static final String METRIC_NAME = "riot.api.request";
+
+  private final MeterRegistry registry;
+
+  public RiotApiMetrics(MeterRegistry registry) {
+    this.registry = registry;
+  }
+
+  public <T> T record(String endpoint, Supplier<T> call) {
+    Timer.Sample sample = Timer.start(registry);
+    try {
+      T result = call.get();
+      sample.stop(registry.timer(METRIC_NAME, "endpoint", endpoint, "outcome", "success"));
+      return result;
+    } catch (RuntimeException e) {
+      sample.stop(registry.timer(METRIC_NAME, "endpoint", endpoint, "outcome", "error"));
+      throw e;
+    }
+  }
+}

--- a/src/main/java/com/bestduo_BE/common/observability/CorrelationIdFilter.java
+++ b/src/main/java/com/bestduo_BE/common/observability/CorrelationIdFilter.java
@@ -1,0 +1,48 @@
+package com.bestduo_BE.common.observability;
+
+import jakarta.servlet.Filter;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.UUID;
+import org.slf4j.MDC;
+import org.springframework.core.Ordered;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+@Component
+@Order(Ordered.HIGHEST_PRECEDENCE)
+public class CorrelationIdFilter implements Filter {
+
+  public static final String HEADER_NAME = "X-Request-Id";
+  public static final String MDC_KEY = "requestId";
+
+  @Override
+  public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+      throws IOException, ServletException {
+    String requestId = resolveRequestId(request);
+    MDC.put(MDC_KEY, requestId);
+    try {
+      if (response instanceof HttpServletResponse httpResponse) {
+        httpResponse.setHeader(HEADER_NAME, requestId);
+      }
+      chain.doFilter(request, response);
+    } finally {
+      MDC.remove(MDC_KEY);
+    }
+  }
+
+  private static String resolveRequestId(ServletRequest request) {
+    if (request instanceof HttpServletRequest httpRequest) {
+      String fromHeader = httpRequest.getHeader(HEADER_NAME);
+      if (fromHeader != null && !fromHeader.isBlank()) {
+        return fromHeader;
+      }
+    }
+    return UUID.randomUUID().toString();
+  }
+}

--- a/src/main/java/com/bestduo_BE/pipeline/application/MatchQueueGaugeRegistrar.java
+++ b/src/main/java/com/bestduo_BE/pipeline/application/MatchQueueGaugeRegistrar.java
@@ -1,0 +1,24 @@
+package com.bestduo_BE.pipeline.application;
+
+import com.bestduo_BE.common.infra.persistence.repository.IngestQueueStatsJpaRepository;
+import jakarta.annotation.PostConstruct;
+import org.springframework.stereotype.Component;
+
+@Component
+public class MatchQueueGaugeRegistrar {
+
+  private final PipelineMetrics pipelineMetrics;
+  private final IngestQueueStatsJpaRepository statsRepository;
+
+  public MatchQueueGaugeRegistrar(
+      PipelineMetrics pipelineMetrics,
+      IngestQueueStatsJpaRepository statsRepository) {
+    this.pipelineMetrics = pipelineMetrics;
+    this.statsRepository = statsRepository;
+  }
+
+  @PostConstruct
+  public void register() {
+    pipelineMetrics.registerMatchQueueGauge(() -> statsRepository.countReadyByTier(null));
+  }
+}

--- a/src/main/java/com/bestduo_BE/pipeline/application/PipelineMetrics.java
+++ b/src/main/java/com/bestduo_BE/pipeline/application/PipelineMetrics.java
@@ -1,0 +1,29 @@
+package com.bestduo_BE.pipeline.application;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import java.util.function.Supplier;
+import org.springframework.stereotype.Component;
+
+@Component
+public class PipelineMetrics {
+
+  private static final String STAGE_COMPLETED = "pipeline.stage.completed";
+  private static final String MATCH_QUEUE_SIZE = "pipeline.match_queue.size";
+
+  private final MeterRegistry registry;
+
+  public PipelineMetrics(MeterRegistry registry) {
+    this.registry = registry;
+  }
+
+  public void recordStageCompleted(int stage, String outcome) {
+    registry.counter(STAGE_COMPLETED, "stage", String.valueOf(stage), "outcome", outcome)
+        .increment();
+  }
+
+  public void registerMatchQueueGauge(Supplier<Number> sizeSupplier) {
+    Gauge.builder(MATCH_QUEUE_SIZE, sizeSupplier, s -> s.get().doubleValue())
+        .register(registry);
+  }
+}

--- a/src/main/java/com/bestduo_BE/pipeline/application/PipelineRunner.java
+++ b/src/main/java/com/bestduo_BE/pipeline/application/PipelineRunner.java
@@ -39,6 +39,7 @@ public class PipelineRunner {
   private final MatchIngestRunner matchIngestRunner;
   private final PatchVersionService patchVersionService;
   private final PipelineProperties props;
+  private final PipelineMetrics pipelineMetrics;
 
   private Thread pipelineThread;
 
@@ -90,14 +91,26 @@ public class PipelineRunner {
     // Stage 1: Seed (일일 예산 내)
     if (dailyLeagueEntriesRunner.hasWorkToday()) {
       log.debug("Stage 1 실행");
-      dailyLeagueEntriesRunner.runNextChunk();
+      try {
+        dailyLeagueEntriesRunner.runNextChunk();
+        pipelineMetrics.recordStageCompleted(1, "success");
+      } catch (RuntimeException e) {
+        pipelineMetrics.recordStageCompleted(1, "error");
+        throw e;
+      }
       return;
     }
 
     // Stage 2: CollectMatchIds (일일 예산 내)
     if (collectMatchIdsRunner.hasPending()) {
       log.debug("Stage 2 실행");
-      collectMatchIdsRunner.runBatch();
+      try {
+        collectMatchIdsRunner.runBatch();
+        pipelineMetrics.recordStageCompleted(2, "success");
+      } catch (RuntimeException e) {
+        pipelineMetrics.recordStageCompleted(2, "error");
+        throw e;
+      }
       return;
     }
 
@@ -108,8 +121,15 @@ public class PipelineRunner {
         .orElse(null);
     Tier priorityTier = props.getStage3PriorityTier();
     log.debug("Stage 3 실행 (effectivePatch={}, priorityTier={})", effectivePatch, priorityTier);
-    MatchIngestRunner.Result result = matchIngestRunner.executeWithPriority(
-        props.getIngestBatchSize(), priorityTier, effectivePatch);
+    MatchIngestRunner.Result result;
+    try {
+      result = matchIngestRunner.executeWithPriority(
+          props.getIngestBatchSize(), priorityTier, effectivePatch);
+      pipelineMetrics.recordStageCompleted(3, "success");
+    } catch (RuntimeException e) {
+      pipelineMetrics.recordStageCompleted(3, "error");
+      throw e;
+    }
 
     if (result.picked() == 0) {
       log.debug("match_queue 비어있음. {}ms 대기", props.getPollingIntervalMs());

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -31,3 +31,11 @@ logging:
 monitoring:
   datasource:
     enabled: false
+
+sentry:
+  environment: prod
+  traces-sample-rate: ${SENTRY_TRACES_SAMPLE_RATE:0.05}
+  enable-tracing: true
+  logging:
+    minimum-event-level: error
+    minimum-breadcrumb-level: info

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -65,3 +65,16 @@ admin:
 monitoring:
   datasource:
     enabled: false
+
+sentry:
+  dsn: ${SENTRY_DSN:}
+  environment: ${SENTRY_ENVIRONMENT:local}
+  release: ${SENTRY_RELEASE:}
+  send-default-pii: false
+  traces-sample-rate: 0.0
+  enable-tracing: false
+  logging:
+    minimum-event-level: warn
+    minimum-breadcrumb-level: info
+  ignored-exceptions-for-type:
+    - com.bestduo_BE.common.infra.riot.exception.RiotRateLimitedException

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -69,7 +69,7 @@ monitoring:
 sentry:
   dsn: ${SENTRY_DSN:}
   environment: ${SENTRY_ENVIRONMENT:local}
-  release: ${SENTRY_RELEASE:}
+  release: ${SENTRY_RELEASE:bestduo-be@${RAILWAY_GIT_COMMIT_SHA:local}}
   send-default-pii: false
   traces-sample-rate: 0.0
   enable-tracing: false

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+  <include resource="org/springframework/boot/logging/logback/defaults.xml"/>
+
+  <springProperty scope="context" name="appName" source="spring.application.name" defaultValue="bestduo-be"/>
+
+  <!-- 기본(local/dev): 사람 읽기 쉬운 패턴, MDC 포함 -->
+  <springProfile name="!prod">
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+      <encoder>
+        <pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level [%thread] [requestId=%X{requestId:-}] %logger{36} - %msg%n</pattern>
+        <charset>UTF-8</charset>
+      </encoder>
+    </appender>
+
+    <root level="INFO">
+      <appender-ref ref="CONSOLE"/>
+    </root>
+  </springProfile>
+
+  <!-- prod: JSON 구조화 로그 (Logstash encoder), MDC를 최상위 필드로 노출 -->
+  <springProfile name="prod">
+    <appender name="JSON_CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+      <encoder class="net.logstash.logback.encoder.LogstashEncoder">
+        <includeMdcKeyName>requestId</includeMdcKeyName>
+        <customFields>{"app":"${appName}"}</customFields>
+        <timeZone>UTC</timeZone>
+      </encoder>
+    </appender>
+
+    <root level="INFO">
+      <appender-ref ref="JSON_CONSOLE"/>
+    </root>
+  </springProfile>
+
+</configuration>

--- a/src/test/java/com/bestduo_BE/common/infra/riot/RiotApiMetricsTest.java
+++ b/src/test/java/com/bestduo_BE/common/infra/riot/RiotApiMetricsTest.java
@@ -1,0 +1,54 @@
+package com.bestduo_BE.common.infra.riot;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import io.micrometer.core.instrument.Timer;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class RiotApiMetricsTest {
+
+  @Test
+  @DisplayName("success supplier 호출 시 riot.api.request{outcome=success} timer가 1회 기록된다")
+  void record_successSupplier_incrementsSuccessTimer() {
+    SimpleMeterRegistry registry = new SimpleMeterRegistry();
+    RiotApiMetrics metrics = new RiotApiMetrics(registry);
+
+    String result = metrics.record("loadMatch", () -> "ok");
+
+    assertThat(result).isEqualTo("ok");
+    Timer timer = registry.timer("riot.api.request", "endpoint", "loadMatch", "outcome", "success");
+    assertThat(timer.count()).isEqualTo(1L);
+  }
+
+  @Test
+  @DisplayName("예외 발생 시 riot.api.request{outcome=error} timer가 기록되고 예외가 전파된다")
+  void record_exceptionPropagated_incrementsErrorTimer() {
+    SimpleMeterRegistry registry = new SimpleMeterRegistry();
+    RiotApiMetrics metrics = new RiotApiMetrics(registry);
+
+    assertThatThrownBy(() -> metrics.record("loadMatch", () -> {
+      throw new RuntimeException("boom");
+    })).isInstanceOf(RuntimeException.class);
+
+    Timer timer = registry.timer("riot.api.request", "endpoint", "loadMatch", "outcome", "error");
+    assertThat(timer.count()).isEqualTo(1L);
+  }
+
+  @Test
+  @DisplayName("endpoint 태그 값이 다르면 독립된 timer로 기록된다")
+  void record_differentEndpoints_produceDistinctTimers() {
+    SimpleMeterRegistry registry = new SimpleMeterRegistry();
+    RiotApiMetrics metrics = new RiotApiMetrics(registry);
+
+    metrics.record("loadMatch", () -> "a");
+    metrics.record("findRecentMatchIds", () -> "b");
+
+    assertThat(registry.timer("riot.api.request", "endpoint", "loadMatch", "outcome", "success").count())
+        .isEqualTo(1L);
+    assertThat(registry.timer("riot.api.request", "endpoint", "findRecentMatchIds", "outcome", "success").count())
+        .isEqualTo(1L);
+  }
+}

--- a/src/test/java/com/bestduo_BE/common/observability/CorrelationIdFilterTest.java
+++ b/src/test/java/com/bestduo_BE/common/observability/CorrelationIdFilterTest.java
@@ -1,0 +1,78 @@
+package com.bestduo_BE.common.observability;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import java.io.IOException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.slf4j.MDC;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+class CorrelationIdFilterTest {
+
+  private final CorrelationIdFilter filter = new CorrelationIdFilter();
+
+  @Test
+  @DisplayName("헤더가 없으면 UUID를 생성해 응답 헤더와 MDC에 세팅한다")
+  void whenHeaderMissing_generatesUuid() throws ServletException, IOException {
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    String[] mdcDuringChain = new String[1];
+
+    FilterChain chain = (req, res) -> mdcDuringChain[0] = MDC.get(CorrelationIdFilter.MDC_KEY);
+
+    filter.doFilter(request, response, chain);
+
+    String headerValue = response.getHeader(CorrelationIdFilter.HEADER_NAME);
+    assertThat(headerValue).isNotBlank();
+    assertThat(mdcDuringChain[0]).isEqualTo(headerValue);
+  }
+
+  @Test
+  @DisplayName("X-Request-Id 헤더가 있으면 그 값을 그대로 사용한다")
+  void whenHeaderPresent_reusesHeaderValue() throws ServletException, IOException {
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    request.addHeader(CorrelationIdFilter.HEADER_NAME, "abc-123");
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    String[] mdcDuringChain = new String[1];
+
+    FilterChain chain = (req, res) -> mdcDuringChain[0] = MDC.get(CorrelationIdFilter.MDC_KEY);
+
+    filter.doFilter(request, response, chain);
+
+    assertThat(response.getHeader(CorrelationIdFilter.HEADER_NAME)).isEqualTo("abc-123");
+    assertThat(mdcDuringChain[0]).isEqualTo("abc-123");
+  }
+
+  @Test
+  @DisplayName("요청 종료 후 MDC에서 correlationId 키가 제거된다")
+  void afterFilter_mdcIsCleared() throws ServletException, IOException {
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    FilterChain chain = (req, res) -> {};
+
+    filter.doFilter(request, response, chain);
+
+    assertThat(MDC.get(CorrelationIdFilter.MDC_KEY)).isNull();
+  }
+
+  @Test
+  @DisplayName("체인이 예외를 던져도 MDC는 정리된다")
+  void whenChainThrows_mdcStillCleared() {
+    MockHttpServletRequest request = new MockHttpServletRequest();
+    MockHttpServletResponse response = new MockHttpServletResponse();
+    FilterChain chain = (req, res) -> {
+      throw new ServletException("boom");
+    };
+
+    try {
+      filter.doFilter(request, response, chain);
+    } catch (Exception ignored) {
+    }
+
+    assertThat(MDC.get(CorrelationIdFilter.MDC_KEY)).isNull();
+  }
+}

--- a/src/test/java/com/bestduo_BE/pipeline/application/PipelineMetricsTest.java
+++ b/src/test/java/com/bestduo_BE/pipeline/application/PipelineMetricsTest.java
@@ -1,0 +1,69 @@
+package com.bestduo_BE.pipeline.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.util.concurrent.atomic.AtomicLong;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class PipelineMetricsTest {
+
+  @Test
+  @DisplayName("stage 성공 시 pipeline.stage.completed{outcome=success} counter가 증가한다")
+  void recordSuccess_incrementsSuccessCounter() {
+    SimpleMeterRegistry registry = new SimpleMeterRegistry();
+    PipelineMetrics metrics = new PipelineMetrics(registry);
+
+    metrics.recordStageCompleted(1, "success");
+    metrics.recordStageCompleted(1, "success");
+
+    double count = registry.counter("pipeline.stage.completed", "stage", "1", "outcome", "success").count();
+    assertThat(count).isEqualTo(2.0);
+  }
+
+  @Test
+  @DisplayName("stage 실패 시 pipeline.stage.completed{outcome=error} counter가 증가한다")
+  void recordError_incrementsErrorCounter() {
+    SimpleMeterRegistry registry = new SimpleMeterRegistry();
+    PipelineMetrics metrics = new PipelineMetrics(registry);
+
+    metrics.recordStageCompleted(3, "error");
+
+    double count = registry.counter("pipeline.stage.completed", "stage", "3", "outcome", "error").count();
+    assertThat(count).isEqualTo(1.0);
+  }
+
+  @Test
+  @DisplayName("stage 태그 값이 달라도 각각 독립된 counter가 된다")
+  void differentStages_produceDistinctCounters() {
+    SimpleMeterRegistry registry = new SimpleMeterRegistry();
+    PipelineMetrics metrics = new PipelineMetrics(registry);
+
+    metrics.recordStageCompleted(1, "success");
+    metrics.recordStageCompleted(2, "success");
+
+    assertThat(registry.counter("pipeline.stage.completed", "stage", "1", "outcome", "success").count())
+        .isEqualTo(1.0);
+    assertThat(registry.counter("pipeline.stage.completed", "stage", "2", "outcome", "success").count())
+        .isEqualTo(1.0);
+  }
+
+  @Test
+  @DisplayName("registerMatchQueueGauge는 pipeline.match_queue.size 게이지를 현재 supplier 값으로 노출한다")
+  void registerMatchQueueGauge_reflectsCurrentSupplierValue() {
+    SimpleMeterRegistry registry = new SimpleMeterRegistry();
+    PipelineMetrics metrics = new PipelineMetrics(registry);
+    AtomicLong size = new AtomicLong(42L);
+
+    metrics.registerMatchQueueGauge(size::get);
+
+    Gauge gauge = registry.find("pipeline.match_queue.size").gauge();
+    assertThat(gauge).isNotNull();
+    assertThat(gauge.value()).isEqualTo(42.0);
+
+    size.set(7L);
+    assertThat(gauge.value()).isEqualTo(7.0);
+  }
+}

--- a/src/test/java/com/bestduo_BE/pipeline/application/PipelineRunnerTest.java
+++ b/src/test/java/com/bestduo_BE/pipeline/application/PipelineRunnerTest.java
@@ -14,6 +14,7 @@ import com.bestduo_BE.common.domain.model.Tier;
 import com.bestduo_BE.common.infra.riot.exception.RiotRateLimitedException;
 import com.bestduo_BE.config.PipelineProperties;
 import com.bestduo_BE.ingest.application.MatchIngestRunner;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -38,8 +39,9 @@ class PipelineRunnerTest {
     props = new PipelineProperties();
     props.setIngestBatchSize(10);
     props.setPollingIntervalMs(100);
+    PipelineMetrics pipelineMetrics = new PipelineMetrics(new SimpleMeterRegistry());
     runner = new PipelineRunner(dailyLeagueEntriesRunner, collectMatchIdsRunner, matchIngestRunner,
-        patchVersionService, props);
+        patchVersionService, props, pipelineMetrics);
   }
 
   @Test


### PR DESCRIPTION
## Summary

운영 준비도 Phase 2 — 관측성(observability) 기반 구축. 구조화 로깅·커스텀 메트릭·Sentry 통합·운영 외부 서비스 가이드를 묶어서 도입.

- **PR-5 (`285822f`)**: 구조화 로깅(JSON + MDC `correlationId`) + 커스텀 메트릭(Pipeline counter/gauge, Riot API timer) — TDD 진행
- **PR-6 (`93caa84`)**: Sentry Spring Boot starter 통합, prod 프로파일 분리, `RiotRateLimitedException` 노이즈 필터
- **PR-7 (`1e373c5`)**: `docs/operations_external_services.md` 신설 + 운영 준비 문서 일괄 정리

## Changes

### PR-5 — 구조화 로깅 + 메트릭
- `CorrelationIdFilter` — 요청별 `X-Correlation-Id` 헤더 ↔ MDC 동기화
- `PipelineMetrics` — `pipeline.stage.completed` (Counter, tags: stage/outcome) + `pipeline.match_queue.size` (Gauge)
- `RiotApiMetrics` — `riot.api.request` (Timer, tags: endpoint/outcome)
- `logback-spring.xml` — `<springProfile>` 기반 로컬 콘솔 / prod JSON 출력 분기
- 단위 테스트 4종 (필터/Pipeline/Riot/Runner) — 한글 `@DisplayName` 적용

### PR-6 — Sentry
- `build.gradle`: `sentry-spring-boot-starter-jakarta:8.16.0` + `sentry-logback:8.16.0`
- `application.yml`: DSN 미설정 시 no-op 동작, traces sample 0%, `RiotRateLimitedException` 무시
- `application-prod.yml`: prod 환경 분리, traces 5% 샘플링

### PR-7 — 운영 가이드
- `docs/operations_external_services.md` (신규):
  - Sentry / Grafana Cloud / Discord Webhook / UptimeRobot 단계별 설정
  - PromQL 4-row 대시보드 + 5종 Alerting 룰 정의
  - Secret 10종 관리표 + 회전/사고 대응 절차
- `docs/operations_env_config.md`, `docs/operations_readiness_plan.md`, `docs/decisions/observability_tradeoffs.md` 동시 커밋 (cross-link 보존)

## Test Plan

- [x] `./gradlew test` 전체 통과 (PR-5 신규 테스트 포함)
- [x] PR-5 단위 테스트 RED→GREEN→REFACTOR 사이클 검증
- [x] `./gradlew bootRun`으로 Sentry DSN 미설정 시 정상 부팅 확인 (no-op)
- [ ] (운영 활성화 후) Sentry DSN 등록 → 의도적 예외 발생 시 이벤트 수신 확인
- [ ] (운영 활성화 후) Grafana Cloud Agent remote_write → Prometheus 메트릭 수신 확인
- [ ] (운영 활성화 후) UptimeRobot Down 상태 시 Discord 알림 확인

## Out of Scope

- README.md 수정사항은 별도 PR로 분리 (본 PR 미포함)
- 외부 서비스(Sentry/Grafana/Discord/UptimeRobot) 실제 계정 생성 및 연동은 머지 후 운영 단계에서 수행 — 절차는 `docs/operations_external_services.md` 참조