### PR TITLE
fix: pipeline_match_queue_size NaN 문제 수정 (Micrometer strongReference)

### DIFF
--- a/src/main/java/com/bestduo_BE/pipeline/application/PipelineMetrics.java
+++ b/src/main/java/com/bestduo_BE/pipeline/application/PipelineMetrics.java
@@ -23,7 +23,10 @@ public class PipelineMetrics {
   }
 
   public void registerMatchQueueGauge(Supplier<Number> sizeSupplier) {
+    // strongReference(true): Micrometer 는 기본적으로 supplier 를 weak reference 로 보유한다.
+    // MatchQueueGaugeRegistrar 에서 전달하는 인라인 람다가 GC 되면 gauge 값이 NaN 으로 떨어지는 문제를 방지한다.
     Gauge.builder(MATCH_QUEUE_SIZE, sizeSupplier, s -> s.get().doubleValue())
+        .strongReference(true)
         .register(registry);
   }
 }

--- a/src/test/java/com/bestduo_BE/pipeline/application/PipelineMetricsTest.java
+++ b/src/test/java/com/bestduo_BE/pipeline/application/PipelineMetricsTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import java.lang.ref.WeakReference;
 import java.util.concurrent.atomic.AtomicLong;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -65,5 +66,48 @@ class PipelineMetricsTest {
 
     size.set(7L);
     assertThat(gauge.value()).isEqualTo(7.0);
+  }
+
+  @Test
+  @DisplayName("registerMatchQueueGauge는 supplier 참조가 외부에 없어도 GC 후 NaN이 아닌 값을 반환한다")
+  void registerMatchQueueGauge_survivesGcWhenSupplierHasNoExternalReference() {
+    SimpleMeterRegistry registry = new SimpleMeterRegistry();
+    PipelineMetrics metrics = new PipelineMetrics(registry);
+
+    // 인라인 람다를 전달한 뒤 호출자가 참조를 유지하지 않는 상황을 재현한다.
+    // Micrometer 는 기본적으로 supplier 를 weak reference 로 보유하므로,
+    // strongReference(true) 가 없으면 GC 후 gauge 값이 NaN 으로 떨어진다.
+    registerInlineLambdaGauge(metrics);
+
+    forceGcUntilWeakReferenceCollected();
+
+    Gauge gauge = registry.find("pipeline.match_queue.size").gauge();
+    assertThat(gauge).isNotNull();
+    assertThat(gauge.value()).isNotNaN();
+    assertThat(gauge.value()).isEqualTo(123.0);
+  }
+
+  private void registerInlineLambdaGauge(PipelineMetrics metrics) {
+    // 지역 변수를 캡처해 람다가 singleton 이 되지 않도록 한다.
+    // MatchQueueGaugeRegistrar 에서 statsRepository 를 캡처하는 실제 패턴을 재현한다.
+    AtomicLong localSource = new AtomicLong(123L);
+    metrics.registerMatchQueueGauge(localSource::get);
+  }
+
+  private void forceGcUntilWeakReferenceCollected() {
+    Object canary = new Object();
+    WeakReference<Object> weakRef = new WeakReference<>(canary);
+    canary = null;
+    int attempts = 0;
+    while (weakRef.get() != null && attempts < 50) {
+      System.gc();
+      try {
+        Thread.sleep(10);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        return;
+      }
+      attempts++;
+    }
   }
 }


### PR DESCRIPTION
## Summary
- `PipelineMetrics.registerMatchQueueGauge` 에 `.strongReference(true)` 추가
- Micrometer 가 gauge supplier 를 weak reference 로 보유하는 footgun 으로 인해 `/actuator/prometheus` 에서 `pipeline_match_queue_size NaN` 이 노출되던 문제 해결
- 회귀 테스트 추가: 캡처 람다 + 강제 GC 시나리오에서 NaN 이 아닌 값을 반환하는지 검증

## Context

`MatchQueueGaugeRegistrar.register()` 가 `@PostConstruct` 에서 전달하는 람다는 `statsRepository` 를 캡처해 singleton 이 아니다. `register()` 반환 후에는 외부 강한 참조가 사라져 Micrometer 의 weak reference 가 GC 되고, gauge 값이 `NaN` 으로 보고된다.

`.strongReference(true)` 는 `PipelineMetrics` 내부 한 줄로 모든 호출자를 보호하므로 가장 작은 변경으로 문제를 해결한다.

## Test plan

- [x] `./gradlew test --tests PipelineMetricsTest` 통과 (5/5)
- [x] fix 적용 전 회귀 테스트 실패 확인 → fix 적용 후 통과 확인
- [ ] Railway 배포 후 `curl .../actuator/prometheus | grep pipeline_match_queue` 가 `0.0` 이상의 숫자 반환
- [ ] Grafana Explore 에서 `pipeline_match_queue_size` 시계열 확인
- [ ] Grafana Alerting 에서 `match-queue-surge` 룰 생성 가능 여부 확인

Closes #58