### PR TITLE
feat(aggregate): aggregate 작업 cron 스케줄러 자동화 (stat × 5 tier + matchup)

### DIFF
--- a/src/main/java/com/bestduo_BE/aggregate/infra/scheduler/BottomDuoAggregateScheduler.java
+++ b/src/main/java/com/bestduo_BE/aggregate/infra/scheduler/BottomDuoAggregateScheduler.java
@@ -1,0 +1,69 @@
+package com.bestduo_BE.aggregate.infra.scheduler;
+
+import com.bestduo_BE.aggregate.application.AggregateBottomDuoMatchup;
+import com.bestduo_BE.aggregate.application.AggregateBottomDuoStats;
+import com.bestduo_BE.common.application.PatchVersionService;
+import com.bestduo_BE.common.domain.model.Tier;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * 매일 cron 시각에 최신 패치 기준으로 stat aggregate(+ ranking) × 5개 tier와 matchup aggregate를
+ * 순차 실행한다.
+ *
+ * <p>대상 tier는 CHALLENGER ~ EMERALD 5개로 한정한다. 한 tier에서 예외가 발생해도 나머지 tier와
+ * matchup 작업은 계속 진행한다 — 부분 실패가 전체 운영을 멈추지 않도록 한다.
+ */
+@Component
+@Slf4j
+@RequiredArgsConstructor
+@ConditionalOnProperty(name = "aggregate.scheduler.enabled", havingValue = "true")
+public class BottomDuoAggregateScheduler {
+
+  private static final List<Tier> SCHEDULED_TIERS = List.of(
+      Tier.CHALLENGER,
+      Tier.GRANDMASTER,
+      Tier.MASTER,
+      Tier.DIAMOND,
+      Tier.EMERALD
+  );
+
+  private final PatchVersionService patchVersionService;
+  private final AggregateBottomDuoStats statUseCase;
+  private final AggregateBottomDuoMatchup matchupUseCase;
+
+  @Scheduled(cron = "${aggregate.scheduler.cron:0 0 4 * * *}", zone = "Asia/Seoul")
+  public void run() {
+    var latestPatch = patchVersionService.currentPatch();
+    if (latestPatch.isEmpty()) {
+      log.warn("[AggregateScheduler] No patch registered — skipping run");
+      return;
+    }
+
+    String patchVersion = latestPatch.get().getPatch();
+    log.info("[AggregateScheduler] start patch={}", patchVersion);
+
+    for (Tier tier : SCHEDULED_TIERS) {
+      try {
+        AggregateBottomDuoStats.Result result = statUseCase.execute(patchVersion, tier);
+        log.info("[AggregateScheduler] stat tier={} affected={} rankings={}",
+            tier, result.affectedRows(), result.rankingsUpdated());
+      } catch (Exception ex) {
+        log.error("[AggregateScheduler] stat aggregate failed tier={}", tier, ex);
+      }
+    }
+
+    try {
+      AggregateBottomDuoMatchup.Result matchupResult = matchupUseCase.execute();
+      log.info("[AggregateScheduler] matchup affected={}", matchupResult.affectedRows());
+    } catch (Exception ex) {
+      log.error("[AggregateScheduler] matchup aggregate failed", ex);
+    }
+
+    log.info("[AggregateScheduler] done patch={}", patchVersion);
+  }
+}

--- a/src/test/java/com/bestduo_BE/aggregate/infra/scheduler/BottomDuoAggregateSchedulerTest.java
+++ b/src/test/java/com/bestduo_BE/aggregate/infra/scheduler/BottomDuoAggregateSchedulerTest.java
@@ -1,0 +1,128 @@
+package com.bestduo_BE.aggregate.infra.scheduler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.bestduo_BE.aggregate.application.AggregateBottomDuoMatchup;
+import com.bestduo_BE.aggregate.application.AggregateBottomDuoStats;
+import com.bestduo_BE.common.application.PatchVersionService;
+import com.bestduo_BE.common.domain.model.Tier;
+import com.bestduo_BE.common.infra.persistence.entity.PatchVersion;
+import java.time.OffsetDateTime;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class BottomDuoAggregateSchedulerTest {
+
+  private static final String PATCH = "15.23";
+  private static final List<Tier> EXPECTED_TIERS = List.of(
+      Tier.CHALLENGER,
+      Tier.GRANDMASTER,
+      Tier.MASTER,
+      Tier.DIAMOND,
+      Tier.EMERALD
+  );
+
+  @Mock
+  private PatchVersionService patchVersionService;
+
+  @Mock
+  private AggregateBottomDuoStats statUseCase;
+
+  @Mock
+  private AggregateBottomDuoMatchup matchupUseCase;
+
+  private BottomDuoAggregateScheduler scheduler;
+
+  @BeforeEach
+  void setUp() {
+    scheduler = new BottomDuoAggregateScheduler(patchVersionService, statUseCase, matchupUseCase);
+  }
+
+  @Test
+  @DisplayName("run — 등록된 patch가 없으면 stat/matchup 모두 호출하지 않는다")
+  void runSkipsWhenNoPatchRegistered() {
+    when(patchVersionService.currentPatch()).thenReturn(Optional.empty());
+
+    scheduler.run();
+
+    verifyNoInteractions(statUseCase);
+    verifyNoInteractions(matchupUseCase);
+  }
+
+  @Test
+  @DisplayName("run — CHALLENGER~EMERALD 5개 tier로 stat을 순차 호출하고 마지막에 matchup을 1회 호출한다")
+  void runInvokesAllFiveTiersThenMatchup() {
+    when(patchVersionService.currentPatch())
+        .thenReturn(Optional.of(PatchVersion.of(PATCH, OffsetDateTime.now())));
+    when(statUseCase.execute(eq(PATCH), any(Tier.class)))
+        .thenReturn(new AggregateBottomDuoStats.Result(10, 5));
+    when(matchupUseCase.execute())
+        .thenReturn(new AggregateBottomDuoMatchup.Result(20));
+
+    scheduler.run();
+
+    ArgumentCaptor<Tier> tierCaptor = ArgumentCaptor.forClass(Tier.class);
+    verify(statUseCase, times(5)).execute(eq(PATCH), tierCaptor.capture());
+    assertThat(tierCaptor.getAllValues()).containsExactlyElementsOf(EXPECTED_TIERS);
+    verify(matchupUseCase).execute();
+  }
+
+  @Test
+  @DisplayName("run — 중간 tier에서 예외가 발생해도 나머지 tier와 matchup은 계속 진행한다")
+  void runContinuesAfterTierFailure() {
+    when(patchVersionService.currentPatch())
+        .thenReturn(Optional.of(PatchVersion.of(PATCH, OffsetDateTime.now())));
+    when(statUseCase.execute(eq(PATCH), eq(Tier.CHALLENGER)))
+        .thenReturn(new AggregateBottomDuoStats.Result(1, 1));
+    when(statUseCase.execute(eq(PATCH), eq(Tier.GRANDMASTER)))
+        .thenReturn(new AggregateBottomDuoStats.Result(2, 2));
+    when(statUseCase.execute(eq(PATCH), eq(Tier.MASTER)))
+        .thenThrow(new RuntimeException("simulated DB error"));
+    when(statUseCase.execute(eq(PATCH), eq(Tier.DIAMOND)))
+        .thenReturn(new AggregateBottomDuoStats.Result(3, 3));
+    when(statUseCase.execute(eq(PATCH), eq(Tier.EMERALD)))
+        .thenReturn(new AggregateBottomDuoStats.Result(4, 4));
+    when(matchupUseCase.execute())
+        .thenReturn(new AggregateBottomDuoMatchup.Result(50));
+
+    scheduler.run();
+
+    verify(statUseCase).execute(PATCH, Tier.CHALLENGER);
+    verify(statUseCase).execute(PATCH, Tier.GRANDMASTER);
+    verify(statUseCase).execute(PATCH, Tier.MASTER);
+    verify(statUseCase).execute(PATCH, Tier.DIAMOND);
+    verify(statUseCase).execute(PATCH, Tier.EMERALD);
+    verify(matchupUseCase).execute();
+  }
+
+  @Test
+  @DisplayName("run — matchup 호출에서 예외가 발생해도 스케줄러는 정상 종료한다")
+  void runSwallowsMatchupFailure() {
+    when(patchVersionService.currentPatch())
+        .thenReturn(Optional.of(PatchVersion.of(PATCH, OffsetDateTime.now())));
+    when(statUseCase.execute(eq(PATCH), any(Tier.class)))
+        .thenReturn(new AggregateBottomDuoStats.Result(1, 1));
+    when(matchupUseCase.execute())
+        .thenThrow(new RuntimeException("simulated matchup error"));
+
+    scheduler.run();
+
+    verify(matchupUseCase).execute();
+    verify(statUseCase, never()).execute(PATCH, Tier.ALL_TIERS);
+  }
+}


### PR DESCRIPTION
## Summary

- 매일 정해진 시각(기본 04:00 Asia/Seoul)에 최신 패치 기준 stat aggregate(+ ranking) × 5개 tier와 matchup aggregate를 순차 실행하는 `BottomDuoAggregateScheduler` 추가
- 기존 `DataDragonPatchSyncScheduler` 패턴(`@Scheduled` + `@ConditionalOnProperty`)을 그대로 따름
- 한 tier 실패가 전체를 멈추지 않도록 try/catch + 로그로 부분 실패에 강함

closes #68

## 동작

- 대상 patch: `PatchVersionService.currentPatch()` 최신 1개
- 순회 tier: `CHALLENGER, GRANDMASTER, MASTER, DIAMOND, EMERALD` 5개
- 실행 순서: stat × 5 tier → matchup × 1
- patch가 없으면 warn 로그만 남기고 종료

## 설정

환경변수만으로 동작 (application.yml 수정 없음 — 다른 미커밋 변경과의 충돌 회피):

| 변수 | 기본값 | 설명 |
|---|---|---|
| `AGGREGATE_SCHEDULER_ENABLED` | `false` | `true`일 때만 빈 등록 (`@ConditionalOnProperty`) |
| `AGGREGATE_SCHEDULER_CRON` | `0 0 4 * * *` | Spring cron 표현식 (zone=Asia/Seoul 고정) |

## 의도적으로 포함하지 않은 것 (YAGNI)

- `ALL_TIERS` 호출: 현재 운영에서 필요 없음. 필요해지면 추가.
- 패치 grace period: stat은 최신 patch 그대로. 다음 cron 주기에 자연 회복.
- 이벤트 기반 트리거: 시간 기반 cron으로 충분.

## Test plan

- [x] `BottomDuoAggregateSchedulerTest` 4 케이스 통과
  - patch 없을 때 use case 호출 안 함
  - 5개 tier × stat + matchup × 1 호출 순서 검증
  - 중간 tier 예외 발생 시 나머지 tier + matchup 계속 진행
  - matchup 예외 발생 시 스케줄러 정상 종료
- [x] `./gradlew compileJava` 통과
- [ ] prod 환경에서 `AGGREGATE_SCHEDULER_ENABLED=true` 세팅 후 다음 cron 주기 실행 로그 확인 (배포 후)