### PR TITLE
docs(aggregate): application.yml에 scheduler 설정 키 노출

### DIFF
--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -49,6 +49,11 @@ patch-sync:
   enabled: ${PATCH_SYNC_ENABLED:true}
   interval-ms: ${PATCH_SYNC_INTERVAL_MS:21600000}  # 6시간
 
+aggregate:
+  scheduler:
+    enabled: ${AGGREGATE_SCHEDULER_ENABLED:false}
+    cron: ${AGGREGATE_SCHEDULER_CRON:0 0 4 * * *}  # 매일 04:00 Asia/Seoul
+
 pipeline:
   runner:
     enabled: ${PIPELINE_RUNNER_ENABLED:true}


### PR DESCRIPTION
## Summary

머지된 #69의 보완 — `BottomDuoAggregateScheduler`가 사용하는 환경변수 키를 다른 모듈(`patch-sync:`, `pipeline:` 등)과 일관되게 `application.yml`에 명시한다.

## 동기

#69에서는 application.yml의 다른 미커밋 변경과 같은 diff hunk에 묶여 있어 분리가 어려웠기에 클래스 default만으로 처리했다. 그 결과 `AGGREGATE_SCHEDULER_ENABLED` / `AGGREGATE_SCHEDULER_CRON`가 yml에 보이지 않아 발견성이 떨어졌다. 환경변수만으로도 동작은 하지만 운영 친화적이지 않다.

## 변경

`src/main/resources/application.yml` (+5):
```yaml
aggregate:
  scheduler:
    enabled: ${AGGREGATE_SCHEDULER_ENABLED:false}
    cron: ${AGGREGATE_SCHEDULER_CRON:0 0 4 * * *}  # 매일 04:00 Asia/Seoul
```

기본값은 `BottomDuoAggregateScheduler`의 `@Scheduled(cron="...:0 0 4 * * *")` default와 동일하므로 동작 변경 없음.

## Test plan

- [x] yml 파싱 정상 (`./gradlew compileJava` 통과)
- [ ] prod에서 `AGGREGATE_SCHEDULER_ENABLED=true` 세팅 시 빈 등록되는지 확인 (배포 후)