### PR TITLE
docs(swagger): /patch/recent을 Client API 그룹에 노출

### DIFF
--- a/src/main/java/com/bestduo_BE/common/presentation/api/PatchController.java
+++ b/src/main/java/com/bestduo_BE/common/presentation/api/PatchController.java
@@ -2,12 +2,15 @@ package com.bestduo_BE.common.presentation.api;
 
 import com.bestduo_BE.common.application.PatchVersionService;
 import com.bestduo_BE.common.presentation.api.dto.PatchVersionResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+@Tag(name = "패치 정보", description = "패치 버전 관련 공개 조회 API입니다.")
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/patch")
@@ -15,6 +18,10 @@ public class PatchController {
 
   private final PatchVersionService patchVersionService;
 
+  @Operation(
+      summary = "최근 패치 2개 조회",
+      description = "최신 → 이전 순으로 최대 2개의 패치를 반환합니다. 1개만 등록되어 있으면 1개만, 없으면 빈 배열을 반환합니다."
+  )
   @GetMapping("/recent")
   public List<PatchVersionResponse> recent() {
     return patchVersionService.recentPatches().stream()

--- a/src/main/java/com/bestduo_BE/config/SwaggerConfig.java
+++ b/src/main/java/com/bestduo_BE/config/SwaggerConfig.java
@@ -44,7 +44,8 @@ public class SwaggerConfig {
                 .group("client-api")
                 .displayName("Client API")
                 .pathsToMatch(
-                        "/bottom-duo/**"
+                        "/bottom-duo/**",
+                        "/patch/**"
                 )
                 .build();
     }


### PR DESCRIPTION
## Summary
- PR #64에서 누락된 Swagger 노출 커밋을 main에 반영
- `SwaggerConfig.clientApi` `pathsToMatch`에 `/patch/**` 추가
- `PatchController`에 `@Tag`, `@Operation` 어노테이션 추가

## Background
PR #64 머지 시점에는 `feat/recent-patches-endpoint` 브랜치에 후속 커밋이 푸시되지 않아 Swagger 설정 변경이 main에 반영되지 못했음. 결과적으로 Railway 배포본의 Swagger UI에 `/patch/recent`가 노출되지 않는 상태.

## Test plan
- [ ] 머지 후 Railway 재배포에서 Swagger UI Client API 그룹에 `/patch/recent`가 "패치 정보" 태그로 보이는지 확인