### PR TITLE
feat(patch): /patch/recent에 grace period 적용

### DIFF
--- a/src/main/java/com/bestduo_BE/common/application/PatchVersionService.java
+++ b/src/main/java/com/bestduo_BE/common/application/PatchVersionService.java
@@ -40,9 +40,24 @@ public class PatchVersionService {
     return patchVersionRepository.findTopByOrderByReleasedAtDesc();
   }
 
-  /** 최신 2개 패치를 최신 → 이전 순으로 반환. 데이터 적으면 1개, 없으면 빈 리스트. */
+  /**
+   * 공개용 최근 패치 2개. 최신 패치가 grace period({@code PATCH_GRACE_PERIOD_DAYS}일) 이내면
+   * 데이터 신뢰도가 낮아 latest를 제외하고 그 이전 2개를 반환한다.
+   * 그 외에는 최신 2개를 그대로 반환한다.
+   */
   public List<PatchVersion> recentPatches() {
-    return patchVersionRepository.findTop2ByOrderByReleasedAtDesc();
+    List<PatchVersion> top3 = patchVersionRepository.findTop3ByOrderByReleasedAtDesc();
+    if (top3.isEmpty()) {
+      return List.of();
+    }
+
+    PatchVersion latest = top3.get(0);
+    boolean inGracePeriod = OffsetDateTime.now()
+        .isBefore(latest.getReleasedAt().plusDays(PATCH_GRACE_PERIOD_DAYS));
+
+    int from = inGracePeriod ? 1 : 0;
+    int to = Math.min(from + 2, top3.size());
+    return List.copyOf(top3.subList(from, to));
   }
 
   /**

--- a/src/main/java/com/bestduo_BE/common/infra/persistence/repository/PatchVersionJpaRepository.java
+++ b/src/main/java/com/bestduo_BE/common/infra/persistence/repository/PatchVersionJpaRepository.java
@@ -15,4 +15,7 @@ public interface PatchVersionJpaRepository extends JpaRepository<PatchVersion, L
 
   /** 최신 2개 패치를 최신 순으로 반환 (grace period 판별용) */
   List<PatchVersion> findTop2ByOrderByReleasedAtDesc();
+
+  /** 최신 3개 패치를 최신 순으로 반환 (grace period에서 latest 제외 후 2개 노출용) */
+  List<PatchVersion> findTop3ByOrderByReleasedAtDesc();
 }

--- a/src/test/java/com/bestduo_BE/common/application/PatchVersionServiceTest.java
+++ b/src/test/java/com/bestduo_BE/common/application/PatchVersionServiceTest.java
@@ -173,14 +173,16 @@ class PatchVersionServiceTest {
   // ── recentPatches ────────────────────────────────────────────────────────
 
   @Test
-  @DisplayName("recentPatches — 최신 2개 패치를 최신 → 이전 순으로 반환")
-  void recentPatches_whenTwoOrMoreExist_returnsTopTwoOrdered() {
-    OffsetDateTime latestAt = OffsetDateTime.parse("2026-04-20T00:00:00+00:00");
-    OffsetDateTime previousAt = OffsetDateTime.parse("2026-04-01T00:00:00+00:00");
+  @DisplayName("recentPatches — 최신 패치가 3일 이상이면 최신 2개 그대로 반환")
+  void recentPatches_whenLatestMature_returnsTopTwoOrdered() {
+    OffsetDateTime latestAt = OffsetDateTime.now().minusDays(4);
+    OffsetDateTime previousAt = OffsetDateTime.now().minusDays(20);
+    OffsetDateTime olderAt = OffsetDateTime.now().minusDays(40);
     PatchVersion latest = PatchVersion.of("16.8", latestAt);
     PatchVersion previous = PatchVersion.of("16.7", previousAt);
-    given(patchVersionRepository.findTop2ByOrderByReleasedAtDesc())
-        .willReturn(List.of(latest, previous));
+    PatchVersion older = PatchVersion.of("16.6", olderAt);
+    given(patchVersionRepository.findTop3ByOrderByReleasedAtDesc())
+        .willReturn(List.of(latest, previous, older));
 
     List<PatchVersion> result = service.recentPatches();
 
@@ -190,10 +192,58 @@ class PatchVersionServiceTest {
   }
 
   @Test
-  @DisplayName("recentPatches — 패치 1개만 있으면 1개만 반환")
-  void recentPatches_whenOnlyOneExists_returnsSingleton() {
-    PatchVersion only = PatchVersion.of("16.8", OffsetDateTime.parse("2026-04-20T00:00:00+00:00"));
-    given(patchVersionRepository.findTop2ByOrderByReleasedAtDesc()).willReturn(List.of(only));
+  @DisplayName("recentPatches — 최신 패치가 3일 이내(grace)면 최신 제외하고 그 이전 2개 반환")
+  void recentPatches_whenLatestInGracePeriod_excludesLatestAndReturnsPreviousTwo() {
+    OffsetDateTime latestAt = OffsetDateTime.now().minusDays(1);
+    OffsetDateTime previousAt = OffsetDateTime.now().minusDays(20);
+    OffsetDateTime olderAt = OffsetDateTime.now().minusDays(40);
+    PatchVersion latest = PatchVersion.of("16.8", latestAt);
+    PatchVersion previous = PatchVersion.of("16.7", previousAt);
+    PatchVersion older = PatchVersion.of("16.6", olderAt);
+    given(patchVersionRepository.findTop3ByOrderByReleasedAtDesc())
+        .willReturn(List.of(latest, previous, older));
+
+    List<PatchVersion> result = service.recentPatches();
+
+    assertThat(result).hasSize(2);
+    assertThat(result.get(0).getPatch()).isEqualTo("16.7");
+    assertThat(result.get(1).getPatch()).isEqualTo("16.6");
+  }
+
+  @Test
+  @DisplayName("recentPatches — grace 중인데 이전 패치가 1개뿐이면 이전 1개만 반환")
+  void recentPatches_whenLatestInGracePeriodWithOnlyOnePrevious_returnsSinglePrevious() {
+    OffsetDateTime latestAt = OffsetDateTime.now().minusDays(1);
+    OffsetDateTime previousAt = OffsetDateTime.now().minusDays(20);
+    PatchVersion latest = PatchVersion.of("16.8", latestAt);
+    PatchVersion previous = PatchVersion.of("16.7", previousAt);
+    given(patchVersionRepository.findTop3ByOrderByReleasedAtDesc())
+        .willReturn(List.of(latest, previous));
+
+    List<PatchVersion> result = service.recentPatches();
+
+    assertThat(result).hasSize(1);
+    assertThat(result.get(0).getPatch()).isEqualTo("16.7");
+  }
+
+  @Test
+  @DisplayName("recentPatches — grace 중이고 이전 패치가 없으면(전체 1개) 빈 리스트 반환")
+  void recentPatches_whenLatestInGracePeriodWithNoPrevious_returnsEmpty() {
+    OffsetDateTime latestAt = OffsetDateTime.now().minusDays(1);
+    PatchVersion latest = PatchVersion.of("16.8", latestAt);
+    given(patchVersionRepository.findTop3ByOrderByReleasedAtDesc()).willReturn(List.of(latest));
+
+    List<PatchVersion> result = service.recentPatches();
+
+    assertThat(result).isEmpty();
+  }
+
+  @Test
+  @DisplayName("recentPatches — mature 상태에서 패치 1개만 있으면 1개만 반환")
+  void recentPatches_whenMatureWithOnlyOne_returnsSingleton() {
+    OffsetDateTime latestAt = OffsetDateTime.now().minusDays(10);
+    PatchVersion only = PatchVersion.of("16.8", latestAt);
+    given(patchVersionRepository.findTop3ByOrderByReleasedAtDesc()).willReturn(List.of(only));
 
     List<PatchVersion> result = service.recentPatches();
 
@@ -204,7 +254,7 @@ class PatchVersionServiceTest {
   @Test
   @DisplayName("recentPatches — 패치가 없으면 빈 리스트 반환")
   void recentPatches_whenEmpty_returnsEmptyList() {
-    given(patchVersionRepository.findTop2ByOrderByReleasedAtDesc()).willReturn(List.of());
+    given(patchVersionRepository.findTop3ByOrderByReleasedAtDesc()).willReturn(List.of());
 
     List<PatchVersion> result = service.recentPatches();
 


### PR DESCRIPTION
## 배경
신규 패치 출시 직후 며칠은 매치 데이터가 부족해 통계 신뢰도가 낮습니다.
이미 `PatchVersionService.resolveEffectivePatchContext()` 에서 같은 이유로 3일 grace 로직을 사용 중인데, 공개 API인 `/patch/recent` 응답에는 적용돼 있지 않아 사용자에게 데이터가 빈약한 최신 패치가 그대로 노출되고 있었습니다.

## 변경
`recentPatches()` 가 grace period 동안 latest 를 제외하고 그 이전 2개 패치를 반환하도록 수정.

| 상황 | 응답 |
|---|---|
| 최신 ≥3일 (mature) | top2 그대로 (기존 동작) |
| 최신 <3일 (grace) + 이전 ≥2개 | latest 제외, 그 이전 2개 |
| 최신 <3일 + 이전 1개만 | 이전 1개만 |
| 최신 <3일 + 이전 0개 (전체 1개) | 빈 배열 |
| 패치 없음 | 빈 배열 |

### 구현
- `PatchVersionJpaRepository`: `findTop3ByOrderByReleasedAtDesc()` 추가 (grace 시 latest 제외 후 2개 노출용)
- `PatchVersionService.recentPatches()`: top3 조회 후 grace 여부에 따라 슬라이스
- grace 임계값은 기존 상수 `PATCH_GRACE_PERIOD_DAYS` 재사용 (현재 3일)

## 영향 범위
- 변경된 동작은 `GET /patch/recent` 응답뿐. `resolveEffectivePatchContext()` 와 다른 사용처는 그대로.
- `PatchController` 는 service 만 의존하므로 컨트롤러 코드/테스트는 수정 불필요.

## Test Plan
- [x] `PatchVersionServiceTest` — recentPatches 시나리오 6개 (mature/grace × 패치 수) 모두 GREEN
- [x] `PatchControllerTest` — 기존 3개 케이스 회귀 없음
- [ ] (수동) 신규 패치 등록 직후 `GET /patch/recent` 호출 시 latest 가 응답에서 빠지는지 확인