### PR TITLE
feat(match): match.collection_tier(NOT NULL) 추가 + 레거시 row 정리

### DIFF
--- a/src/main/java/com/bestduo_BE/common/infra/persistence/entity/Match.java
+++ b/src/main/java/com/bestduo_BE/common/infra/persistence/entity/Match.java
@@ -1,7 +1,10 @@
 package com.bestduo_BE.common.infra.persistence.entity;
 
+import com.bestduo_BE.common.domain.model.Tier;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import java.time.OffsetDateTime;
@@ -33,6 +36,15 @@ public class Match {
   @Column(name = "game_version")
   private String gameVersion;
 
+  /**
+   * 이 매치를 어느 tier 버킷에서 수집했는지 나타내는 메타.
+   * <p>bottom_duo_raw 가 retention 으로 사라져도 match 자체에서 tier 분류를 복구할 수 있게 한다.
+   * <p>V4 마이그레이션 이전에 들어온 레거시 row 는 정리되어 NOT NULL 이 보장된다.
+   */
+  @Enumerated(EnumType.STRING)
+  @Column(name = "collection_tier", nullable = false)
+  private Tier collectionTier;
+
   @Column(name = "fetched_at", nullable = false)
   private OffsetDateTime fetchedAt;
 
@@ -40,12 +52,19 @@ public class Match {
   @Column(name = "payload_json", nullable = false, columnDefinition = "jsonb")
   private String payloadJson;
 
-  public static Match from(String matchId, Integer queueId, Long gameCreation, String gameVersion, String payloadJson) {
+  public static Match from(
+      String matchId,
+      Integer queueId,
+      Long gameCreation,
+      String gameVersion,
+      Tier collectionTier,
+      String payloadJson) {
     return Match.builder()
         .matchId(matchId)
         .queueId(queueId)
         .gameCreation(gameCreation)
         .gameVersion(gameVersion)
+        .collectionTier(collectionTier)
         .fetchedAt(OffsetDateTime.now())
         .payloadJson(payloadJson)
         .build();

--- a/src/main/java/com/bestduo_BE/ingest/application/IngestMatchDetail.java
+++ b/src/main/java/com/bestduo_BE/ingest/application/IngestMatchDetail.java
@@ -44,7 +44,7 @@ public class IngestMatchDetail {
       raws = filtered;
     }
 
-    matchSaver.save(matchId, match);
+    matchSaver.save(matchId, match, tier);
     bottomDuoRawSaver.saveAllIdempotent(raws);
     return new IngestResult(raws.size(), extractMatchStartTimeSec(match));
   }

--- a/src/main/java/com/bestduo_BE/ingest/infra/persistence/MatchSaver.java
+++ b/src/main/java/com/bestduo_BE/ingest/infra/persistence/MatchSaver.java
@@ -1,5 +1,6 @@
 package com.bestduo_BE.ingest.infra.persistence;
 
+import com.bestduo_BE.common.domain.model.Tier;
 import com.bestduo_BE.common.infra.persistence.entity.Match;
 import com.bestduo_BE.common.infra.persistence.repository.MatchJpaRepository;
 import com.bestduo_BE.common.infra.riot.dto.InfoDto;
@@ -15,7 +16,7 @@ public class MatchSaver {
   private final MatchJpaRepository matchRepository;
   private final ObjectMapper objectMapper;
 
-  public void save(String matchId, RiotMatchDto matchDetail) {
+  public void save(String matchId, RiotMatchDto matchDetail, Tier collectionTier) {
     InfoDto info = matchDetail.info();
 
     String payload = objectMapper.writeValueAsString(matchDetail);
@@ -25,6 +26,7 @@ public class MatchSaver {
         info.queueId(),
         info.gameCreation(),
         info.gameVersion(),
+        collectionTier,
         payload
     );
 

--- a/src/main/resources/db/migration/V4__add_match_collection_tier.sql
+++ b/src/main/resources/db/migration/V4__add_match_collection_tier.sql
@@ -1,0 +1,53 @@
+-- V4: match 테이블에 collection_tier(NOT NULL) 컬럼을 추가하고 레거시 row를 정리한다.
+--
+-- 배경:
+--   - 그간 match 테이블은 "어느 tier 버킷에서 수집했는가" 메타를 갖지 않아,
+--     bottom_duo_raw 의 사본 정보를 통해서만 tier 분류가 가능했다.
+--   - bottom_duo_raw 는 retention 정책으로 top-N patch 만 유지되므로,
+--     장기 보관(match.payload_json) 자체에서 tier 를 복구할 수 없는 매치들이 남게 된다.
+--   - 이 마이그레이션은 match 가 항상 자기 자신의 tier 메타를 갖게 만들어,
+--     향후 bottom_duo_raw 를 점진적으로 제거할 수 있는 발판을 마련한다.
+--
+-- 데이터 사전 진단 (2026-05-16):
+--   - match 전체 ~732k row 중 약 61,855건(≈8.4%)이 match_queue 엔트리 없이 잔존.
+--   - 분포 확인 결과 100% 가 retention(top-3) 밖의 옛 patch 또는
+--     game_version 이 잘못 파싱된 잡음(예: '.').
+--   - 이들은 어차피 현재 retention 정책상 어떤 집계에도 기여하지 않으며,
+--     tier 메타도 복구 불가하다. → 본 마이그레이션에서 정리한다.
+--
+-- 동작 순서:
+--   1. match_queue 와 매칭되지 않는 레거시 row 삭제
+--      (top-3 patch 중에는 missing_queue=0 이 확인되었으므로 살아있는 데이터에 영향 없음)
+--   2. collection_tier 컬럼 추가 (우선 NULL 허용)
+--   3. match_queue.collection_tier 로 백필
+--   4. NOT NULL 제약 부여
+--
+-- 환경:
+--   - 운영(Railway): 이 스크립트가 1회 실행되어 정리 + 컬럼 + 백필을 수행한다.
+--   - 새 환경(fresh DB): match 테이블은 Hibernate ddl-auto 가 만들고,
+--     이 스크립트는 빈 테이블 위에서 안전하게 통과한다 (DELETE 0건, UPDATE 0건).
+--   - 테스트(H2): spring.flyway.enabled=false 이므로 실행되지 않는다.
+--
+-- 컬럼 타입은 V3 와 동일하게 Hibernate 6.x PostgreSQL Dialect 기본 매핑을 따른다.
+--   @Enumerated(STRING) -> varchar(255)
+
+-- 1) 레거시 매치 정리: match_queue 엔트리가 없는 row 는 tier 복구 불가능하므로 삭제.
+DELETE FROM match
+ WHERE NOT EXISTS (
+     SELECT 1 FROM match_queue mq WHERE mq.match_id = match.match_id
+ );
+
+-- 2) collection_tier 컬럼 추가 (백필 동안 NULL 허용).
+ALTER TABLE match
+    ADD COLUMN IF NOT EXISTS collection_tier varchar(255);
+
+-- 3) match_queue 로부터 백필.
+UPDATE match
+   SET collection_tier = mq.collection_tier
+  FROM match_queue mq
+ WHERE match.match_id = mq.match_id
+   AND match.collection_tier IS NULL;
+
+-- 4) NOT NULL 제약 부여. 이 시점에 남아있는 row 는 모두 백필되었어야 한다.
+ALTER TABLE match
+    ALTER COLUMN collection_tier SET NOT NULL;

--- a/src/test/java/com/bestduo_BE/ingest/application/IngestMatchDetailPatchFilterTest.java
+++ b/src/test/java/com/bestduo_BE/ingest/application/IngestMatchDetailPatchFilterTest.java
@@ -5,6 +5,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
 
 import com.bestduo_BE.common.domain.model.BottomDuoRaw;
 import com.bestduo_BE.common.domain.model.IngestResult;
@@ -68,7 +69,7 @@ class IngestMatchDetailPatchFilterTest {
 
     IngestResult result = useCase.execute("KR_2", Tier.GOLD, "15.23");
 
-    verify(matchSaver, never()).save("KR_2", match);
+    verifyNoInteractions(matchSaver);
     verify(bottomDuoRawSaver, never()).saveAllIdempotent(any());
     assertThat(result.rawCreated()).isEqualTo(0);
   }

--- a/src/test/java/com/bestduo_BE/ingest/application/IngestMatchDetailTest.java
+++ b/src/test/java/com/bestduo_BE/ingest/application/IngestMatchDetailTest.java
@@ -52,7 +52,7 @@ class IngestMatchDetailTest {
 
     IngestResult result = useCase.execute("KR_1", Tier.EMERALD, null);
 
-    verify(matchSaver).save("KR_1", match);
+    verify(matchSaver).save("KR_1", match, Tier.EMERALD);
     ArgumentCaptor<List<BottomDuoRaw>> rawsCaptor = ArgumentCaptor.forClass(List.class);
     verify(bottomDuoRawSaver).saveAllIdempotent(rawsCaptor.capture());
     List<BottomDuoRaw> raws = rawsCaptor.getValue();

--- a/src/test/java/com/bestduo_BE/ingest/infra/persistence/MatchSaverTest.java
+++ b/src/test/java/com/bestduo_BE/ingest/infra/persistence/MatchSaverTest.java
@@ -4,6 +4,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.BDDMockito.then;
 
+import com.bestduo_BE.common.domain.model.Tier;
 import com.bestduo_BE.common.infra.persistence.entity.Match;
 import com.bestduo_BE.common.infra.persistence.repository.MatchJpaRepository;
 import com.bestduo_BE.common.infra.riot.dto.InfoDto;
@@ -34,7 +35,7 @@ class MatchSaverTest {
   }
 
   @Test
-  @DisplayName("save — InfoDto로부터 Match 엔티티를 생성하고 저장한다")
+  @DisplayName("save — InfoDto와 collectionTier로부터 Match 엔티티를 생성하고 저장한다")
   void save_persistsMatchEntityBuiltFromInfoDto() {
     RiotMatchDto dto = new RiotMatchDto(
         null,
@@ -49,7 +50,7 @@ class MatchSaverTest {
     );
     given(objectMapper.writeValueAsString(dto)).willReturn("{payload}");
 
-    saver.save("KR_TEST", dto);
+    saver.save("KR_TEST", dto, Tier.DIAMOND);
 
     ArgumentCaptor<Match> captor = ArgumentCaptor.forClass(Match.class);
     then(matchRepository).should().save(captor.capture());
@@ -58,6 +59,7 @@ class MatchSaverTest {
     assertEquals(420, saved.getQueueId());
     assertEquals(dto.info().gameCreation(), saved.getGameCreation());
     assertEquals("15.1", saved.getGameVersion());
+    assertEquals(Tier.DIAMOND, saved.getCollectionTier());
     assertEquals("{payload}", saved.getPayloadJson());
     then(objectMapper).should().writeValueAsString(dto);
   }


### PR DESCRIPTION
## Summary

Issue #75 의 PR 1.

- `match` 테이블에 `collection_tier`(NOT NULL) 컬럼을 추가하고, `match_queue.collection_tier` 로부터 백필
- `match_queue` 엔트리가 없는 레거시 row(약 61,855건, ~8.4%)를 같은 마이그레이션에서 삭제
- 신규 매치 저장 시 `MatchSaver.save` 가 수집 tier 를 받아 함께 기록하도록 변경

이후 PR 에서 aggregate SQL 을 `match.collection_tier` 기준으로 마이그레이션하고, 최종적으로 `bottom_duo_raw` 테이블을 제거할 예정.

## 데이터 진단 (사전 검증)

`match` 전체 ~732k row 중 `match_queue` 엔트리가 없는 row 의 patch 분포:

| 그룹 | patch | missing_queue 비율 |
|---|---|---|
| Top-3 retention | 16.10 / 16.9 / 16.8 | **0%** |
| 그 외 (16.6 이하) | 16.6 / 16.5 / 16.4 / ... / 14.x | **100%** |
| `game_version='.'` (잡음) | — | 56건 |

= 레거시 row 는 모두 retention 정책상 어떤 집계에도 기여하지 않으며, tier 메타도 복구 불가능. 본 PR 의 V4 마이그레이션이 일괄 정리한다.

## Migration 동작 순서

1. `match_queue` 와 매칭되지 않는 row 삭제 (~61,855건)
2. `match.collection_tier` 컬럼 추가 (우선 NULL 허용)
3. `match_queue.collection_tier` 로 백필
4. `NOT NULL` 제약 부여

## Test plan

- [x] `./gradlew compileJava compileTestJava` 통과
- [x] `./gradlew test --tests "com.bestduo_BE.ingest.*"` 통과
- [x] 전체 테스트 331/333 통과 (실패 2건은 Docker 데몬 미실행에 따른 기존 Testcontainers IT, 본 변경과 무관)
- [ ] 배포 후 Railway 에서 V4 마이그레이션 로그 확인
- [ ] 배포 후 신규 매치 저장 시 `collection_tier` 가 NOT NULL 로 들어가는지 확인
- [ ] 다음 cron 사이클에서 aggregate 결과 변화 없음 확인 (이번 PR 은 aggregate 쿼리를 건드리지 않음)

## Out of scope

- aggregate SQL 의 `bottom_duo_raw` → `match` 전환 (다음 PR)
- `bottom_duo_raw` 테이블 제거 (그 다음 PR)
- `match.payload_json` cold archive (별도 트랙)