### PR TITLE
fix: Stage 3 priority 티어 큐 비었을 때 다른 티어로 순회 (#60)

### DIFF
--- a/src/main/java/com/bestduo_BE/pipeline/application/PipelineRunner.java
+++ b/src/main/java/com/bestduo_BE/pipeline/application/PipelineRunner.java
@@ -36,6 +36,7 @@ import org.springframework.stereotype.Component;
 public class PipelineRunner {
 
   private static final long RATE_LIMIT_SLEEP_MS = 60_000L;
+  private static final Tier ROUND_ROBIN_LOWEST_TIER = Tier.EMERALD;
 
   private final DailyLeagueEntriesRunner dailyLeagueEntriesRunner;
   private final CollectMatchIdsRunner collectMatchIdsRunner;
@@ -142,6 +143,7 @@ public class PipelineRunner {
   /**
    * priorityTier가 지정되지 않으면(null/ALL_TIERS) tier 필터 없이 한 번 호출한다(레거시 동작).
    * 지정되면 priority → 나머지 티어 순으로 순회하다가 picked > 0 시점에 멈춘다.
+   * 순회 범위는 CHALLENGER ~ {@link #ROUND_ROBIN_LOWEST_TIER}까지로 제한된다.
    * 모든 티어가 비면 마지막 Result(picked=0)를 반환해 호출부가 sleep으로 진입하도록 한다.
    */
   private MatchIngestRunner.Result runStage3WithTierRoundRobin(
@@ -164,12 +166,15 @@ public class PipelineRunner {
   }
 
   private static List<Tier> buildTierOrder(Tier priority) {
-    List<Tier> all = Arrays.stream(Tier.values())
+    List<Tier> allowed = Arrays.stream(Tier.values())
         .filter(t -> t != Tier.ALL_TIERS)
+        .filter(t -> t.ordinal() <= ROUND_ROBIN_LOWEST_TIER.ordinal())
         .toList();
-    List<Tier> ordered = new ArrayList<>(all.size());
-    ordered.add(priority);
-    for (Tier t : all) {
+    List<Tier> ordered = new ArrayList<>(allowed.size() + 1);
+    if (allowed.contains(priority)) {
+      ordered.add(priority);
+    }
+    for (Tier t : allowed) {
       if (t != priority) {
         ordered.add(t);
       }

--- a/src/main/java/com/bestduo_BE/pipeline/application/PipelineRunner.java
+++ b/src/main/java/com/bestduo_BE/pipeline/application/PipelineRunner.java
@@ -8,6 +8,9 @@ import com.bestduo_BE.config.PipelineProperties;
 import com.bestduo_BE.ingest.application.MatchIngestRunner;
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -123,8 +126,7 @@ public class PipelineRunner {
     log.debug("Stage 3 실행 (effectivePatch={}, priorityTier={})", effectivePatch, priorityTier);
     MatchIngestRunner.Result result;
     try {
-      result = matchIngestRunner.executeWithPriority(
-          props.getIngestBatchSize(), priorityTier, effectivePatch);
+      result = runStage3WithTierRoundRobin(priorityTier, effectivePatch);
       pipelineMetrics.recordStageCompleted(3, "success");
     } catch (RuntimeException e) {
       pipelineMetrics.recordStageCompleted(3, "error");
@@ -135,6 +137,44 @@ public class PipelineRunner {
       log.debug("match_queue 비어있음. {}ms 대기", props.getPollingIntervalMs());
       Thread.sleep(props.getPollingIntervalMs());
     }
+  }
+
+  /**
+   * priorityTier가 지정되지 않으면(null/ALL_TIERS) tier 필터 없이 한 번 호출한다(레거시 동작).
+   * 지정되면 priority → 나머지 티어 순으로 순회하다가 picked > 0 시점에 멈춘다.
+   * 모든 티어가 비면 마지막 Result(picked=0)를 반환해 호출부가 sleep으로 진입하도록 한다.
+   */
+  private MatchIngestRunner.Result runStage3WithTierRoundRobin(
+      Tier priorityTier, String effectivePatch) {
+    int batchSize = props.getIngestBatchSize();
+    if (priorityTier == null || priorityTier == Tier.ALL_TIERS) {
+      return matchIngestRunner.executeWithPriority(batchSize, null, effectivePatch);
+    }
+
+    List<Tier> order = buildTierOrder(priorityTier);
+    MatchIngestRunner.Result result = null;
+    for (Tier t : order) {
+      result = matchIngestRunner.executeWithPriority(batchSize, t, effectivePatch);
+      if (result.picked() > 0) {
+        return result;
+      }
+      log.debug("Stage 3 tier={} 비어있음, 다음 tier로 순회", t);
+    }
+    return result;
+  }
+
+  private static List<Tier> buildTierOrder(Tier priority) {
+    List<Tier> all = Arrays.stream(Tier.values())
+        .filter(t -> t != Tier.ALL_TIERS)
+        .toList();
+    List<Tier> ordered = new ArrayList<>(all.size());
+    ordered.add(priority);
+    for (Tier t : all) {
+      if (t != priority) {
+        ordered.add(t);
+      }
+    }
+    return ordered;
   }
 
   private void sleep(long ms) {

--- a/src/test/java/com/bestduo_BE/pipeline/application/PipelineRunnerTest.java
+++ b/src/test/java/com/bestduo_BE/pipeline/application/PipelineRunnerTest.java
@@ -4,8 +4,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import com.bestduo_BE.common.application.PatchVersionService;
@@ -168,6 +170,68 @@ class PipelineRunnerTest {
 
     assertThatThrownBy(() -> runner.executeTick())
         .isInstanceOf(RiotRateLimitedException.class);
+  }
+
+  @Test
+  @DisplayName("priority 티어가 비면 다음 티어로 순회하다가 잡힌 시점에 tick 종료")
+  void executeTick_whenPriorityTierEmpty_fallsBackToNextTier() throws InterruptedException {
+    props.setStage3PriorityTier(Tier.EMERALD);
+    given(dailyLeagueEntriesRunner.hasWorkToday()).willReturn(false);
+    given(collectMatchIdsRunner.hasPending()).willReturn(false);
+    given(patchVersionService.resolveEffectivePatchContext())
+        .willReturn(Optional.of(new EffectivePatchContext("15.23", 1000L, null)));
+    // EMERALD: 0건, CHALLENGER: 1건 — 그 뒤 티어는 호출되면 안 됨
+    given(matchIngestRunner.executeWithPriority(anyInt(), eq(Tier.EMERALD), any()))
+        .willReturn(ingestResult(0));
+    given(matchIngestRunner.executeWithPriority(anyInt(), eq(Tier.CHALLENGER), any()))
+        .willReturn(ingestResult(1));
+
+    runner.executeTick();
+
+    verify(matchIngestRunner).executeWithPriority(props.getIngestBatchSize(), Tier.EMERALD, "15.23");
+    verify(matchIngestRunner).executeWithPriority(props.getIngestBatchSize(), Tier.CHALLENGER, "15.23");
+    verify(matchIngestRunner, never())
+        .executeWithPriority(anyInt(), eq(Tier.GRANDMASTER), any());
+    verify(matchIngestRunner, never())
+        .executeWithPriority(anyInt(), eq(Tier.MASTER), any());
+  }
+
+  @Test
+  @DisplayName("priority 티어 지정 시 모든 티어가 비면 폴링 간격만큼 대기한다")
+  void executeTick_whenPriorityTierSetAndAllTiersEmpty_sleepsPollingInterval()
+      throws InterruptedException {
+    props.setStage3PriorityTier(Tier.EMERALD);
+    given(dailyLeagueEntriesRunner.hasWorkToday()).willReturn(false);
+    given(collectMatchIdsRunner.hasPending()).willReturn(false);
+    given(patchVersionService.resolveEffectivePatchContext()).willReturn(Optional.empty());
+    given(matchIngestRunner.executeWithPriority(anyInt(), any(), any()))
+        .willReturn(ingestResult(0));
+
+    long start = System.currentTimeMillis();
+    runner.executeTick();
+    long elapsed = System.currentTimeMillis() - start;
+
+    // 실제 티어 10종 모두 시도 후 sleep
+    verify(matchIngestRunner, times(10)).executeWithPriority(anyInt(), any(Tier.class), any());
+    assertThat(elapsed).isGreaterThanOrEqualTo(80L);
+  }
+
+  @Test
+  @DisplayName("stage3PriorityTier가 ALL_TIERS이면 단일 호출(레거시)로 null tier를 사용한다")
+  void executeTick_whenStage3PriorityTierIsAllTiers_singleCallWithNull()
+      throws InterruptedException {
+    props.setStage3PriorityTier(Tier.ALL_TIERS);
+    given(dailyLeagueEntriesRunner.hasWorkToday()).willReturn(false);
+    given(collectMatchIdsRunner.hasPending()).willReturn(false);
+    given(patchVersionService.resolveEffectivePatchContext())
+        .willReturn(Optional.of(new EffectivePatchContext("15.23", 1000L, null)));
+    given(matchIngestRunner.executeWithPriority(anyInt(), any(), any()))
+        .willReturn(ingestResult(1));
+
+    runner.executeTick();
+
+    verify(matchIngestRunner, times(1))
+        .executeWithPriority(props.getIngestBatchSize(), null, "15.23");
   }
 
   private MatchIngestRunner.Result ingestResult(int picked) {

--- a/src/test/java/com/bestduo_BE/pipeline/application/PipelineRunnerTest.java
+++ b/src/test/java/com/bestduo_BE/pipeline/application/PipelineRunnerTest.java
@@ -211,9 +211,29 @@ class PipelineRunnerTest {
     runner.executeTick();
     long elapsed = System.currentTimeMillis() - start;
 
-    // 실제 티어 10종 모두 시도 후 sleep
-    verify(matchIngestRunner, times(10)).executeWithPriority(anyInt(), any(Tier.class), any());
+    // CHALLENGER ~ EMERALD까지 5개 티어 시도 후 sleep
+    verify(matchIngestRunner, times(5)).executeWithPriority(anyInt(), any(Tier.class), any());
     assertThat(elapsed).isGreaterThanOrEqualTo(80L);
+  }
+
+  @Test
+  @DisplayName("PLATINUM 이하 티어는 round-robin 순회에서 제외된다")
+  void executeTick_whenPriorityTierSetAndAllTiersEmpty_skipsPlatinumAndBelow()
+      throws InterruptedException {
+    props.setStage3PriorityTier(Tier.EMERALD);
+    given(dailyLeagueEntriesRunner.hasWorkToday()).willReturn(false);
+    given(collectMatchIdsRunner.hasPending()).willReturn(false);
+    given(patchVersionService.resolveEffectivePatchContext()).willReturn(Optional.empty());
+    given(matchIngestRunner.executeWithPriority(anyInt(), any(), any()))
+        .willReturn(ingestResult(0));
+
+    runner.executeTick();
+
+    verify(matchIngestRunner, never()).executeWithPriority(anyInt(), eq(Tier.PLATINUM), any());
+    verify(matchIngestRunner, never()).executeWithPriority(anyInt(), eq(Tier.GOLD), any());
+    verify(matchIngestRunner, never()).executeWithPriority(anyInt(), eq(Tier.SILVER), any());
+    verify(matchIngestRunner, never()).executeWithPriority(anyInt(), eq(Tier.BRONZE), any());
+    verify(matchIngestRunner, never()).executeWithPriority(anyInt(), eq(Tier.IRON), any());
   }
 
   @Test


### PR DESCRIPTION
## Summary
- Stage 3에서 `stage3PriorityTier`가 특정 티어로 설정된 경우, 해당 티어의 `match_queue`가 비면 다른 티어로 자동 순회하도록 수정
- priority → 나머지 티어 순으로 round-robin 하다가 `picked > 0` 시점에 즉시 종료
- 모든 티어가 비어있으면 기존처럼 `pollingIntervalMs` 동안 sleep
- `priorityTier == null || ALL_TIERS`인 경우는 단일 호출(null 필터)로 레거시 동작 유지

## Test plan
- [x] `executeTick_whenPriorityTierEmpty_fallsBackToNextTier` — EMERALD 비어있을 때 CHALLENGER 순회 확인
- [x] `executeTick_whenPriorityTierSetAndAllTiersEmpty_sleepsPollingInterval` — 모든 티어 시도 후 sleep 진입 확인
- [x] `executeTick_whenStage3PriorityTierIsAllTiers_singleCallWithNull` — 레거시 단일 호출 동작 보존 확인
- [x] 기존 PipelineRunnerTest 12개 테스트 모두 통과

Closes #60