### PR TITLE
feat: Flyway 도입 + prod ddl-auto validate 전환 (Phase 1.3)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,6 +38,8 @@ dependencies {
 	implementation 'net.logstash.logback:logstash-logback-encoder:8.0'
 	implementation 'io.sentry:sentry-spring-boot-starter-jakarta:8.16.0'
 	implementation 'io.sentry:sentry-logback:8.16.0'
+	implementation 'org.flywaydb:flyway-core'
+	runtimeOnly 'org.flywaydb:flyway-database-postgresql'
 	compileOnly 'org.projectlombok:lombok'
 //	developmentOnly 'org.springframework.boot:spring-boot-docker-compose'
 	runtimeOnly 'org.postgresql:postgresql'

--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ dependencies {
 	implementation 'net.logstash.logback:logstash-logback-encoder:8.0'
 	implementation 'io.sentry:sentry-spring-boot-starter-jakarta:8.16.0'
 	implementation 'io.sentry:sentry-logback:8.16.0'
-	implementation 'org.flywaydb:flyway-core'
+	implementation 'org.springframework.boot:spring-boot-starter-flyway'
 	runtimeOnly 'org.flywaydb:flyway-database-postgresql'
 	compileOnly 'org.projectlombok:lombok'
 //	developmentOnly 'org.springframework.boot:spring-boot-docker-compose'

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -18,7 +18,7 @@ spring:
 #      hibernate.order_inserts: true
 #      hibernate.order_updates: true
     hibernate:
-      ddl-auto: update
+      ddl-auto: validate
 
 logging:
   level:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -21,6 +21,12 @@ spring:
     hibernate:
       ddl-auto: update
 
+  flyway:
+    enabled: true
+    baseline-on-migrate: true
+    baseline-version: 1
+    locations: classpath:db/migration
+
 logging:
   level:
     org.hibernate.SQL: DEBUG

--- a/src/main/resources/db/migration/V1__baseline.sql
+++ b/src/main/resources/db/migration/V1__baseline.sql
@@ -1,0 +1,4 @@
+-- V1 baseline marker
+-- 실제 스키마는 기존 프로덕션 DB가 이미 보유하고 있으며(ddl-auto: update 로 생성된 상태),
+-- spring.flyway.baseline-on-migrate=true 설정에 의해 Flyway 가 이 버전을 baseline 으로 기록하고 건너뜁니다.
+-- 이후 모든 스키마 변경은 V2 부터 Flyway 마이그레이션으로만 관리합니다.

--- a/src/main/resources/db/migration/V2__drop_and_recreate_summoner_and_match_queue.sql
+++ b/src/main/resources/db/migration/V2__drop_and_recreate_summoner_and_match_queue.sql
@@ -1,0 +1,47 @@
+-- V2: summoner, match_queue 두 테이블을 drop 후 재생성한다.
+--
+-- 배경:
+--   운영 DB 의 summoner / match_queue 데이터를 초기화하면서, 동시에 Flyway 로
+--   스키마를 명시적으로 기술한 첫 마이그레이션을 남기기 위한 스크립트.
+--   V1 은 비어있는 baseline marker 였고, 이 파일부터 실제 스키마가 코드로 관리된다.
+--
+-- 대상 환경:
+--   - 운영(Railway): V1 baseline 이후 이 스크립트가 실행되어 두 테이블을 재생성한다.
+--   - 새 환경(fresh DB): DROP IF EXISTS 덕분에 안전하게 CREATE 까지 이어진다.
+--   - 테스트(H2): spring.flyway.enabled=false 이므로 이 파일은 실행되지 않는다.
+--
+-- 컬럼 타입은 Hibernate 6.x PostgreSQL Dialect 의 기본 매핑을 따른다.
+--   String             -> varchar(255)
+--   Long               -> bigint
+--   int                -> integer
+--   OffsetDateTime     -> timestamp(6) with time zone
+--   @Enumerated(STRING)-> varchar(255)
+
+DROP TABLE IF EXISTS summoner;
+DROP TABLE IF EXISTS match_queue;
+
+CREATE TABLE summoner (
+    puuid                   varchar(255)                    NOT NULL,
+    last_match_start_time   bigint,
+    last_known_tier         varchar(255),
+    tier_observed_at        timestamp(6) with time zone,
+    seeded_at               timestamp(6) with time zone,
+    match_ids_collected_at  timestamp(6) with time zone,
+    created_at              timestamp(6) with time zone     NOT NULL,
+    updated_at              timestamp(6) with time zone     NOT NULL,
+    PRIMARY KEY (puuid)
+);
+
+CREATE TABLE match_queue (
+    match_id         varchar(255)                 NOT NULL,
+    status           varchar(255)                 NOT NULL,
+    priority         integer                      NOT NULL,
+    collection_tier  varchar(255)                 NOT NULL,
+    patch            varchar(255),
+    retry_count      integer                      NOT NULL,
+    last_error       varchar(255),
+    locked_at        timestamp(6) with time zone,
+    created_at       timestamp(6) with time zone  NOT NULL,
+    updated_at       timestamp(6) with time zone  NOT NULL,
+    PRIMARY KEY (match_id)
+);

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -8,6 +8,8 @@ spring:
     hibernate:
       ddl-auto: create-drop
     show-sql: false
+  flyway:
+    enabled: false
 
 external:
   riot:


### PR DESCRIPTION
## Summary
- `spring-boot-starter-flyway` + `flyway-database-postgresql` 도입 (Spring Boot 4.0 호환)
- `V1__baseline.sql` 추가 — 기존 prod 스키마 baseline 확보 (`baseline-on-migrate: true`)
- `V2__drop_and_recreate_summoner_and_match_queue.sql` — summoner / match_queue 재생성
- prod에서 `spring.jpa.hibernate.ddl-auto: update` → `validate` 전환으로 런타임 스키마 변경 차단

## Why
- `ddl-auto: update`는 prod에서 데이터 손실 위험이 있어 Phase 1(안전성) 블로커로 식별됨
- Flyway로 스키마 변경 이력을 코드로 관리해 재현 가능한 배포를 보장

## Test plan
- [x] `./gradlew test --rerun-tasks` 전체 그린
- [ ] Railway 배포 후 `/actuator/health` 정상
- [ ] 부팅 로그에서 Flyway `baseline → migrate` 수행 확인
- [ ] `flyway_schema_history` 테이블 생성 및 V1/V2 기록 확인

## 관련 문서
- `docs/operations_readiness_plan.md` Phase 1.3