### PR TITLE
feat(aggregate): cron 집계 경로를 match.payload_json 기준 단일 경로로 통일

### DIFF
--- a/docs/aggregate-from-match-verification.md
+++ b/docs/aggregate-from-match-verification.md
@@ -1,0 +1,106 @@
+# Aggregate from match — 첫 cron 검증 절차
+
+## 배경
+
+PR 2 에서 cron 의 stat/matchup 집계 경로를 `bottom_duo_raw` 위 SQL 에서
+`match.payload_json` 위 메모리 누적 ({@link AggregateBottomDuoFromMatch}) 으로 단일화했다.
+
+`bottom_duo_raw` 테이블 자체는 이번 PR 에서 제거하지 않고 ingest 경로에서 계속 작성된다.
+이 상태에서 첫 cron 사이클 직후 raw 기반 결과와 match 기반 결과의 정합성을 한 번 수동 확인한다.
+
+## 검증 시점
+
+- 새 코드 배포 후 첫 cron(매일 04:00 Asia/Seoul) 이 완료된 직후
+- 이후 매 배포마다 반복할 필요 없음 — 1회성 cutover 검증
+
+## 검증 쿼리
+
+### 1. stat 결과 비교
+
+같은 (patch, tier, adc, sup) 키에서 raw 기반 재계산값과 현재 `bottom_duo_stat_agg`(=match 기반 upsert 결과) 가 다른 row 를 찾는다.
+
+```sql
+SELECT
+  s.patch_version, s.tier, s.adc_champion_id, s.sup_champion_id,
+  s.wins  AS match_wins,
+  s.games AS match_games,
+  raw_agg.wins  AS raw_wins,
+  raw_agg.games AS raw_games
+FROM bottom_duo_stat_agg s
+JOIN (
+  SELECT
+    COALESCE(patch, 'UNKNOWN')         AS patch_version,
+    collection_tier                    AS tier,
+    adc_champion_id::text              AS adc_champion_id,
+    sup_champion_id::text              AS sup_champion_id,
+    SUM(CASE WHEN win THEN 1 ELSE 0 END) AS wins,
+    COUNT(*)                           AS games
+  FROM bottom_duo_raw
+  GROUP BY 1, 2, 3, 4
+) raw_agg
+  ON raw_agg.patch_version   = s.patch_version
+ AND raw_agg.tier            = s.tier
+ AND raw_agg.adc_champion_id = s.adc_champion_id
+ AND raw_agg.sup_champion_id = s.sup_champion_id
+WHERE s.wins  <> raw_agg.wins
+   OR s.games <> raw_agg.games;
+```
+
+**기대 결과: 0 row** → match 기반 결과 = raw 기반 결과 = 안전 확인.
+
+### 2. matchup 결과 비교
+
+```sql
+SELECT
+  m.patch_version, m.tier,
+  m.my_adc_champion_id, m.my_sup_champion_id,
+  m.opp_adc_champion_id, m.opp_sup_champion_id,
+  m.wins  AS match_wins,
+  m.games AS match_games,
+  raw_agg.wins  AS raw_wins,
+  raw_agg.games AS raw_games
+FROM bottom_duo_matchup_agg m
+JOIN (
+  SELECT
+    COALESCE(a.patch, 'UNKNOWN')    AS patch_version,
+    a.collection_tier               AS tier,
+    a.adc_champion_id::text         AS my_adc_champion_id,
+    a.sup_champion_id::text         AS my_sup_champion_id,
+    b.adc_champion_id::text         AS opp_adc_champion_id,
+    b.sup_champion_id::text         AS opp_sup_champion_id,
+    SUM(CASE WHEN a.win THEN 1 ELSE 0 END) AS wins,
+    COUNT(*)                        AS games
+  FROM bottom_duo_raw a
+  JOIN bottom_duo_raw b
+    ON a.match_id        = b.match_id
+   AND a.collection_tier = b.collection_tier
+   AND a.team_id        <> b.team_id
+  GROUP BY 1, 2, 3, 4, 5, 6
+) raw_agg
+  ON raw_agg.patch_version       = m.patch_version
+ AND raw_agg.tier                = m.tier
+ AND raw_agg.my_adc_champion_id  = m.my_adc_champion_id
+ AND raw_agg.my_sup_champion_id  = m.my_sup_champion_id
+ AND raw_agg.opp_adc_champion_id = m.opp_adc_champion_id
+ AND raw_agg.opp_sup_champion_id = m.opp_sup_champion_id
+WHERE m.wins  <> raw_agg.wins
+   OR m.games <> raw_agg.games;
+```
+
+**기대 결과: 0 row**.
+
+## 차이가 발견될 경우
+
+1. 차이가 발생한 (patch, tier, adc, sup) 조합을 식별
+2. 같은 키의 `bottom_duo_raw` row 들을 직접 조회해 추출 로직 차이 분석
+3. `BottomDuoExtractor` 또는 `AggregateBottomDuoFromMatch` 의 누적 로직 점검
+4. 수정 후 해당 (patch, tier) 만 재처리 트리거하거나 다음 cron 까지 대기
+
+## 검증 완료 후
+
+검증이 통과하면 다음 PR (bottom_duo_raw 제거) 을 진행한다. 그 PR 에서:
+
+- `bottom_duo_raw` 테이블 + 관련 entity/repository 제거
+- `IngestMatchDetail` 에서 `BottomDuoRawSaver` 호출 제거
+- `CleanupOldPatches` 에서 raw cleanup 제거
+- `AggregateBottomDuoStats` / `AggregateBottomDuoMatchup` (deprecated) 클래스 삭제

--- a/docs/aggregate-from-match-verification.md
+++ b/docs/aggregate-from-match-verification.md
@@ -89,12 +89,67 @@ WHERE m.wins  <> raw_agg.wins
 
 **기대 결과: 0 row**.
 
+> matchup 은 self-join 결과라 raw 에 같은 match 의 양 팀 row 가 모두 들어가 있어야만 한 건이 잡힌다.
+> ingest 가 cron 도중에 한 팀만 먼저 insert 한 중간 상태에서는 양쪽 모두 0 으로 잡혀 timing
+> 영향이 거의 없다 — 첫 쿼리에서 바로 0 이 나오는 경우가 일반적.
+
+### 3. stat 차이가 나올 때 — per-tier cutoff 보정
+
+cron 은 tier 를 직렬로 처리하고 그 사이 ingest 가 계속 `bottom_duo_raw` 에 쓰기 때문에,
+검증 시점의 raw 에는 stat_agg 가 보지 못한 row 가 섞여 있을 수 있다. 1번 쿼리에서 diff
+가 0 이 아니면 곧바로 알고리즘 오류로 단정하지 말고, raw 를 tier 별 stat_agg.updated_at
+이전으로 잘라서 다시 비교한다.
+
+```sql
+WITH cutoff AS (
+  SELECT tier, max(updated_at) AS t
+  FROM bottom_duo_stat_agg
+  WHERE patch_version = :patch
+  GROUP BY tier
+)
+SELECT count(*) AS diff_count
+FROM bottom_duo_stat_agg s
+JOIN (
+  SELECT
+    COALESCE(r.patch, 'UNKNOWN') AS patch_version,
+    r.collection_tier            AS tier,
+    r.adc_champion_id::text      AS adc_champion_id,
+    r.sup_champion_id::text      AS sup_champion_id,
+    SUM(CASE WHEN r.win THEN 1 ELSE 0 END) AS wins,
+    COUNT(*)                     AS games
+  FROM bottom_duo_raw r
+  JOIN cutoff c
+    ON c.tier = r.collection_tier
+   AND r.created_at <= c.t
+  WHERE COALESCE(r.patch, 'UNKNOWN') = :patch
+  GROUP BY 1, 2, 3, 4
+) raw_agg
+  ON raw_agg.patch_version   = s.patch_version
+ AND raw_agg.tier            = s.tier
+ AND raw_agg.adc_champion_id = s.adc_champion_id
+ AND raw_agg.sup_champion_id = s.sup_champion_id
+WHERE s.patch_version = :patch
+  AND (s.wins <> raw_agg.wins OR s.games <> raw_agg.games);
+```
+
+**기대 결과: 0**. cutoff 미적용에서는 diff 가 나오더라도 cutoff 적용 후 0 이면 알고리즘
+동치 — RAW 와 MATCH 경로 사이 timing slippage 일 뿐이다.
+
 ## 차이가 발견될 경우
+
+cutoff 적용 후에도 diff 가 0 이 아니면 알고리즘 차이 가능성이 높다. 다음 순서로 분기한다.
 
 1. 차이가 발생한 (patch, tier, adc, sup) 조합을 식별
 2. 같은 키의 `bottom_duo_raw` row 들을 직접 조회해 추출 로직 차이 분석
 3. `BottomDuoExtractor` 또는 `AggregateBottomDuoFromMatch` 의 누적 로직 점검
 4. 수정 후 해당 (patch, tier) 만 재처리 트리거하거나 다음 cron 까지 대기
+
+### 흔한 false-positive 패턴
+
+- **단일 팀만 raw 에 들어간 match**: `match.payload_json` 에는 양 팀이 있지만 어느 시점에
+  ingest 가 한쪽만 저장하고 끝난 historical row. RAW self-join (matchup) 에서는
+  자연스럽게 빠지고, MATCH 경로에서는 두 팀 모두 추출돼 stat 에만 잡혀 diff 로 보임.
+  → MATCH 결과가 더 정확. 굳이 보정하지 않는다.
 
 ## 검증 완료 후
 

--- a/src/main/java/com/bestduo_BE/aggregate/application/AggregateBottomDuoFromMatch.java
+++ b/src/main/java/com/bestduo_BE/aggregate/application/AggregateBottomDuoFromMatch.java
@@ -1,0 +1,192 @@
+package com.bestduo_BE.aggregate.application;
+
+import com.bestduo_BE.common.domain.model.BottomDuoRaw;
+import com.bestduo_BE.common.domain.model.Tier;
+import com.bestduo_BE.common.domain.service.BottomDuoExtractor;
+import com.bestduo_BE.common.infra.persistence.entity.Match;
+import com.bestduo_BE.common.infra.persistence.repository.MatchJpaRepository;
+import com.bestduo_BE.common.infra.riot.dto.RiotMatchDto;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Service;
+import tools.jackson.databind.ObjectMapper;
+
+@Service
+@RequiredArgsConstructor
+public class AggregateBottomDuoFromMatch {
+
+  private static final int PAGE_SIZE = 500;
+  private static final int UPSERT_BATCH_SIZE = 500;
+
+  private final MatchJpaRepository matchRepository;
+  private final BottomDuoExtractor extractor;
+  private final ObjectMapper objectMapper;
+  private final JdbcTemplate jdbcTemplate;
+
+  public Result execute(String patch, Tier tier, boolean upsert) {
+    Map<StatKey, Counter> statAcc = new HashMap<>();
+    Map<MatchupKey, Counter> matchupAcc = new HashMap<>();
+
+    int processed = streamAndAccumulate(patch, tier, statAcc, matchupAcc);
+
+    int statUpserted = 0;
+    int matchupUpserted = 0;
+    if (upsert) {
+      statUpserted = bulkUpsertStats(patch, tier, statAcc);
+      matchupUpserted = bulkUpsertMatchups(patch, tier, matchupAcc);
+    }
+
+    return new Result(
+        processed,
+        statAcc.size(),
+        matchupAcc.size(),
+        statUpserted,
+        matchupUpserted,
+        totalGames(statAcc),
+        totalGames(matchupAcc)
+    );
+  }
+
+  private int bulkUpsertStats(String patch, Tier tier, Map<StatKey, Counter> acc) {
+    if (acc.isEmpty()) return 0;
+    String sql =
+        """
+        insert into bottom_duo_stat_agg(
+          patch_version, adc_champion_id, sup_champion_id, tier,
+          wins, games, win_rate, pick_rate, adjusted_win_rate,
+          rank_score, ranking_status, created_at, updated_at
+        ) values (?, ?, ?, ?, ?, ?, ?, 0, ?, 0, 'PENDING', now(), now())
+        on conflict (patch_version, adc_champion_id, sup_champion_id, tier)
+        do update set
+          wins = excluded.wins,
+          games = excluded.games,
+          win_rate = excluded.win_rate,
+          pick_rate = excluded.pick_rate,
+          adjusted_win_rate = excluded.adjusted_win_rate,
+          rank_score = excluded.rank_score,
+          ranking_status = excluded.ranking_status,
+          updated_at = now()
+        """;
+    jdbcTemplate.batchUpdate(sql, acc.entrySet(), UPSERT_BATCH_SIZE, (ps, e) -> {
+      Counter c = e.getValue();
+      double winRate = c.games == 0 ? 0 : ((double) c.wins) / c.games;
+      double adjustedWinRate =
+          c.games == 0 ? 0 : ((double) c.wins + 50.0) / (c.games + 100);
+      ps.setString(1, patch);
+      ps.setString(2, Integer.toString(e.getKey().adcId()));
+      ps.setString(3, Integer.toString(e.getKey().supId()));
+      ps.setString(4, tier.name());
+      ps.setInt(5, c.wins);
+      ps.setInt(6, c.games);
+      ps.setDouble(7, winRate);
+      ps.setDouble(8, adjustedWinRate);
+    });
+    return acc.size();
+  }
+
+  private int bulkUpsertMatchups(String patch, Tier tier, Map<MatchupKey, Counter> acc) {
+    if (acc.isEmpty()) return 0;
+    String sql =
+        """
+        insert into bottom_duo_matchup_agg(
+          patch_version,
+          my_adc_champion_id, my_sup_champion_id,
+          opp_adc_champion_id, opp_sup_champion_id,
+          tier, wins, games, created_at, updated_at
+        ) values (?, ?, ?, ?, ?, ?, ?, ?, now(), now())
+        on conflict (patch_version, my_adc_champion_id, my_sup_champion_id,
+                     opp_adc_champion_id, opp_sup_champion_id, tier)
+        do update set
+          wins = excluded.wins,
+          games = excluded.games,
+          updated_at = now()
+        """;
+    jdbcTemplate.batchUpdate(sql, acc.entrySet(), UPSERT_BATCH_SIZE, (ps, e) -> {
+      MatchupKey k = e.getKey();
+      Counter c = e.getValue();
+      ps.setString(1, patch);
+      ps.setString(2, Integer.toString(k.myAdc()));
+      ps.setString(3, Integer.toString(k.mySup()));
+      ps.setString(4, Integer.toString(k.oppAdc()));
+      ps.setString(5, Integer.toString(k.oppSup()));
+      ps.setString(6, tier.name());
+      ps.setInt(7, c.wins);
+      ps.setInt(8, c.games);
+    });
+    return acc.size();
+  }
+
+  private int streamAndAccumulate(
+      String patch,
+      Tier tier,
+      Map<StatKey, Counter> statAcc,
+      Map<MatchupKey, Counter> matchupAcc) {
+    String cursor = "";
+    int total = 0;
+    while (true) {
+      List<Match> page =
+          matchRepository.findPageByTierAndPatch(tier.name(), patch, cursor, PAGE_SIZE);
+      if (page.isEmpty()) break;
+      for (Match m : page) {
+        RiotMatchDto dto = objectMapper.readValue(m.getPayloadJson(), RiotMatchDto.class);
+        List<BottomDuoRaw> duos = extractor.extract(m.getMatchId(), dto, tier);
+        accumulate(duos, statAcc, matchupAcc);
+        cursor = m.getMatchId();
+      }
+      total += page.size();
+    }
+    return total;
+  }
+
+  private void accumulate(
+      List<BottomDuoRaw> duos,
+      Map<StatKey, Counter> statAcc,
+      Map<MatchupKey, Counter> matchupAcc) {
+    for (BottomDuoRaw d : duos) {
+      StatKey key = new StatKey(d.adcChampionId(), d.supChampionId());
+      statAcc.computeIfAbsent(key, k -> new Counter()).add(d.win());
+    }
+    if (duos.size() == 2) {
+      BottomDuoRaw a = duos.get(0);
+      BottomDuoRaw b = duos.get(1);
+      MatchupKey aVsB =
+          new MatchupKey(a.adcChampionId(), a.supChampionId(), b.adcChampionId(), b.supChampionId());
+      MatchupKey bVsA =
+          new MatchupKey(b.adcChampionId(), b.supChampionId(), a.adcChampionId(), a.supChampionId());
+      matchupAcc.computeIfAbsent(aVsB, k -> new Counter()).add(a.win());
+      matchupAcc.computeIfAbsent(bVsA, k -> new Counter()).add(b.win());
+    }
+  }
+
+  private static long totalGames(Map<?, Counter> acc) {
+    long s = 0;
+    for (Counter c : acc.values()) s += c.games;
+    return s;
+  }
+
+  public record Result(
+      int matchesProcessed,
+      int statKeys,
+      int matchupKeys,
+      int statUpserted,
+      int matchupUpserted,
+      long statTotalGames,
+      long matchupTotalGames
+  ) {}
+
+  private record StatKey(int adcId, int supId) {}
+
+  private record MatchupKey(int myAdc, int mySup, int oppAdc, int oppSup) {}
+
+  private static final class Counter {
+    int wins;
+    int games;
+    void add(boolean win) {
+      if (win) wins++;
+      games++;
+    }
+  }
+}

--- a/src/main/java/com/bestduo_BE/aggregate/application/AggregateBottomDuoMatchup.java
+++ b/src/main/java/com/bestduo_BE/aggregate/application/AggregateBottomDuoMatchup.java
@@ -4,6 +4,12 @@ import com.bestduo_BE.aggregate.infra.persistence.BottomDuoMatchupAggregator;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+/**
+ * @deprecated bottom_duo_raw self-join 기반 matchup upsert 경로. {@link AggregateBottomDuoFromMatch}
+ *     로 대체됨. {@code BottomDuoAggregateScheduler} 는 더 이상 이 클래스를 호출하지 않는다.
+ *     bottom_duo_raw 테이블 자체 제거 PR 에서 함께 제거 예정.
+ */
+@Deprecated
 @Service
 @RequiredArgsConstructor
 public class AggregateBottomDuoMatchup {

--- a/src/main/java/com/bestduo_BE/aggregate/application/AggregateBottomDuoStats.java
+++ b/src/main/java/com/bestduo_BE/aggregate/application/AggregateBottomDuoStats.java
@@ -5,6 +5,12 @@ import com.bestduo_BE.common.domain.model.Tier;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
+/**
+ * @deprecated bottom_duo_raw 기반 stat upsert 경로. {@link AggregateBottomDuoFromMatch} 로 대체됨.
+ *     {@code BottomDuoAggregateScheduler} 는 더 이상 이 클래스를 호출하지 않는다.
+ *     bottom_duo_raw 테이블 자체 제거 PR 에서 함께 제거 예정.
+ */
+@Deprecated
 @Service
 @RequiredArgsConstructor
 public class AggregateBottomDuoStats {

--- a/src/main/java/com/bestduo_BE/aggregate/infra/scheduler/BottomDuoAggregateScheduler.java
+++ b/src/main/java/com/bestduo_BE/aggregate/infra/scheduler/BottomDuoAggregateScheduler.java
@@ -1,7 +1,6 @@
 package com.bestduo_BE.aggregate.infra.scheduler;
 
-import com.bestduo_BE.aggregate.application.AggregateBottomDuoMatchup;
-import com.bestduo_BE.aggregate.application.AggregateBottomDuoStats;
+import com.bestduo_BE.aggregate.application.AggregateBottomDuoFromMatch;
 import com.bestduo_BE.aggregate.application.CleanupOldPatches;
 import com.bestduo_BE.common.application.PatchVersionService;
 import com.bestduo_BE.common.domain.model.Tier;
@@ -13,11 +12,15 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 /**
- * 매일 cron 시각에 최신 패치 기준으로 stat aggregate(+ ranking) × 5개 tier와 matchup aggregate를
- * 순차 실행한다.
+ * 매일 cron 시각에 최신 패치 기준으로 stat + matchup aggregate 를 {@code match.payload_json} 으로부터
+ * 직접 계산해 upsert 한다 ({@link AggregateBottomDuoFromMatch} 단일 경로).
  *
- * <p>대상 tier는 CHALLENGER ~ EMERALD 5개로 한정한다. 한 tier에서 예외가 발생해도 나머지 tier와
- * matchup 작업은 계속 진행한다 — 부분 실패가 전체 운영을 멈추지 않도록 한다.
+ * <p>대상 tier 는 CHALLENGER ~ EMERALD 5개로 한정한다. 한 tier 에서 예외가 발생해도 나머지 tier 와
+ * cleanup 단계는 계속 진행한다.
+ *
+ * <p>이전에는 {@code bottom_duo_raw} 위 SQL GROUP BY/self-join 으로 같은 결과를 만들었으나,
+ * 향후 lane 조합 확장을 위해 단일 경로로 통일했다. 검증 절차는 {@code docs/aggregate-from-match-verification.md}
+ * 참고.
  */
 @Component
 @Slf4j
@@ -34,8 +37,7 @@ public class BottomDuoAggregateScheduler {
   );
 
   private final PatchVersionService patchVersionService;
-  private final AggregateBottomDuoStats statUseCase;
-  private final AggregateBottomDuoMatchup matchupUseCase;
+  private final AggregateBottomDuoFromMatch fromMatchUseCase;
   private final CleanupOldPatches cleanupUseCase;
 
   @Scheduled(cron = "${aggregate.scheduler.cron:0 0 4 * * *}", zone = "Asia/Seoul")
@@ -51,19 +53,17 @@ public class BottomDuoAggregateScheduler {
 
     for (Tier tier : SCHEDULED_TIERS) {
       try {
-        AggregateBottomDuoStats.Result result = statUseCase.execute(patchVersion, tier);
-        log.info("[AggregateScheduler] stat tier={} affected={} rankings={}",
-            tier, result.affectedRows(), result.rankingsUpdated());
+        AggregateBottomDuoFromMatch.Result result =
+            fromMatchUseCase.execute(patchVersion, tier, true);
+        log.info(
+            "[AggregateScheduler] tier={} processed={} statKeys={} matchupKeys={}"
+                + " statTotalGames={} matchupTotalGames={} upserted={}/{}",
+            tier, result.matchesProcessed(), result.statKeys(), result.matchupKeys(),
+            result.statTotalGames(), result.matchupTotalGames(),
+            result.statUpserted(), result.matchupUpserted());
       } catch (Exception ex) {
-        log.error("[AggregateScheduler] stat aggregate failed tier={}", tier, ex);
+        log.error("[AggregateScheduler] aggregate failed tier={}", tier, ex);
       }
-    }
-
-    try {
-      AggregateBottomDuoMatchup.Result matchupResult = matchupUseCase.execute();
-      log.info("[AggregateScheduler] matchup affected={}", matchupResult.affectedRows());
-    } catch (Exception ex) {
-      log.error("[AggregateScheduler] matchup aggregate failed", ex);
     }
 
     try {

--- a/src/main/java/com/bestduo_BE/common/infra/persistence/repository/MatchJpaRepository.java
+++ b/src/main/java/com/bestduo_BE/common/infra/persistence/repository/MatchJpaRepository.java
@@ -2,6 +2,31 @@ package com.bestduo_BE.common.infra.persistence.repository;
 
 
 import com.bestduo_BE.common.infra.persistence.entity.Match;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
-public interface MatchJpaRepository extends JpaRepository<Match, String> {}
+public interface MatchJpaRepository extends JpaRepository<Match, String> {
+
+  /**
+   * (patch, collection_tier) 범위의 match 를 match_id keyset 기준으로 페이지네이션한다.
+   * <p>aggregate from match 경로에서 payload_json 을 메모리로 흘려보내며 처리하기 위함.
+   * <p>game_version 의 앞 두 토큰을 patch 로 매칭한다 (예: '15.23.1.2' → '15.23').
+   */
+  @Query(value = """
+      select *
+      from match
+      where collection_tier = :tier
+        and split_part(game_version, '.', 1) || '.' || split_part(game_version, '.', 2) = :patch
+        and match_id > :afterId
+      order by match_id asc
+      limit :pageSize
+      """, nativeQuery = true)
+  List<Match> findPageByTierAndPatch(
+      @Param("tier") String tier,
+      @Param("patch") String patch,
+      @Param("afterId") String afterId,
+      @Param("pageSize") int pageSize
+  );
+}

--- a/src/test/java/com/bestduo_BE/aggregate/application/AggregateBottomDuoFromMatchTest.java
+++ b/src/test/java/com/bestduo_BE/aggregate/application/AggregateBottomDuoFromMatchTest.java
@@ -1,0 +1,182 @@
+package com.bestduo_BE.aggregate.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyCollection;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.bestduo_BE.common.domain.model.BottomDuoRaw;
+import com.bestduo_BE.common.domain.model.Tier;
+import com.bestduo_BE.common.domain.service.BottomDuoExtractor;
+import com.bestduo_BE.common.infra.persistence.entity.Match;
+import com.bestduo_BE.common.infra.persistence.repository.MatchJpaRepository;
+import com.bestduo_BE.common.infra.riot.dto.RiotMatchDto;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.ParameterizedPreparedStatementSetter;
+import tools.jackson.databind.ObjectMapper;
+
+@ExtendWith(MockitoExtension.class)
+class AggregateBottomDuoFromMatchTest {
+
+  private static final String PATCH = "16.9";
+
+  @Mock private MatchJpaRepository matchRepository;
+  @Mock private BottomDuoExtractor extractor;
+  @Mock private ObjectMapper objectMapper;
+  @Mock private JdbcTemplate jdbcTemplate;
+
+  private AggregateBottomDuoFromMatch useCase;
+
+  @BeforeEach
+  void setUp() {
+    useCase = new AggregateBottomDuoFromMatch(matchRepository, extractor, objectMapper, jdbcTemplate);
+  }
+
+  @Test
+  @DisplayName("execute — 매치가 없으면 0건 처리하고 upsert 도 호출하지 않는다")
+  void execute_emptyResultFromRepo_returnsZeroProcessed() {
+    when(matchRepository.findPageByTierAndPatch(eq(Tier.EMERALD.name()), eq(PATCH), anyString(), anyInt()))
+        .thenReturn(List.of());
+
+    AggregateBottomDuoFromMatch.Result result = useCase.execute(PATCH, Tier.EMERALD, true);
+
+    assertThat(result.matchesProcessed()).isZero();
+    assertThat(result.statKeys()).isZero();
+    assertThat(result.matchupKeys()).isZero();
+    assertThat(result.statUpserted()).isZero();
+    assertThat(result.matchupUpserted()).isZero();
+    verifyNoInteractions(jdbcTemplate);
+    verifyNoInteractions(extractor);
+  }
+
+  @Test
+  @DisplayName("execute — 한 매치에서 양 팀 듀오가 나오면 stat 2키, matchup 양방향 2키를 누적한다")
+  void execute_singleMatchTwoDuos_accumulatesStatAndMatchup() throws Exception {
+    Match m = matchEntity("KR_1");
+    when(matchRepository.findPageByTierAndPatch(eq(Tier.EMERALD.name()), eq(PATCH), eq(""), anyInt()))
+        .thenReturn(List.of(m));
+    when(matchRepository.findPageByTierAndPatch(eq(Tier.EMERALD.name()), eq(PATCH), eq("KR_1"), anyInt()))
+        .thenReturn(List.of());
+    RiotMatchDto dto = stubDto();
+    when(objectMapper.readValue(any(String.class), eq(RiotMatchDto.class))).thenReturn(dto);
+    when(extractor.extract("KR_1", dto, Tier.EMERALD)).thenReturn(List.of(
+        new BottomDuoRaw("KR_1", 100, 222, 412, true, PATCH, Tier.EMERALD),
+        new BottomDuoRaw("KR_1", 200, 51, 201, false, PATCH, Tier.EMERALD)
+    ));
+
+    AggregateBottomDuoFromMatch.Result result = useCase.execute(PATCH, Tier.EMERALD, false);
+
+    assertThat(result.matchesProcessed()).isEqualTo(1);
+    assertThat(result.statKeys()).isEqualTo(2);          // (222,412), (51,201)
+    assertThat(result.matchupKeys()).isEqualTo(2);       // A->B, B->A
+    assertThat(result.statTotalGames()).isEqualTo(2L);
+    assertThat(result.matchupTotalGames()).isEqualTo(2L);
+    verifyNoInteractions(jdbcTemplate);                  // upsert=false
+  }
+
+  @Test
+  @DisplayName("execute — 같은 듀오 조합이 여러 매치에서 등장하면 wins/games 카운트가 누적된다")
+  void execute_multipleMatchesSameDuos_accumulatesCounts() throws Exception {
+    Match m1 = matchEntity("KR_1");
+    Match m2 = matchEntity("KR_2");
+    Match m3 = matchEntity("KR_3");
+    when(matchRepository.findPageByTierAndPatch(eq(Tier.EMERALD.name()), eq(PATCH), eq(""), anyInt()))
+        .thenReturn(List.of(m1, m2, m3));
+    when(matchRepository.findPageByTierAndPatch(eq(Tier.EMERALD.name()), eq(PATCH), eq("KR_3"), anyInt()))
+        .thenReturn(List.of());
+    RiotMatchDto dto = stubDto();
+    when(objectMapper.readValue(any(String.class), eq(RiotMatchDto.class))).thenReturn(dto);
+    // 같은 듀오(222,412) vs 같은 듀오(51,201) 가 3매치 — 222팀이 2승 1패
+    when(extractor.extract("KR_1", dto, Tier.EMERALD)).thenReturn(List.of(
+        new BottomDuoRaw("KR_1", 100, 222, 412, true, PATCH, Tier.EMERALD),
+        new BottomDuoRaw("KR_1", 200, 51, 201, false, PATCH, Tier.EMERALD)
+    ));
+    when(extractor.extract("KR_2", dto, Tier.EMERALD)).thenReturn(List.of(
+        new BottomDuoRaw("KR_2", 100, 222, 412, true, PATCH, Tier.EMERALD),
+        new BottomDuoRaw("KR_2", 200, 51, 201, false, PATCH, Tier.EMERALD)
+    ));
+    when(extractor.extract("KR_3", dto, Tier.EMERALD)).thenReturn(List.of(
+        new BottomDuoRaw("KR_3", 100, 222, 412, false, PATCH, Tier.EMERALD),
+        new BottomDuoRaw("KR_3", 200, 51, 201, true, PATCH, Tier.EMERALD)
+    ));
+
+    AggregateBottomDuoFromMatch.Result result = useCase.execute(PATCH, Tier.EMERALD, false);
+
+    assertThat(result.matchesProcessed()).isEqualTo(3);
+    assertThat(result.statKeys()).isEqualTo(2);            // 여전히 같은 두 듀오
+    assertThat(result.matchupKeys()).isEqualTo(2);         // A->B, B->A
+    assertThat(result.statTotalGames()).isEqualTo(6L);     // 각 듀오 3게임씩
+    assertThat(result.matchupTotalGames()).isEqualTo(6L);  // 양방향 합산
+  }
+
+  @Test
+  @DisplayName("execute — upsert=true 면 stat/matchup SQL 을 JdbcTemplate.batchUpdate 로 실행한다")
+  void execute_upsertTrue_callsJdbcTemplateBatchUpdate() throws Exception {
+    Match m = matchEntity("KR_1");
+    when(matchRepository.findPageByTierAndPatch(eq(Tier.EMERALD.name()), eq(PATCH), eq(""), anyInt()))
+        .thenReturn(List.of(m));
+    when(matchRepository.findPageByTierAndPatch(eq(Tier.EMERALD.name()), eq(PATCH), eq("KR_1"), anyInt()))
+        .thenReturn(List.of());
+    RiotMatchDto dto = stubDto();
+    when(objectMapper.readValue(any(String.class), eq(RiotMatchDto.class))).thenReturn(dto);
+    when(extractor.extract("KR_1", dto, Tier.EMERALD)).thenReturn(List.of(
+        new BottomDuoRaw("KR_1", 100, 222, 412, true, PATCH, Tier.EMERALD),
+        new BottomDuoRaw("KR_1", 200, 51, 201, false, PATCH, Tier.EMERALD)
+    ));
+
+    AggregateBottomDuoFromMatch.Result result = useCase.execute(PATCH, Tier.EMERALD, true);
+
+    assertThat(result.statUpserted()).isEqualTo(2);
+    assertThat(result.matchupUpserted()).isEqualTo(2);
+    // stat + matchup 두 종류의 SQL 이 호출되어야 함
+    verify(jdbcTemplate, atLeastOnce()).batchUpdate(
+        anyString(), anyCollection(), anyInt(), any(ParameterizedPreparedStatementSetter.class));
+  }
+
+  @Test
+  @DisplayName("execute — 여러 페이지에 걸쳐 매치가 있을 때 keyset 페이지네이션으로 모두 순회한다")
+  void execute_paginatesAcrossMultiplePages() throws Exception {
+    Match m1 = matchEntity("KR_1");
+    Match m2 = matchEntity("KR_2");
+    // 첫 페이지: KR_1
+    when(matchRepository.findPageByTierAndPatch(eq(Tier.EMERALD.name()), eq(PATCH), eq(""), anyInt()))
+        .thenReturn(List.of(m1));
+    // 두번째 페이지: KR_2 (커서가 KR_1 으로 넘어옴)
+    when(matchRepository.findPageByTierAndPatch(eq(Tier.EMERALD.name()), eq(PATCH), eq("KR_1"), anyInt()))
+        .thenReturn(List.of(m2));
+    // 세번째 페이지: 종료
+    when(matchRepository.findPageByTierAndPatch(eq(Tier.EMERALD.name()), eq(PATCH), eq("KR_2"), anyInt()))
+        .thenReturn(List.of());
+    RiotMatchDto dto = stubDto();
+    when(objectMapper.readValue(any(String.class), eq(RiotMatchDto.class))).thenReturn(dto);
+    when(extractor.extract(any(), any(), any())).thenReturn(List.of());
+
+    AggregateBottomDuoFromMatch.Result result = useCase.execute(PATCH, Tier.EMERALD, false);
+
+    assertThat(result.matchesProcessed()).isEqualTo(2);
+  }
+
+  private Match matchEntity(String matchId) {
+    return Match.builder()
+        .matchId(matchId)
+        .payloadJson("{}")
+        .build();
+  }
+
+  private RiotMatchDto stubDto() {
+    return new RiotMatchDto(null, null);
+  }
+}

--- a/src/test/java/com/bestduo_BE/aggregate/infra/scheduler/BottomDuoAggregateSchedulerTest.java
+++ b/src/test/java/com/bestduo_BE/aggregate/infra/scheduler/BottomDuoAggregateSchedulerTest.java
@@ -3,14 +3,12 @@ package com.bestduo_BE.aggregate.infra.scheduler;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
-import com.bestduo_BE.aggregate.application.AggregateBottomDuoMatchup;
-import com.bestduo_BE.aggregate.application.AggregateBottomDuoStats;
+import com.bestduo_BE.aggregate.application.AggregateBottomDuoFromMatch;
 import com.bestduo_BE.aggregate.application.CleanupOldPatches;
 import com.bestduo_BE.common.application.PatchVersionService;
 import com.bestduo_BE.common.domain.model.Tier;
@@ -42,10 +40,7 @@ class BottomDuoAggregateSchedulerTest {
   private PatchVersionService patchVersionService;
 
   @Mock
-  private AggregateBottomDuoStats statUseCase;
-
-  @Mock
-  private AggregateBottomDuoMatchup matchupUseCase;
+  private AggregateBottomDuoFromMatch fromMatchUseCase;
 
   @Mock
   private CleanupOldPatches cleanupUseCase;
@@ -55,90 +50,64 @@ class BottomDuoAggregateSchedulerTest {
   @BeforeEach
   void setUp() {
     scheduler = new BottomDuoAggregateScheduler(
-        patchVersionService, statUseCase, matchupUseCase, cleanupUseCase);
+        patchVersionService, fromMatchUseCase, cleanupUseCase);
   }
 
   @Test
-  @DisplayName("run — 등록된 patch가 없으면 stat/matchup/cleanup 모두 호출하지 않는다")
+  @DisplayName("run — 등록된 patch가 없으면 fromMatch/cleanup 모두 호출하지 않는다")
   void runSkipsWhenNoPatchRegistered() {
     when(patchVersionService.currentPatch()).thenReturn(Optional.empty());
 
     scheduler.run();
 
-    verifyNoInteractions(statUseCase);
-    verifyNoInteractions(matchupUseCase);
+    verifyNoInteractions(fromMatchUseCase);
     verifyNoInteractions(cleanupUseCase);
   }
 
   @Test
-  @DisplayName("run — CHALLENGER~EMERALD 5개 tier 후 matchup, 마지막으로 cleanup을 호출한다")
-  void runInvokesAllFiveTiersThenMatchupThenCleanup() {
+  @DisplayName("run — CHALLENGER~EMERALD 5개 tier 에 대해 fromMatch 를 upsert=true 로 호출 후 cleanup 을 호출한다")
+  void runInvokesAllFiveTiersThenCleanup() {
     when(patchVersionService.currentPatch())
         .thenReturn(Optional.of(PatchVersion.of(PATCH, OffsetDateTime.now())));
-    when(statUseCase.execute(eq(PATCH), any(Tier.class)))
-        .thenReturn(new AggregateBottomDuoStats.Result(10, 5));
-    when(matchupUseCase.execute())
-        .thenReturn(new AggregateBottomDuoMatchup.Result(20));
+    when(fromMatchUseCase.execute(eq(PATCH), any(Tier.class), eq(true)))
+        .thenReturn(new AggregateBottomDuoFromMatch.Result(10, 5, 5, 5, 5, 10L, 10L));
     when(cleanupUseCase.execute())
         .thenReturn(new CleanupOldPatches.Result(1, 2, 3, List.of(PATCH)));
 
     scheduler.run();
 
     ArgumentCaptor<Tier> tierCaptor = ArgumentCaptor.forClass(Tier.class);
-    verify(statUseCase, times(5)).execute(eq(PATCH), tierCaptor.capture());
+    verify(fromMatchUseCase, times(5)).execute(eq(PATCH), tierCaptor.capture(), eq(true));
     assertThat(tierCaptor.getAllValues()).containsExactlyElementsOf(EXPECTED_TIERS);
-    verify(matchupUseCase).execute();
     verify(cleanupUseCase).execute();
   }
 
   @Test
-  @DisplayName("run — 중간 tier에서 예외가 발생해도 나머지 tier와 matchup은 계속 진행한다")
+  @DisplayName("run — 중간 tier 에서 예외가 발생해도 나머지 tier 와 cleanup 은 계속 진행한다")
   void runContinuesAfterTierFailure() {
     when(patchVersionService.currentPatch())
         .thenReturn(Optional.of(PatchVersion.of(PATCH, OffsetDateTime.now())));
-    when(statUseCase.execute(eq(PATCH), eq(Tier.CHALLENGER)))
-        .thenReturn(new AggregateBottomDuoStats.Result(1, 1));
-    when(statUseCase.execute(eq(PATCH), eq(Tier.GRANDMASTER)))
-        .thenReturn(new AggregateBottomDuoStats.Result(2, 2));
-    when(statUseCase.execute(eq(PATCH), eq(Tier.MASTER)))
-        .thenThrow(new RuntimeException("simulated DB error"));
-    when(statUseCase.execute(eq(PATCH), eq(Tier.DIAMOND)))
-        .thenReturn(new AggregateBottomDuoStats.Result(3, 3));
-    when(statUseCase.execute(eq(PATCH), eq(Tier.EMERALD)))
-        .thenReturn(new AggregateBottomDuoStats.Result(4, 4));
-    when(matchupUseCase.execute())
-        .thenReturn(new AggregateBottomDuoMatchup.Result(50));
+    when(fromMatchUseCase.execute(eq(PATCH), eq(Tier.CHALLENGER), eq(true)))
+        .thenReturn(new AggregateBottomDuoFromMatch.Result(1, 1, 1, 1, 1, 1L, 1L));
+    when(fromMatchUseCase.execute(eq(PATCH), eq(Tier.GRANDMASTER), eq(true)))
+        .thenReturn(new AggregateBottomDuoFromMatch.Result(2, 2, 2, 2, 2, 2L, 2L));
+    when(fromMatchUseCase.execute(eq(PATCH), eq(Tier.MASTER), eq(true)))
+        .thenThrow(new RuntimeException("simulated extract error"));
+    when(fromMatchUseCase.execute(eq(PATCH), eq(Tier.DIAMOND), eq(true)))
+        .thenReturn(new AggregateBottomDuoFromMatch.Result(3, 3, 3, 3, 3, 3L, 3L));
+    when(fromMatchUseCase.execute(eq(PATCH), eq(Tier.EMERALD), eq(true)))
+        .thenReturn(new AggregateBottomDuoFromMatch.Result(4, 4, 4, 4, 4, 4L, 4L));
     when(cleanupUseCase.execute())
         .thenReturn(new CleanupOldPatches.Result(0, 0, 0, List.of(PATCH)));
 
     scheduler.run();
 
-    verify(statUseCase).execute(PATCH, Tier.CHALLENGER);
-    verify(statUseCase).execute(PATCH, Tier.GRANDMASTER);
-    verify(statUseCase).execute(PATCH, Tier.MASTER);
-    verify(statUseCase).execute(PATCH, Tier.DIAMOND);
-    verify(statUseCase).execute(PATCH, Tier.EMERALD);
-    verify(matchupUseCase).execute();
+    verify(fromMatchUseCase).execute(PATCH, Tier.CHALLENGER, true);
+    verify(fromMatchUseCase).execute(PATCH, Tier.GRANDMASTER, true);
+    verify(fromMatchUseCase).execute(PATCH, Tier.MASTER, true);
+    verify(fromMatchUseCase).execute(PATCH, Tier.DIAMOND, true);
+    verify(fromMatchUseCase).execute(PATCH, Tier.EMERALD, true);
     verify(cleanupUseCase).execute();
-  }
-
-  @Test
-  @DisplayName("run — matchup 호출에서 예외가 발생해도 cleanup은 호출되고 스케줄러는 정상 종료한다")
-  void runSwallowsMatchupFailure() {
-    when(patchVersionService.currentPatch())
-        .thenReturn(Optional.of(PatchVersion.of(PATCH, OffsetDateTime.now())));
-    when(statUseCase.execute(eq(PATCH), any(Tier.class)))
-        .thenReturn(new AggregateBottomDuoStats.Result(1, 1));
-    when(matchupUseCase.execute())
-        .thenThrow(new RuntimeException("simulated matchup error"));
-    when(cleanupUseCase.execute())
-        .thenReturn(new CleanupOldPatches.Result(0, 0, 0, List.of(PATCH)));
-
-    scheduler.run();
-
-    verify(matchupUseCase).execute();
-    verify(cleanupUseCase).execute();
-    verify(statUseCase, never()).execute(PATCH, Tier.ALL_TIERS);
   }
 
   @Test
@@ -146,10 +115,8 @@ class BottomDuoAggregateSchedulerTest {
   void runSwallowsCleanupFailure() {
     when(patchVersionService.currentPatch())
         .thenReturn(Optional.of(PatchVersion.of(PATCH, OffsetDateTime.now())));
-    when(statUseCase.execute(eq(PATCH), any(Tier.class)))
-        .thenReturn(new AggregateBottomDuoStats.Result(1, 1));
-    when(matchupUseCase.execute())
-        .thenReturn(new AggregateBottomDuoMatchup.Result(10));
+    when(fromMatchUseCase.execute(eq(PATCH), any(Tier.class), eq(true)))
+        .thenReturn(new AggregateBottomDuoFromMatch.Result(1, 1, 1, 1, 1, 1L, 1L));
     when(cleanupUseCase.execute())
         .thenThrow(new RuntimeException("simulated cleanup error"));
 


### PR DESCRIPTION
## Summary

Issue #75 의 PR 2.

- `cron` 의 stat / matchup 집계 경로를 **match.payload_json 위 메모리 누적** 단일 경로로 통일했다.
- 기존 `bottom_duo_raw` 위 SQL GROUP BY / self-join 경로(`AggregateBottomDuoStats`, `AggregateBottomDuoMatchup`)는 `@Deprecated` 표시. 다음 PR(`bottom_duo_raw` 테이블 제거)에서 함께 삭제.
- 매치업 self-join 자체가 사라져 알고리즘이 O(N) 으로 단순해짐 (한 매치당 양 팀 데이터를 메모리에서 한 번만 보고 pair 생성).

## 주요 변경

### 신규
- `AggregateBottomDuoFromMatch` — 단일 use case. `(patch, tier)` 범위 매치를 keyset 페이지네이션으로 흘려보내며 `BottomDuoExtractor` 재사용해 stat/matchup 을 동시 누적. `JdbcTemplate.batchUpdate` 으로 bulk upsert.
- `MatchJpaRepository.findPageByTierAndPatch` — `(collection_tier, split_part(game_version,...))` 필터 + match_id keyset 페이지네이션.
- `docs/aggregate-from-match-verification.md` — 첫 cron 후 raw vs match 결과를 수동 SQL 로 비교하는 1회성 cutover 검증 절차.

### 단순화
- `BottomDuoAggregateScheduler` — fromMatch 단일 경로만 호출하도록 정리. source flag 도입 없음(over-engineering 회피).

### Deprecated
- `AggregateBottomDuoStats` (raw 기반 stat upsert)
- `AggregateBottomDuoMatchup` (raw 기반 matchup self-join upsert)

## 메모리 / 성능 추정

| 항목 | worst-case (EMERALD + 16.8) |
|---|---|
| 처리 매치 수 | ~130k |
| stat accumulator 메모리 | < 1 MB |
| matchup accumulator 메모리 | ~7 MB |
| 페이지 버퍼 (1000 match) | ~10 MB |
| **per-tier peak** | **~20 MB** |
| Railway 추가 비용 | < $0.01/월 |

Tier 별로 누적기를 재생성하므로 peak 은 한 tier 분만. 첫 운영 사이클에서 `heapMB` 와 `statKeys` / `matchupKeys` 가 로그에 찍히도록 인스트루멘트되어 있어 실측 검증 가능.

## 검증 전략

`docs/aggregate-from-match-verification.md` 에 정리된 SQL 두 개를 첫 cron 직후 1회 실행해 raw 기반 결과와 match 기반 결과의 정합성을 확인한다. 둘 다 0 row 반환이 기대치.

## Test plan

- [x] TDD 사이클: 5개 use case 테스트 + 4개 스케줄러 테스트
- [x] `./gradlew test` — 335/337 통과 (실패 2건은 Docker 데몬 미실행에 따른 기존 Testcontainers IT, 본 변경과 무관)
- [ ] 배포 후 첫 cron 의 `[AggregateScheduler]` 로그에서 tier 별 `statKeys` / `matchupKeys` / `statTotalGames` / `matchupTotalGames` / `heapMB` 확인
- [ ] `docs/aggregate-from-match-verification.md` 의 SQL 두 개 실행 → 0 row 확인
- [ ] `/bottom-duo/stats` API 응답이 평소와 동일한지 스팟 체크

## Out of scope

- `bottom_duo_raw` 테이블 / `BottomDuoRawSaver` / `IngestMatchDetail` 의 raw 저장 호출 제거 → **PR 3**
- `AggregateBottomDuoStats` / `AggregateBottomDuoMatchup` 클래스 자체 삭제 → **PR 3**
- 옛 patch 매치 정리 (retention 밖 `match` row) → 별도 트랙