### PR TITLE
chore: Grafana Alloy scrape config 추가 (Grafana Cloud remote_write)

### DIFF
--- a/infra/alloy/.dockerignore
+++ b/infra/alloy/.dockerignore
@@ -1,0 +1,3 @@
+**
+!Dockerfile
+!config.alloy

--- a/infra/alloy/Dockerfile
+++ b/infra/alloy/Dockerfile
@@ -1,0 +1,8 @@
+FROM grafana/alloy:latest
+
+COPY config.alloy /etc/alloy/config.alloy
+
+EXPOSE 12345
+
+ENTRYPOINT ["/bin/alloy"]
+CMD ["run", "--server.http.listen-addr=0.0.0.0:12345", "/etc/alloy/config.alloy"]

--- a/infra/alloy/config.alloy
+++ b/infra/alloy/config.alloy
@@ -1,0 +1,29 @@
+// Grafana Alloy config — scrapes Spring Boot /actuator/prometheus and forwards to Grafana Cloud.
+//
+// Required env vars on the Railway Alloy service:
+//   GRAFANA_CLOUD_URL    e.g. https://prometheus-prod-XX-prod-XX-XXXX.grafana.net/api/prom/push
+//   GRAFANA_CLOUD_USER   numeric instance id
+//   GRAFANA_CLOUD_TOKEN  Access Policy Token with scope: metrics:write
+//   TARGET_APP_ADDRESS   Spring Boot private-network address, e.g. bestduo-be.railway.internal:8080
+
+prometheus.scrape "bestduo_be" {
+  targets = [{
+    __address__      = sys.env("TARGET_APP_ADDRESS"),
+    __metrics_path__ = "/actuator/prometheus",
+  }]
+  forward_to      = [prometheus.remote_write.grafana_cloud.receiver]
+  job_name        = "bestduo-be"
+  scrape_interval = "30s"
+  scrape_timeout  = "10s"
+}
+
+prometheus.remote_write "grafana_cloud" {
+  endpoint {
+    url = sys.env("GRAFANA_CLOUD_URL")
+
+    basic_auth {
+      username = sys.env("GRAFANA_CLOUD_USER")
+      password = sys.env("GRAFANA_CLOUD_TOKEN")
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Railway에 별도 서비스로 배포할 **Grafana Alloy** 설정 추가
- `infra/alloy/` 경로에 Dockerfile, config.alloy, .dockerignore 3개 파일
- Spring Boot 앱의 `/actuator/prometheus` 를 30초 간격 scrape → Grafana Cloud 로 `remote_write`
- 앱 코드 변경 없음, 기존 서비스 영향 없음

## Why
[docs/operations_external_services.md §2.2 Option A](../docs/operations_external_services.md) 에 따라 Alloy 를 별도 컨테이너로 띄워 Spring Boot 앱을 변경 없이 Grafana Cloud 로 metric forwarding 한다.

## Deploy 시 Railway 설정
**새 서비스 (Alloy)**
- Source: 같은 repo, Root Directory `infra/alloy`
- Builder: **Dockerfile**
- Watch Paths: `infra/alloy/**`
- Private Networking: **On**, Public Networking: **Off**
- Env: `GRAFANA_CLOUD_URL`, `GRAFANA_CLOUD_USER`, `GRAFANA_CLOUD_TOKEN`, `TARGET_APP_ADDRESS`

**기존 Spring Boot 서비스**
- Watch Paths 좁히기: `src/**`, `build.gradle`, `settings.gradle`, `gradle/**`, `Dockerfile` → `infra/alloy/` 변경 시 재배포 방지
- Private Networking: **On** 확인

## Test plan
- [ ] Railway Alloy 서비스 Deploy 성공 로그 확인 (`Server listening on 0.0.0.0:12345`)
- [ ] Grafana Cloud Explore → `up{job="bestduo-be"}` = 1
- [ ] `jvm_memory_used_bytes` 쿼리에서 데이터 수신 확인
- [ ] `pipeline_stage_completed_total` 커스텀 메트릭 수신 확인
- [ ] 기존 Spring Boot 서비스 재배포 없이 메트릭만 수집되는지 확인