### PR TITLE
feat(bottom-duo): /bottom-duo/stats에 size 파라미터 추가해 상위 N개만 노출

### DIFF
--- a/src/main/java/com/bestduo_BE/aggregate/application/GetBottomDuoStatistics.java
+++ b/src/main/java/com/bestduo_BE/aggregate/application/GetBottomDuoStatistics.java
@@ -12,7 +12,8 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class GetBottomDuoStatistics {
 
-  private static final int MAX_ROWS = 1000;
+  static final int MIN_SIZE = 1;
+  static final int MAX_SIZE = 1000;
 
   private final BottomDuoStatFinder statFinder;
   private final ChampionMetaClient championMetaClient;
@@ -22,11 +23,13 @@ public class GetBottomDuoStatistics {
       String patchVersionOrNull,
       String adcChampionIdOrNull,
       String supChampionIdOrNull,
-      BottomDuoStatFinder.SortKey sortKey
+      BottomDuoStatFinder.SortKey sortKey,
+      int size
   ) {
     String patchVersion = blankToNull(patchVersionOrNull);
     String adcChampionId = blankToNull(adcChampionIdOrNull);
     String supChampionId = blankToNull(supChampionIdOrNull);
+    int clampedSize = Math.min(MAX_SIZE, Math.max(MIN_SIZE, size));
 
     String resolvedPatchVersion = statFinder.resolvePatchVersion(patchVersion);
     int totalGames = statFinder.findTierTotalGames(tier, resolvedPatchVersion);
@@ -39,7 +42,7 @@ public class GetBottomDuoStatistics {
                 supChampionId,
                 sortKey,
                 totalGames,
-                MAX_ROWS
+                clampedSize
             ).stream()
             .map(row -> toItem(row, totalGames))
             .toList();

--- a/src/main/java/com/bestduo_BE/aggregate/presentation/api/BottomDuoStatisticsController.java
+++ b/src/main/java/com/bestduo_BE/aggregate/presentation/api/BottomDuoStatisticsController.java
@@ -27,14 +27,16 @@ public class BottomDuoStatisticsController {
   @Operation(
       summary = "바텀 듀오 전체 통계 조회",
       description = "선택한 조건(티어, 시즌, 패치, 큐 타입 등)에 대해 바텀 듀오의 승률, 픽률, 밴률 등의 종합 통계를 조회합니다."
+          + " size 파라미터로 상위 N개만 받을 수 있으며, 범위(1~1000)를 벗어나면 자동 보정됩니다."
   )
   public BottomDuoStatisticsResponse getList(
       @RequestParam Tier tier,
       @RequestParam(required = false) String patchVersion,
       @RequestParam(required = false) String adcChampionId,
       @RequestParam(required = false) String supChampionId,
-      @RequestParam(defaultValue = "PICKRATE_DESC") BottomDuoStatFinder.SortKey sort
+      @RequestParam(defaultValue = "PICKRATE_DESC") BottomDuoStatFinder.SortKey sort,
+      @RequestParam(defaultValue = "100") int size
   ) {
-    return useCase.execute(tier, patchVersion, adcChampionId, supChampionId, sort);
+    return useCase.execute(tier, patchVersion, adcChampionId, supChampionId, sort, size);
   }
 }

--- a/src/test/java/com/bestduo_BE/aggregate/application/GetBottomDuoStatisticsTest.java
+++ b/src/test/java/com/bestduo_BE/aggregate/application/GetBottomDuoStatisticsTest.java
@@ -1,6 +1,90 @@
 package com.bestduo_BE.aggregate.application;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.bestduo_BE.aggregate.infra.persistence.BottomDuoStatFinder;
+import com.bestduo_BE.common.application.port.ChampionMetaClient;
+import com.bestduo_BE.common.domain.model.Tier;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
 class GetBottomDuoStatisticsTest {
 
+  @Mock
+  private BottomDuoStatFinder statFinder;
 
+  @Mock
+  private ChampionMetaClient championMetaClient;
+
+  @InjectMocks
+  private GetBottomDuoStatistics useCase;
+
+  @Test
+  @DisplayName("size가 정상 범위면 그대로 maxRows로 전달된다")
+  void passesSizeAsMaxRowsWhenWithinRange() {
+    stubFinderEmpty("14.10");
+
+    useCase.execute(Tier.GOLD, "14.10", null, null,
+        BottomDuoStatFinder.SortKey.PICKRATE_DESC, 50);
+
+    verify(statFinder).findStats(
+        eq(Tier.GOLD),
+        eq("14.10"),
+        eq((String) null),
+        eq((String) null),
+        eq(BottomDuoStatFinder.SortKey.PICKRATE_DESC),
+        anyInt(),
+        eq(50)
+    );
+  }
+
+  @Test
+  @DisplayName("size가 0 이하면 1로 보정된다")
+  void clampsSizeToMinWhenTooSmall() {
+    stubFinderEmpty("14.10");
+
+    useCase.execute(Tier.GOLD, "14.10", null, null,
+        BottomDuoStatFinder.SortKey.PICKRATE_DESC, 0);
+
+    var maxRowsCaptor = ArgumentCaptor.forClass(Integer.class);
+    verify(statFinder).findStats(
+        any(), anyString(), any(), any(), any(), anyInt(), maxRowsCaptor.capture()
+    );
+    assertThat(maxRowsCaptor.getValue()).isEqualTo(GetBottomDuoStatistics.MIN_SIZE);
+  }
+
+  @Test
+  @DisplayName("size가 상한을 넘으면 MAX_SIZE(1000)로 보정된다")
+  void clampsSizeToMaxWhenTooLarge() {
+    stubFinderEmpty("14.10");
+
+    useCase.execute(Tier.GOLD, "14.10", null, null,
+        BottomDuoStatFinder.SortKey.PICKRATE_DESC, 99999);
+
+    var maxRowsCaptor = ArgumentCaptor.forClass(Integer.class);
+    verify(statFinder).findStats(
+        any(), anyString(), any(), any(), any(), anyInt(), maxRowsCaptor.capture()
+    );
+    assertThat(maxRowsCaptor.getValue()).isEqualTo(GetBottomDuoStatistics.MAX_SIZE);
+  }
+
+  private void stubFinderEmpty(String resolvedPatch) {
+    when(statFinder.resolvePatchVersion(any())).thenReturn(resolvedPatch);
+    when(statFinder.findTierTotalGames(any(), any())).thenReturn(0);
+    when(statFinder.findStats(any(), any(), any(), any(), any(), anyInt(), anyInt()))
+        .thenReturn(List.of());
+  }
 }

--- a/src/test/java/com/bestduo_BE/aggregate/presentation/api/BottomDuoStatisticsControllerTest.java
+++ b/src/test/java/com/bestduo_BE/aggregate/presentation/api/BottomDuoStatisticsControllerTest.java
@@ -58,7 +58,8 @@ class BottomDuoStatisticsControllerTest {
         "14.10",
         "Ashe",
         "Thresh",
-        BottomDuoStatFinder.SortKey.WINRATE_ASC
+        BottomDuoStatFinder.SortKey.WINRATE_ASC,
+        20
     )).thenReturn(response);
 
     mockMvc.perform(get("/bottom-duo/stats")
@@ -66,7 +67,8 @@ class BottomDuoStatisticsControllerTest {
             .param("patchVersion", "14.10")
             .param("adcChampionId", "Ashe")
             .param("supChampionId", "Thresh")
-            .param("sort", "WINRATE_ASC"))
+            .param("sort", "WINRATE_ASC")
+            .param("size", "20"))
         .andExpect(status().isOk())
         .andExpect(content().json(objectMapper.writeValueAsString(response)));
 
@@ -75,12 +77,13 @@ class BottomDuoStatisticsControllerTest {
         "14.10",
         "Ashe",
         "Thresh",
-        BottomDuoStatFinder.SortKey.WINRATE_ASC
+        BottomDuoStatFinder.SortKey.WINRATE_ASC,
+        20
     );
   }
 
   @Test
-  @DisplayName("GET /bottom-duo/stats — sort 파라미터 미제공 시 기본 정렬을 사용한다")
+  @DisplayName("GET /bottom-duo/stats — sort/size 파라미터 미제공 시 기본값(PICKRATE_DESC, size=100)을 사용한다")
   void getListUsesDefaultSortWhenNotProvided() throws Exception {
     BottomDuoStatisticsResponse response = new BottomDuoStatisticsResponse("SILVER", null, 0, List.of());
     when(viewBottomDuoStatistics.execute(
@@ -88,7 +91,8 @@ class BottomDuoStatisticsControllerTest {
         null,
         null,
         null,
-        BottomDuoStatFinder.SortKey.PICKRATE_DESC
+        BottomDuoStatFinder.SortKey.PICKRATE_DESC,
+        100
     )).thenReturn(response);
 
     mockMvc.perform(get("/bottom-duo/stats")
@@ -101,7 +105,8 @@ class BottomDuoStatisticsControllerTest {
         null,
         null,
         null,
-        BottomDuoStatFinder.SortKey.PICKRATE_DESC
+        BottomDuoStatFinder.SortKey.PICKRATE_DESC,
+        100
     );
   }
 }


### PR DESCRIPTION
## Summary
- 현재 `GET /bottom-duo/stats`는 내부 `MAX_ROWS=1000`까지 전부 반환해 정보가 너무 많아 가독성이 떨어지는 문제 해결
- 컨트롤러에 `size` 쿼리 파라미터 추가 (기본 100, 범위 1~1000, 범위 밖이면 clamp)
- 유스케이스 시그니처에 `size` 인자 추가, `BottomDuoStatFinder.findStats(..., maxRows)`로 전달

## Changes
- `BottomDuoStatisticsController.getList()`: `@RequestParam(defaultValue = "100") int size` 추가
- `GetBottomDuoStatistics.execute(...)`: `int size` 파라미터 추가, `MIN_SIZE=1` ~ `MAX_SIZE=1000`으로 clamp
- 기존 `MAX_ROWS=1000` 상수 제거 → `MIN_SIZE`/`MAX_SIZE`로 대체

## Test plan
- [x] `BottomDuoStatisticsControllerTest` 갱신 — 명시 size 전달 + 미지정 시 기본 100
- [x] `GetBottomDuoStatisticsTest` 신규 — 정상 범위 그대로 전달 / 하한 보정(0→1) / 상한 보정(99999→1000)
- [x] `./gradlew test --tests "...GetBottomDuoStatisticsTest" --tests "...BottomDuoStatisticsControllerTest"` 통과

Closes #72