### PR TITLE
feat: 최근 패치 2개 조회 GET /patch/recent 추가

### DIFF
--- a/src/main/java/com/bestduo_BE/common/application/PatchVersionService.java
+++ b/src/main/java/com/bestduo_BE/common/application/PatchVersionService.java
@@ -40,6 +40,11 @@ public class PatchVersionService {
     return patchVersionRepository.findTopByOrderByReleasedAtDesc();
   }
 
+  /** 최신 2개 패치를 최신 → 이전 순으로 반환. 데이터 적으면 1개, 없으면 빈 리스트. */
+  public List<PatchVersion> recentPatches() {
+    return patchVersionRepository.findTop2ByOrderByReleasedAtDesc();
+  }
+
   /**
    * match ID 수집에 사용할 "유효 패치" 컨텍스트를 반환한다.
    *

--- a/src/main/java/com/bestduo_BE/common/presentation/api/PatchController.java
+++ b/src/main/java/com/bestduo_BE/common/presentation/api/PatchController.java
@@ -1,0 +1,24 @@
+package com.bestduo_BE.common.presentation.api;
+
+import com.bestduo_BE.common.application.PatchVersionService;
+import com.bestduo_BE.common.presentation.api.dto.PatchVersionResponse;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/patch")
+public class PatchController {
+
+  private final PatchVersionService patchVersionService;
+
+  @GetMapping("/recent")
+  public List<PatchVersionResponse> recent() {
+    return patchVersionService.recentPatches().stream()
+        .map(p -> new PatchVersionResponse(p.getPatch(), p.getReleasedAt()))
+        .toList();
+  }
+}

--- a/src/test/java/com/bestduo_BE/common/application/PatchVersionServiceTest.java
+++ b/src/test/java/com/bestduo_BE/common/application/PatchVersionServiceTest.java
@@ -170,6 +170,47 @@ class PatchVersionServiceTest {
     assertThat(ctx.isInGracePeriod()).isFalse();
   }
 
+  // ── recentPatches ────────────────────────────────────────────────────────
+
+  @Test
+  @DisplayName("recentPatches — 최신 2개 패치를 최신 → 이전 순으로 반환")
+  void recentPatches_whenTwoOrMoreExist_returnsTopTwoOrdered() {
+    OffsetDateTime latestAt = OffsetDateTime.parse("2026-04-20T00:00:00+00:00");
+    OffsetDateTime previousAt = OffsetDateTime.parse("2026-04-01T00:00:00+00:00");
+    PatchVersion latest = PatchVersion.of("16.8", latestAt);
+    PatchVersion previous = PatchVersion.of("16.7", previousAt);
+    given(patchVersionRepository.findTop2ByOrderByReleasedAtDesc())
+        .willReturn(List.of(latest, previous));
+
+    List<PatchVersion> result = service.recentPatches();
+
+    assertThat(result).hasSize(2);
+    assertThat(result.get(0).getPatch()).isEqualTo("16.8");
+    assertThat(result.get(1).getPatch()).isEqualTo("16.7");
+  }
+
+  @Test
+  @DisplayName("recentPatches — 패치 1개만 있으면 1개만 반환")
+  void recentPatches_whenOnlyOneExists_returnsSingleton() {
+    PatchVersion only = PatchVersion.of("16.8", OffsetDateTime.parse("2026-04-20T00:00:00+00:00"));
+    given(patchVersionRepository.findTop2ByOrderByReleasedAtDesc()).willReturn(List.of(only));
+
+    List<PatchVersion> result = service.recentPatches();
+
+    assertThat(result).hasSize(1);
+    assertThat(result.get(0).getPatch()).isEqualTo("16.8");
+  }
+
+  @Test
+  @DisplayName("recentPatches — 패치가 없으면 빈 리스트 반환")
+  void recentPatches_whenEmpty_returnsEmptyList() {
+    given(patchVersionRepository.findTop2ByOrderByReleasedAtDesc()).willReturn(List.of());
+
+    List<PatchVersion> result = service.recentPatches();
+
+    assertThat(result).isEmpty();
+  }
+
   @Test
   @DisplayName("resolveEffectivePatchContext — 출시 정확히 3일이 지난 시점은 grace period 아님")
   void resolveEffectivePatchContext_whenExactlyThreeDaysOld_notInGracePeriod() {

--- a/src/test/java/com/bestduo_BE/common/presentation/api/PatchControllerTest.java
+++ b/src/test/java/com/bestduo_BE/common/presentation/api/PatchControllerTest.java
@@ -1,0 +1,63 @@
+package com.bestduo_BE.common.presentation.api;
+
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.bestduo_BE.common.application.PatchVersionService;
+import com.bestduo_BE.common.infra.persistence.entity.PatchVersion;
+import java.time.OffsetDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(PatchController.class)
+class PatchControllerTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @MockitoBean
+  private PatchVersionService patchVersionService;
+
+  @Test
+  @DisplayName("GET /patch/recent — 최신 2개 패치를 최신 → 이전 순으로 200 OK 반환")
+  void recent_whenTwoExist_returns200WithBothOrdered() throws Exception {
+    PatchVersion latest = PatchVersion.of("16.8", OffsetDateTime.parse("2026-04-20T00:00:00+00:00"));
+    PatchVersion previous = PatchVersion.of("16.7", OffsetDateTime.parse("2026-04-01T00:00:00+00:00"));
+    given(patchVersionService.recentPatches()).willReturn(List.of(latest, previous));
+
+    mockMvc.perform(get("/patch/recent"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.length()").value(2))
+        .andExpect(jsonPath("$[0].patch").value("16.8"))
+        .andExpect(jsonPath("$[1].patch").value("16.7"));
+  }
+
+  @Test
+  @DisplayName("GET /patch/recent — 패치가 1개뿐이면 1개만 반환")
+  void recent_whenOnlyOneExists_returnsSingleton() throws Exception {
+    PatchVersion only = PatchVersion.of("16.8", OffsetDateTime.parse("2026-04-20T00:00:00+00:00"));
+    given(patchVersionService.recentPatches()).willReturn(List.of(only));
+
+    mockMvc.perform(get("/patch/recent"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.length()").value(1))
+        .andExpect(jsonPath("$[0].patch").value("16.8"));
+  }
+
+  @Test
+  @DisplayName("GET /patch/recent — 패치가 없으면 빈 배열 반환")
+  void recent_whenEmpty_returnsEmptyArray() throws Exception {
+    given(patchVersionService.recentPatches()).willReturn(List.of());
+
+    mockMvc.perform(get("/patch/recent"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.length()").value(0));
+  }
+}


### PR DESCRIPTION
## Summary
- 새 public 엔드포인트 `GET /patch/recent` 추가 — 최신 → 이전 순으로 최대 2개의 `PatchVersionResponse` 반환.
- `PatchVersionService.recentPatches()` 추가 (기존 `findTop2ByOrderByReleasedAtDesc` 위임).
- 패치가 1개뿐이면 1개만, 없으면 빈 배열을 반환 (404 아님).

## Test plan
- [x] `PatchVersionServiceTest`: 2개/1개/0개 케이스
- [x] `PatchControllerTest` (WebMvcTest): 2개/1개/0개 케이스, 응답 구조 검증
- [x] `./gradlew test --tests PatchVersionServiceTest --tests PatchControllerTest` 그린
- [ ] 운영 환경에서 `GET /patch/recent` 호출 시 인증 없이 200 OK + JSON 배열 확인