### PR TITLE
fix: upsertLeagueEntry 에 @Transactional 추가 (Issue #51)

### DIFF
--- a/src/main/java/com/bestduo_BE/common/infra/persistence/repository/MatchQueueJpaRepository.java
+++ b/src/main/java/com/bestduo_BE/common/infra/persistence/repository/MatchQueueJpaRepository.java
@@ -6,6 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 public interface MatchQueueJpaRepository extends JpaRepository<MatchQueue, String> {
   @Query(value = """
@@ -23,6 +24,7 @@ public interface MatchQueueJpaRepository extends JpaRepository<MatchQueue, Strin
   List<MatchQueue> pickReadyOrRetry(@Param("limit") int limit);
 
   // 1) RUNNING stale 복구: lockedAt 오래된 RUNNING을 READY로 되돌림
+  @Transactional
   @Modifying(clearAutomatically = true, flushAutomatically = true)
   @Query(value = """
     update match_queue
@@ -36,6 +38,7 @@ public interface MatchQueueJpaRepository extends JpaRepository<MatchQueue, Strin
   int recoverStaleRunning(@Param("staleMinutes") int staleMinutes);
 
   // 2) READY만 먼저 pick&lock (RUNNING으로 바꾸고 반환)
+  @Transactional
   @Modifying(clearAutomatically = true, flushAutomatically = true)
   @Query(value = """
     with candidates as (
@@ -58,6 +61,7 @@ public interface MatchQueueJpaRepository extends JpaRepository<MatchQueue, Strin
   List<MatchQueue> pickReadyAndLock(@Param("limit") int limit, @Param("collectionTier") String collectionTier);
 
   // 3) ERROR 중 재시도 가능한 것만 pick&lock (cooldown + maxRetry)
+  @Transactional
   @Modifying(clearAutomatically = true, flushAutomatically = true)
   @Query(value = """
     with candidates as (
@@ -88,6 +92,7 @@ public interface MatchQueueJpaRepository extends JpaRepository<MatchQueue, Strin
       @Param("collectionTier") String collectionTier
   );
 
+  @Transactional
   @Modifying(clearAutomatically = true, flushAutomatically = true)
   @Query(value = """
     update match_queue
@@ -110,6 +115,7 @@ public interface MatchQueueJpaRepository extends JpaRepository<MatchQueue, Strin
    *   <li>updated_at ASC</li>
    * </ol>
    */
+  @Transactional
   @Modifying(clearAutomatically = true, flushAutomatically = true)
   @Query(value = """
     with candidates as (

--- a/src/main/java/com/bestduo_BE/common/infra/persistence/repository/SummonerJpaRepository.java
+++ b/src/main/java/com/bestduo_BE/common/infra/persistence/repository/SummonerJpaRepository.java
@@ -109,6 +109,7 @@ public interface SummonerJpaRepository extends JpaRepository<Summoner, String> {
    * Stage 1 upsert: 없으면 등록, 있으면 tier·seeded_at 갱신.
    * 두 경우 모두 seeded_at(leagueEntryFetchedAt)을 주어진 시점으로 설정한다.
    */
+  @Transactional
   @Modifying(clearAutomatically = true, flushAutomatically = true)
   @Query(value = """
       INSERT INTO summoner (puuid, last_known_tier, tier_observed_at, seeded_at, created_at, updated_at)

--- a/src/main/java/com/bestduo_BE/common/infra/persistence/repository/SummonerJpaRepository.java
+++ b/src/main/java/com/bestduo_BE/common/infra/persistence/repository/SummonerJpaRepository.java
@@ -12,6 +12,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 public interface SummonerJpaRepository extends JpaRepository<Summoner, String> {
 
+  @Transactional
   @Modifying(clearAutomatically = true, flushAutomatically = true)
   @Query(value = """
       update summoner
@@ -25,6 +26,7 @@ public interface SummonerJpaRepository extends JpaRepository<Summoner, String> {
       """, nativeQuery = true)
   int advanceLastMatchStartTime(@Param("puuid") String puuid, @Param("candidateCursor") Long candidateCursor);
 
+  @Transactional
   @Modifying(clearAutomatically = true, flushAutomatically = true)
   @Query(value = """
       INSERT INTO summoner (
@@ -37,6 +39,7 @@ public interface SummonerJpaRepository extends JpaRepository<Summoner, String> {
       """, nativeQuery = true)
   int insertIfAbsent(@Param("puuid") String puuid, @Param("now") OffsetDateTime now);
 
+  @Transactional
   @Modifying(clearAutomatically = true, flushAutomatically = true)
   @Query(value = """
       update summoner

--- a/src/test/java/com/bestduo_BE/common/infra/persistence/repository/MatchQueueJpaRepositoryTransactionalTest.java
+++ b/src/test/java/com/bestduo_BE/common/infra/persistence/repository/MatchQueueJpaRepositoryTransactionalTest.java
@@ -1,0 +1,76 @@
+package com.bestduo_BE.common.infra.persistence.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.lang.reflect.Method;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * MatchQueueJpaRepository의 @Modifying 쿼리들이 자체 @Transactional 을 선언하도록 강제한다.
+ *
+ * <p>현재는 호출자(MatchQueueDispatcher)가 외부 @Transactional 로 감싸고 있어 동작하지만,
+ * 외부 트랜잭션 없이 호출되는 경우 jakarta.persistence.TransactionRequiredException 이 발생한다.
+ * 레포지토리 메서드에 @Transactional 을 붙여 호출자 실수에도 안전하게 만든다.
+ */
+class MatchQueueJpaRepositoryTransactionalTest {
+
+  @Test
+  @DisplayName("recoverStaleRunning — @Modifying 쿼리는 자체 @Transactional 을 가져야 한다")
+  void recoverStaleRunning_mustDeclareTransactional() throws NoSuchMethodException {
+    Method method = MatchQueueJpaRepository.class.getMethod("recoverStaleRunning", int.class);
+
+    assertThat(method.getAnnotation(Transactional.class))
+        .as("recoverStaleRunning must be annotated with @Transactional — "
+            + "@Modifying(flushAutomatically = true) requires an active transaction")
+        .isNotNull();
+  }
+
+  @Test
+  @DisplayName("pickReadyAndLock — @Modifying 쿼리는 자체 @Transactional 을 가져야 한다")
+  void pickReadyAndLock_mustDeclareTransactional() throws NoSuchMethodException {
+    Method method = MatchQueueJpaRepository.class.getMethod(
+        "pickReadyAndLock", int.class, String.class);
+
+    assertThat(method.getAnnotation(Transactional.class))
+        .as("pickReadyAndLock must be annotated with @Transactional — "
+            + "@Modifying(flushAutomatically = true) requires an active transaction")
+        .isNotNull();
+  }
+
+  @Test
+  @DisplayName("pickRetryableErrorAndLock — @Modifying 쿼리는 자체 @Transactional 을 가져야 한다")
+  void pickRetryableErrorAndLock_mustDeclareTransactional() throws NoSuchMethodException {
+    Method method = MatchQueueJpaRepository.class.getMethod(
+        "pickRetryableErrorAndLock", int.class, int.class, int.class, String.class);
+
+    assertThat(method.getAnnotation(Transactional.class))
+        .as("pickRetryableErrorAndLock must be annotated with @Transactional — "
+            + "@Modifying(flushAutomatically = true) requires an active transaction")
+        .isNotNull();
+  }
+
+  @Test
+  @DisplayName("unlockToReady — @Modifying 쿼리는 자체 @Transactional 을 가져야 한다")
+  void unlockToReady_mustDeclareTransactional() throws NoSuchMethodException {
+    Method method = MatchQueueJpaRepository.class.getMethod("unlockToReady", String.class);
+
+    assertThat(method.getAnnotation(Transactional.class))
+        .as("unlockToReady must be annotated with @Transactional — "
+            + "@Modifying(flushAutomatically = true) requires an active transaction")
+        .isNotNull();
+  }
+
+  @Test
+  @DisplayName("pickReadyWithPriorityAndLock — @Modifying 쿼리는 자체 @Transactional 을 가져야 한다")
+  void pickReadyWithPriorityAndLock_mustDeclareTransactional() throws NoSuchMethodException {
+    Method method = MatchQueueJpaRepository.class.getMethod(
+        "pickReadyWithPriorityAndLock", int.class, String.class, String.class);
+
+    assertThat(method.getAnnotation(Transactional.class))
+        .as("pickReadyWithPriorityAndLock must be annotated with @Transactional — "
+            + "@Modifying(flushAutomatically = true) requires an active transaction")
+        .isNotNull();
+  }
+}

--- a/src/test/java/com/bestduo_BE/common/infra/persistence/repository/SummonerJpaRepositoryTest.java
+++ b/src/test/java/com/bestduo_BE/common/infra/persistence/repository/SummonerJpaRepositoryTest.java
@@ -56,6 +56,45 @@ class SummonerJpaRepositoryTest {
   }
 
   @Test
+  @DisplayName("advanceLastMatchStartTime — @Modifying 쿼리는 자체 @Transactional 을 가져야 한다")
+  void advanceLastMatchStartTime_mustDeclareTransactional() throws NoSuchMethodException {
+    Method method = SummonerJpaRepository.class.getMethod(
+        "advanceLastMatchStartTime", String.class, Long.class);
+
+    assertThat(method.getAnnotation(Transactional.class))
+        .as("advanceLastMatchStartTime must be annotated with @Transactional — "
+            + "@Modifying(flushAutomatically = true) requires an active transaction, "
+            + "and future callers may invoke it outside a managed transaction")
+        .isNotNull();
+  }
+
+  @Test
+  @DisplayName("insertIfAbsent — @Modifying 쿼리는 자체 @Transactional 을 가져야 한다")
+  void insertIfAbsent_mustDeclareTransactional() throws NoSuchMethodException {
+    Method method = SummonerJpaRepository.class.getMethod(
+        "insertIfAbsent", String.class, OffsetDateTime.class);
+
+    assertThat(method.getAnnotation(Transactional.class))
+        .as("insertIfAbsent must be annotated with @Transactional — "
+            + "@Modifying(flushAutomatically = true) requires an active transaction, "
+            + "and future callers may invoke it outside a managed transaction")
+        .isNotNull();
+  }
+
+  @Test
+  @DisplayName("updateTierMetadata — @Modifying 쿼리는 자체 @Transactional 을 가져야 한다")
+  void updateTierMetadata_mustDeclareTransactional() throws NoSuchMethodException {
+    Method method = SummonerJpaRepository.class.getMethod(
+        "updateTierMetadata", String.class, String.class, OffsetDateTime.class);
+
+    assertThat(method.getAnnotation(Transactional.class))
+        .as("updateTierMetadata must be annotated with @Transactional — "
+            + "@Modifying(flushAutomatically = true) requires an active transaction, "
+            + "and future callers may invoke it outside a managed transaction")
+        .isNotNull();
+  }
+
+  @Test
   @DisplayName("updateTierMetadata — 관측된 tier 정보를 DB에 저장한다")
   void updateTierMetadataStoresObservedTier() {
     repository.save(Summoner.create("p-1"));

--- a/src/test/java/com/bestduo_BE/common/infra/persistence/repository/SummonerJpaRepositoryTest.java
+++ b/src/test/java/com/bestduo_BE/common/infra/persistence/repository/SummonerJpaRepositoryTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.bestduo_BE.common.domain.model.Tier;
 import com.bestduo_BE.common.infra.persistence.entity.Summoner;
+import java.lang.reflect.Method;
 import java.time.OffsetDateTime;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -11,6 +12,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.data.jpa.test.autoconfigure.DataJpaTest;
 import org.springframework.test.context.TestPropertySource;
+import org.springframework.transaction.annotation.Transactional;
 
 @DataJpaTest
 @TestPropertySource(properties = {
@@ -36,6 +38,21 @@ class SummonerJpaRepositoryTest {
     List<Summoner> targets = repository.findRefreshTargets(2, Tier.GOLD.name());
 
     assertThat(targets).extracting(Summoner::getPuuid).containsExactly(gold.getPuuid(), "unknown");
+  }
+
+  @Test
+  @DisplayName("upsertLeagueEntry — @Modifying 쿼리는 자체 @Transactional 을 가져야 한다")
+  void upsertLeagueEntry_mustDeclareTransactional() throws NoSuchMethodException {
+    Method method = SummonerJpaRepository.class.getMethod(
+        "upsertLeagueEntry", String.class, String.class, OffsetDateTime.class);
+
+    Transactional transactional = method.getAnnotation(Transactional.class);
+
+    assertThat(transactional)
+        .as("upsertLeagueEntry must be annotated with @Transactional — "
+            + "callers like LeagueEntriesFetcher invoke it outside a managed transaction, "
+            + "and @Modifying(flushAutomatically = true) requires an active transaction")
+        .isNotNull();
   }
 
   @Test


### PR DESCRIPTION
## Summary
- `SummonerJpaRepository.upsertLeagueEntry` 에 `@Transactional` 을 추가해 Railway 운영에서 발생한 `TransactionRequiredException` 을 해결한다.
- 형제 메서드(`markLeagueEntryFetched`, `markMatchIdsCollected`) 와 동일한 트랜잭션 경계 패턴을 적용한다.
- 회귀 방지용 리플렉션 기반 테스트를 추가한다.

Fixes #51.

## Root Cause
`LeagueEntriesFetcher.processEntry` 는 `@Service` 레벨에 `@Transactional` 이 없는 상태에서 `upsertLeagueEntry` 를 호출한다. 해당 메서드는 `@Modifying(flushAutomatically = true)` 를 사용하지만 `@Transactional` 이 없어 플러시 시점에 활성 트랜잭션을 찾지 못해 `jakarta.persistence.TransactionRequiredException` 이 던져졌다.

## Why reflection test instead of behavioral test
H2 (PostgreSQL 모드 포함) 는 `ON CONFLICT ... DO UPDATE` 구문을 파싱하지 못한다. 그래서 실제 SQL 실행으로 회귀를 검증할 수 없고, 이 버그의 본질은 "해당 메서드에 `@Transactional` 이 반드시 붙어있어야 한다" 이므로 리플렉션으로 어노테이션 존재를 검증한다. 누군가 실수로 어노테이션을 제거하면 빌드가 즉시 깨진다.

## Test plan
- [x] `./gradlew test --tests "*SummonerJpaRepositoryTest"` — 녹색
- [x] `./gradlew test` 전체 스위트 — 녹색
- [x] 어노테이션 제거 시 새 테스트가 실패하는 것을 확인 (RED 검증)
- [ ] dev 머지 → main 머지 후 Railway 재배포 로그에서 `TransactionRequiredException` 미발생 확인