### PR TITLE
feat: Swagger UI에서 Admin API 인증(X-Admin-Key) 지원

### DIFF
--- a/src/main/java/com/bestduo_BE/config/SwaggerConfig.java
+++ b/src/main/java/com/bestduo_BE/config/SwaggerConfig.java
@@ -1,7 +1,10 @@
 package com.bestduo_BE.config;
 
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
 import io.swagger.v3.oas.models.servers.Server;
 import java.util.List;
 import org.springdoc.core.models.GroupedOpenApi;
@@ -11,10 +14,20 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class SwaggerConfig {
 
+    private static final String ADMIN_API_KEY_SCHEME = "AdminApiKey";
+    private static final String ADMIN_API_KEY_HEADER = "X-Admin-Key";
+
     @Bean
     public OpenAPI bestduoOpenApi() {
         return new OpenAPI()
                 .servers(List.of(new Server().url("/")))  // 상대 경로로 same-origin 유지 (프록시/HTTPS 대응)
+                .components(new Components()
+                        .addSecuritySchemes(ADMIN_API_KEY_SCHEME,
+                                new SecurityScheme()
+                                        .type(SecurityScheme.Type.APIKEY)
+                                        .in(SecurityScheme.In.HEADER)
+                                        .name(ADMIN_API_KEY_HEADER)
+                                        .description("Admin API 인증 헤더 (application.yml의 admin.api.key 값)")))
                 .info(new Info()
                         .title("BestDuo API")
                         .description("BestDuo 서비스 OpenAPI 문서")
@@ -48,6 +61,9 @@ public class SwaggerConfig {
                 .pathsToMatch(
                         "/admin/**"
                 )
+                .addOpenApiCustomizer(openApi ->
+                        openApi.addSecurityItem(
+                                new SecurityRequirement().addList(ADMIN_API_KEY_SCHEME)))
                 .build();
     }
 }


### PR DESCRIPTION
## Summary
- `SwaggerConfig` 에 `AdminApiKey` SecurityScheme(APIKEY / HEADER / `X-Admin-Key`) 추가
- `admin-api` GroupedOpenApi 에만 `SecurityRequirement` 적용 → `client-api` 에는 영향 없음
- Swagger UI 의 Authorize 버튼으로 `X-Admin-Key` 를 입력하면 `/admin/**` 엔드포인트를 직접 호출 가능

## Background
`/admin/**` 은 `AdminApiKeyInterceptor` 가 `X-Admin-Key` 헤더를 검증하지만, 기존 `SwaggerConfig` 에는 SecurityScheme 설정이 없어 Swagger UI 에서 admin 컨트롤러를 호출할 수 없었음. 운영 중 수동 점검/재실행 편의를 위해 Swagger 에서도 호출 가능하도록 스킴을 추가.

## Test plan
- [ ] 앱 기동 시 `ADMIN_API_KEY` env 주입 (없으면 `@NotBlank` 검증 실패 확인)
- [ ] `http://localhost:8080/swagger-ui/index.html` 접속 후 상단 그룹에서 **admin-api** 선택
- [ ] 우측 상단 **Authorize** 버튼에 `AdminApiKey` 입력칸이 보이는지 확인
- [ ] 키 입력 후 `/admin/**` 엔드포인트 Try it out → 요청 헤더에 `X-Admin-Key` 가 포함되어 200 응답
- [ ] 틀린 키/미입력으로 호출 시 401 응답 확인
- [ ] **client-api** 그룹에는 Authorize 요구가 붙지 않는지 확인 (잠금 아이콘 없음)