### PR TITLE
fix: CoverageBucket 일일 페이지 카운터 자정 리셋 누락 (#55)

### DIFF
--- a/src/main/java/com/bestduo_BE/pipeline/application/DailyLeagueEntriesRunner.java
+++ b/src/main/java/com/bestduo_BE/pipeline/application/DailyLeagueEntriesRunner.java
@@ -11,6 +11,7 @@ import com.bestduo_BE.coverage.infra.persistence.entity.CoverageBucket;
 import com.bestduo_BE.coverage.infra.persistence.repository.CoverageBucketJpaRepository;
 import com.bestduo_BE.leagueentry.application.LeagueEntriesFetcher;
 import com.bestduo_BE.leagueentry.application.LeagueEntriesFetcher.LeagueEntriesFetchResult;
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
@@ -88,8 +89,10 @@ public class DailyLeagueEntriesRunner {
       log.warn("non-apex seed 스킵: 현재 패치 정보 없음");
       return ChunkResult.noWork();
     }
+    LocalDate today = LocalDate.now();
     for (Tier tier : NON_APEX_TIERS) {
       CoverageBucket bucket = getOrCreateBucket(effectivePatch, tier);
+      bucket.resetDailyPagesIfNeeded(bucket.getDailyPagesResetAt(), today);
       if (bucket.hasRemainingDailyQuota(props.getDiaEmeDailyPageQuota())) {
         return runNonApexPage(bucket, tier);
       }
@@ -116,9 +119,16 @@ public class DailyLeagueEntriesRunner {
     if (effectivePatch == null) {
       return false;
     }
+    LocalDate today = LocalDate.now();
     for (Tier tier : NON_APEX_TIERS) {
       Optional<CoverageBucket> opt = coverageBucketRepository.findByPatchAndTier(effectivePatch, tier);
-      if (opt.isEmpty() || opt.get().hasRemainingDailyQuota(props.getDiaEmeDailyPageQuota())) {
+      if (opt.isEmpty()) {
+        return true;
+      }
+      CoverageBucket bucket = opt.get();
+      // 자정 경계 확인은 in-memory 에서만 수행 (영속화는 runNextChunk → runNonApexPage 의 save 가 담당)
+      bucket.resetDailyPagesIfNeeded(bucket.getDailyPagesResetAt(), today);
+      if (bucket.hasRemainingDailyQuota(props.getDiaEmeDailyPageQuota())) {
         return true;
       }
     }

--- a/src/test/java/com/bestduo_BE/pipeline/application/DailyLeagueEntriesRunnerTest.java
+++ b/src/test/java/com/bestduo_BE/pipeline/application/DailyLeagueEntriesRunnerTest.java
@@ -346,15 +346,73 @@ class DailyLeagueEntriesRunnerTest {
     assertThat(runner.hasWorkToday()).isFalse();
   }
 
+  // ── Phase 2: 자정 경계 reset (회귀 방지) ──────────────────────────────
+
+  @Test
+  @DisplayName("어제 quota 소진된 DIA 버킷은 자정 후 hasWorkToday=true (resetDailyPagesIfNeeded 호출)")
+  void hasWorkToday_whenDiaBucketExhaustedYesterday_returnsTrue() {
+    given(budgetTracker.canSeed()).willReturn(true);
+
+    DailyPipelineState state = DailyPipelineState.create(LocalDate.now());
+    state.recordSeedCompletedTier(Tier.CHALLENGER);
+    state.recordSeedCompletedTier(Tier.GRANDMASTER);
+    state.recordSeedCompletedTier(Tier.MASTER);
+    given(budgetTracker.getOrCreateTodayState()).willReturn(state);
+
+    given(patchVersionService.resolveEffectivePatchContext()).willReturn(Optional.of(new EffectivePatchContext("15.23", 0L, null)));
+    given(coverageBucketRepository.findByPatchAndTier("15.23", Tier.DIAMOND))
+        .willReturn(Optional.of(bucketExhaustedOn(Tier.DIAMOND, "15.23", LocalDate.now().minusDays(1))));
+
+    assertThat(runner.hasWorkToday()).isTrue();
+  }
+
+  @Test
+  @DisplayName("어제 quota 소진된 DIA 버킷은 runNextChunk에서 reset 후 새 페이지를 실행한다")
+  void runNextChunk_whenDiaBucketExhaustedYesterday_resetsAndRunsPage() {
+    given(budgetTracker.canSeed()).willReturn(true);
+
+    DailyPipelineState state = DailyPipelineState.create(LocalDate.now());
+    state.recordSeedCompletedTier(Tier.CHALLENGER);
+    state.recordSeedCompletedTier(Tier.GRANDMASTER);
+    state.recordSeedCompletedTier(Tier.MASTER);
+    given(budgetTracker.getOrCreateTodayState()).willReturn(state);
+
+    given(patchVersionService.resolveEffectivePatchContext()).willReturn(Optional.of(new EffectivePatchContext("15.23", 0L, null)));
+    CoverageBucket diaBucket = bucketExhaustedOn(Tier.DIAMOND, "15.23", LocalDate.now().minusDays(1));
+    given(coverageBucketRepository.findByPatchAndTier("15.23", Tier.DIAMOND)).willReturn(Optional.of(diaBucket));
+    given(coverageBucketRepository.save(any(CoverageBucket.class))).willReturn(diaBucket);
+    given(leagueEntriesFetcher.execute(any())).willReturn(new LeagueEntriesFetchResult(1, 10, 5));
+
+    DailyLeagueEntriesRunner.ChunkResult chunk = runner.runNextChunk();
+
+    assertThat(chunk.type()).isEqualTo(DailyLeagueEntriesRunner.ChunkResult.Type.NON_APEX_PAGE);
+    assertThat(chunk.tier()).isEqualTo(Tier.DIAMOND);
+    // reset 후 1페이지 처리됨 → dailyPagesProcessed = 1
+    assertThat(diaBucket.getDailyPagesProcessed()).isEqualTo(1);
+    verify(coverageBucketRepository).save(diaBucket);
+  }
+
   // ── helpers ────────────────────────────────────────────────────────
 
   private CoverageBucket bucketNotCompleted(Tier tier, String patch) {
     return CoverageBucket.create(patch, tier);
   }
 
-  /** dailyPagesProcessed = quota(기본값 10)로 설정한 버킷 */
+  /** 지정한 날짜 기준으로 dailyPagesProcessed = quota 인 버킷. 자정 경계 시뮬레이션용. */
+  private CoverageBucket bucketExhaustedOn(Tier tier, String patch, LocalDate resetDate) {
+    CoverageBucket bucket = CoverageBucket.create(patch, tier);
+    bucket.resetDailyPagesIfNeeded(null, resetDate);
+    for (int i = 0; i < props.getDiaEmeDailyPageQuota(); i++) {
+      bucket.incrementDailyPagesProcessed();
+    }
+    return bucket;
+  }
+
+  /** dailyPagesProcessed = quota(기본값 10)로 설정한 버킷. 오늘 이미 reset 된 상태로 마킹. */
   private CoverageBucket bucketWithQuotaExhausted(Tier tier, String patch) {
     CoverageBucket bucket = CoverageBucket.create(patch, tier);
+    // dailyPagesResetAt = today 로 설정 (그래야 runner의 resetDailyPagesIfNeeded 가 재리셋하지 않음)
+    bucket.resetDailyPagesIfNeeded(null, LocalDate.now());
     for (int i = 0; i < props.getDiaEmeDailyPageQuota(); i++) {
       bucket.incrementDailyPagesProcessed();
     }


### PR DESCRIPTION
## Summary

- `DailyLeagueEntriesRunner` 가 `CoverageBucket#resetDailyPagesIfNeeded` 를 호출하지 않아 DIA/EME 의 `dailyPagesProcessed` 가 자정 경계에서 누적되던 문제 수정
- `runNextChunk` / `hasUncompletedNonApexBucket` 두 경로 모두 bucket 로드 직후 reset 호출
- 자정 경계 시뮬레이션 회귀 방지 테스트 2개 추가

## 동작

- `resetDailyPagesIfNeeded(lastResetAt, today)` 는 `lastResetAt < today` 일 때만 리셋하므로 idempotent — 같은 날 후속 호출은 no-op
- 첫 save 이후 DB 의 `dailyPagesResetAt` 이 오늘로 박히므로 루프 매 iteration 마다 reset 되지 않음
- `hasUncompletedNonApexBucket` 의 in-memory reset 은 read-only 검사용이므로 영속화하지 않음 (영속화는 `runNonApexPage` 의 save 가 담당)

Closes #55

## Test plan

- [x] `./gradlew test --tests "*DailyLeagueEntriesRunner*"` 통과
- [x] `./gradlew test --tests "*CoverageBucket*"` 통과
- [x] 전체 `./gradlew test` 통과
- [ ] 운영 배포 후 DIA/EME bucket 의 `dailyPagesProcessed` 가 자정 후 0 으로 리셋되는지 모니터링
- [ ] 운영 로그에서 `Stage1 non-apex 페이지 시작` 로그가 매일 발생하는지 확인