### PR TITLE
fix(aggregate): scheduler에 ranking 단계 추가 + 수동 재계산 admin endpoint

### DIFF
--- a/src/main/java/com/bestduo_BE/aggregate/infra/scheduler/BottomDuoAggregateScheduler.java
+++ b/src/main/java/com/bestduo_BE/aggregate/infra/scheduler/BottomDuoAggregateScheduler.java
@@ -2,6 +2,7 @@ package com.bestduo_BE.aggregate.infra.scheduler;
 
 import com.bestduo_BE.aggregate.application.AggregateBottomDuoFromMatch;
 import com.bestduo_BE.aggregate.application.CleanupOldPatches;
+import com.bestduo_BE.aggregate.application.ComputeBottomDuoRanking;
 import com.bestduo_BE.common.application.PatchVersionService;
 import com.bestduo_BE.common.domain.model.Tier;
 import java.util.List;
@@ -13,10 +14,10 @@ import org.springframework.stereotype.Component;
 
 /**
  * 매일 cron 시각에 최신 패치 기준으로 stat + matchup aggregate 를 {@code match.payload_json} 으로부터
- * 직접 계산해 upsert 한다 ({@link AggregateBottomDuoFromMatch} 단일 경로).
+ * 직접 계산해 upsert 한 뒤, 같은 tier 에 대해 ranking 까지 계산해 PENDING 행을 RANKED 로 승격시킨다.
  *
- * <p>대상 tier 는 CHALLENGER ~ EMERALD 5개로 한정한다. 한 tier 에서 예외가 발생해도 나머지 tier 와
- * cleanup 단계는 계속 진행한다.
+ * <p>대상 tier 는 CHALLENGER ~ EMERALD 5개로 한정한다. 한 tier 의 aggregate 가 실패하면 해당 tier 의
+ * ranking 은 건너뛰지만, 나머지 tier 와 cleanup 단계는 계속 진행한다.
  */
 @Component
 @Slf4j
@@ -34,6 +35,7 @@ public class BottomDuoAggregateScheduler {
 
   private final PatchVersionService patchVersionService;
   private final AggregateBottomDuoFromMatch fromMatchUseCase;
+  private final ComputeBottomDuoRanking rankingUseCase;
   private final CleanupOldPatches cleanupUseCase;
 
   @Scheduled(cron = "${aggregate.scheduler.cron:0 0 4 * * *}", zone = "Asia/Seoul")
@@ -48,6 +50,7 @@ public class BottomDuoAggregateScheduler {
     log.info("[AggregateScheduler] start patch={}", patchVersion);
 
     for (Tier tier : SCHEDULED_TIERS) {
+      boolean aggregateSucceeded = false;
       try {
         AggregateBottomDuoFromMatch.Result result =
             fromMatchUseCase.execute(patchVersion, tier, true);
@@ -57,8 +60,22 @@ public class BottomDuoAggregateScheduler {
             tier, result.matchesProcessed(), result.statKeys(), result.matchupKeys(),
             result.statTotalGames(), result.matchupTotalGames(),
             result.statUpserted(), result.matchupUpserted());
+        aggregateSucceeded = true;
       } catch (Exception ex) {
         log.error("[AggregateScheduler] aggregate failed tier={}", tier, ex);
+      }
+
+      if (!aggregateSucceeded) {
+        continue;
+      }
+
+      try {
+        ComputeBottomDuoRanking.Result rankingResult =
+            rankingUseCase.execute(patchVersion, tier.name());
+        log.info("[AggregateScheduler] ranking tier={} updatedRows={}",
+            tier, rankingResult.updatedRows());
+      } catch (Exception ex) {
+        log.error("[AggregateScheduler] ranking failed tier={}", tier, ex);
       }
     }
 

--- a/src/main/java/com/bestduo_BE/aggregate/presentation/api/AggregateAdminController.java
+++ b/src/main/java/com/bestduo_BE/aggregate/presentation/api/AggregateAdminController.java
@@ -1,0 +1,61 @@
+package com.bestduo_BE.aggregate.presentation.api;
+
+import com.bestduo_BE.aggregate.application.ComputeBottomDuoRanking;
+import com.bestduo_BE.common.domain.model.Tier;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Aggregate 영역의 일회성 수동 트리거.
+ *
+ * <p>주 용도: 스케줄러가 aggregate 만 수행하고 ranking 호출이 빠졌던 회귀(regression) 이후,
+ * 해당 patch 의 PENDING 행을 RANKED 로 승격시키기 위한 복구 endpoint.
+ *
+ * <p>인증: {@code AdminApiKeyInterceptor} 가 {@code X-Admin-Key} 헤더를 검증한다.
+ */
+@RestController
+@RequestMapping("/admin/aggregate")
+@RequiredArgsConstructor
+@Slf4j
+public class AggregateAdminController {
+
+  private static final List<Tier> DEFAULT_TIERS = List.of(
+      Tier.CHALLENGER, Tier.GRANDMASTER, Tier.MASTER, Tier.DIAMOND, Tier.EMERALD);
+
+  private final ComputeBottomDuoRanking rankingUseCase;
+
+  @PostMapping("/recompute-ranking")
+  public RecomputeRankingResponse recomputeRanking(
+      @RequestParam String patch,
+      @RequestParam(required = false) List<Tier> tiers) {
+
+    List<Tier> targetTiers = (tiers == null || tiers.isEmpty()) ? DEFAULT_TIERS : tiers;
+    List<TierResult> results = new ArrayList<>();
+    int totalUpdated = 0;
+
+    for (Tier tier : targetTiers) {
+      try {
+        ComputeBottomDuoRanking.Result r = rankingUseCase.execute(patch, tier.name());
+        results.add(new TierResult(tier.name(), r.updatedRows(), null));
+        totalUpdated += r.updatedRows();
+      } catch (Exception ex) {
+        log.error("[AggregateAdmin] ranking failed patch={} tier={}", patch, tier, ex);
+        results.add(new TierResult(tier.name(), 0, ex.getMessage()));
+      }
+    }
+
+    log.info("[AggregateAdmin] recompute-ranking complete patch={} tiers={} totalUpdated={}",
+        patch, targetTiers, totalUpdated);
+    return new RecomputeRankingResponse(patch, totalUpdated, results);
+  }
+
+  public record RecomputeRankingResponse(String patch, int totalUpdated, List<TierResult> results) {}
+
+  public record TierResult(String tier, int updatedRows, String error) {}
+}

--- a/src/test/java/com/bestduo_BE/aggregate/infra/scheduler/BottomDuoAggregateSchedulerTest.java
+++ b/src/test/java/com/bestduo_BE/aggregate/infra/scheduler/BottomDuoAggregateSchedulerTest.java
@@ -3,6 +3,7 @@ package com.bestduo_BE.aggregate.infra.scheduler;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoInteractions;
@@ -10,6 +11,7 @@ import static org.mockito.Mockito.when;
 
 import com.bestduo_BE.aggregate.application.AggregateBottomDuoFromMatch;
 import com.bestduo_BE.aggregate.application.CleanupOldPatches;
+import com.bestduo_BE.aggregate.application.ComputeBottomDuoRanking;
 import com.bestduo_BE.common.application.PatchVersionService;
 import com.bestduo_BE.common.domain.model.Tier;
 import com.bestduo_BE.common.infra.persistence.entity.PatchVersion;
@@ -43,6 +45,9 @@ class BottomDuoAggregateSchedulerTest {
   private AggregateBottomDuoFromMatch fromMatchUseCase;
 
   @Mock
+  private ComputeBottomDuoRanking rankingUseCase;
+
+  @Mock
   private CleanupOldPatches cleanupUseCase;
 
   private BottomDuoAggregateScheduler scheduler;
@@ -50,27 +55,30 @@ class BottomDuoAggregateSchedulerTest {
   @BeforeEach
   void setUp() {
     scheduler = new BottomDuoAggregateScheduler(
-        patchVersionService, fromMatchUseCase, cleanupUseCase);
+        patchVersionService, fromMatchUseCase, rankingUseCase, cleanupUseCase);
   }
 
   @Test
-  @DisplayName("run — 등록된 patch가 없으면 fromMatch/cleanup 모두 호출하지 않는다")
+  @DisplayName("run — 등록된 patch가 없으면 fromMatch/ranking/cleanup 모두 호출하지 않는다")
   void runSkipsWhenNoPatchRegistered() {
     when(patchVersionService.currentPatch()).thenReturn(Optional.empty());
 
     scheduler.run();
 
     verifyNoInteractions(fromMatchUseCase);
+    verifyNoInteractions(rankingUseCase);
     verifyNoInteractions(cleanupUseCase);
   }
 
   @Test
-  @DisplayName("run — CHALLENGER~EMERALD 5개 tier 에 대해 fromMatch 를 upsert=true 로 호출 후 cleanup 을 호출한다")
-  void runInvokesAllFiveTiersThenCleanup() {
+  @DisplayName("run — CHALLENGER~EMERALD 5개 tier 에 대해 fromMatch → ranking 순으로 호출 후 cleanup 을 호출한다")
+  void runInvokesFromMatchThenRankingForAllFiveTiersThenCleanup() {
     when(patchVersionService.currentPatch())
         .thenReturn(Optional.of(PatchVersion.of(PATCH, OffsetDateTime.now())));
     when(fromMatchUseCase.execute(eq(PATCH), any(Tier.class), eq(true)))
         .thenReturn(new AggregateBottomDuoFromMatch.Result(10, 5, 5, 5, 5, 10L, 10L));
+    when(rankingUseCase.execute(eq(PATCH), any(String.class)))
+        .thenReturn(new ComputeBottomDuoRanking.Result(PATCH, 5));
     when(cleanupUseCase.execute())
         .thenReturn(new CleanupOldPatches.Result(1, 2, List.of(PATCH)));
 
@@ -79,12 +87,18 @@ class BottomDuoAggregateSchedulerTest {
     ArgumentCaptor<Tier> tierCaptor = ArgumentCaptor.forClass(Tier.class);
     verify(fromMatchUseCase, times(5)).execute(eq(PATCH), tierCaptor.capture(), eq(true));
     assertThat(tierCaptor.getAllValues()).containsExactlyElementsOf(EXPECTED_TIERS);
+
+    ArgumentCaptor<String> rankingTierCaptor = ArgumentCaptor.forClass(String.class);
+    verify(rankingUseCase, times(5)).execute(eq(PATCH), rankingTierCaptor.capture());
+    assertThat(rankingTierCaptor.getAllValues())
+        .containsExactlyElementsOf(EXPECTED_TIERS.stream().map(Tier::name).toList());
+
     verify(cleanupUseCase).execute();
   }
 
   @Test
-  @DisplayName("run — 중간 tier 에서 예외가 발생해도 나머지 tier 와 cleanup 은 계속 진행한다")
-  void runContinuesAfterTierFailure() {
+  @DisplayName("run — fromMatch 가 예외를 던진 tier 는 ranking 을 건너뛰고 다음 tier 로 진행한다")
+  void runSkipsRankingWhenFromMatchFails() {
     when(patchVersionService.currentPatch())
         .thenReturn(Optional.of(PatchVersion.of(PATCH, OffsetDateTime.now())));
     when(fromMatchUseCase.execute(eq(PATCH), eq(Tier.CHALLENGER), eq(true)))
@@ -97,16 +111,45 @@ class BottomDuoAggregateSchedulerTest {
         .thenReturn(new AggregateBottomDuoFromMatch.Result(3, 3, 3, 3, 3, 3L, 3L));
     when(fromMatchUseCase.execute(eq(PATCH), eq(Tier.EMERALD), eq(true)))
         .thenReturn(new AggregateBottomDuoFromMatch.Result(4, 4, 4, 4, 4, 4L, 4L));
+    when(rankingUseCase.execute(eq(PATCH), any(String.class)))
+        .thenReturn(new ComputeBottomDuoRanking.Result(PATCH, 1));
     when(cleanupUseCase.execute())
         .thenReturn(new CleanupOldPatches.Result(0, 0, List.of(PATCH)));
 
     scheduler.run();
 
-    verify(fromMatchUseCase).execute(PATCH, Tier.CHALLENGER, true);
-    verify(fromMatchUseCase).execute(PATCH, Tier.GRANDMASTER, true);
-    verify(fromMatchUseCase).execute(PATCH, Tier.MASTER, true);
-    verify(fromMatchUseCase).execute(PATCH, Tier.DIAMOND, true);
-    verify(fromMatchUseCase).execute(PATCH, Tier.EMERALD, true);
+    verify(rankingUseCase).execute(PATCH, Tier.CHALLENGER.name());
+    verify(rankingUseCase).execute(PATCH, Tier.GRANDMASTER.name());
+    verify(rankingUseCase, never()).execute(PATCH, Tier.MASTER.name());
+    verify(rankingUseCase).execute(PATCH, Tier.DIAMOND.name());
+    verify(rankingUseCase).execute(PATCH, Tier.EMERALD.name());
+    verify(cleanupUseCase).execute();
+  }
+
+  @Test
+  @DisplayName("run — ranking 에서 예외가 발생해도 나머지 tier 와 cleanup 은 계속 진행한다")
+  void runContinuesAfterRankingFailure() {
+    when(patchVersionService.currentPatch())
+        .thenReturn(Optional.of(PatchVersion.of(PATCH, OffsetDateTime.now())));
+    when(fromMatchUseCase.execute(eq(PATCH), any(Tier.class), eq(true)))
+        .thenReturn(new AggregateBottomDuoFromMatch.Result(1, 1, 1, 1, 1, 1L, 1L));
+    when(rankingUseCase.execute(eq(PATCH), eq(Tier.MASTER.name())))
+        .thenThrow(new RuntimeException("simulated ranking error"));
+    when(rankingUseCase.execute(eq(PATCH), eq(Tier.CHALLENGER.name())))
+        .thenReturn(new ComputeBottomDuoRanking.Result(PATCH, 1));
+    when(rankingUseCase.execute(eq(PATCH), eq(Tier.GRANDMASTER.name())))
+        .thenReturn(new ComputeBottomDuoRanking.Result(PATCH, 1));
+    when(rankingUseCase.execute(eq(PATCH), eq(Tier.DIAMOND.name())))
+        .thenReturn(new ComputeBottomDuoRanking.Result(PATCH, 1));
+    when(rankingUseCase.execute(eq(PATCH), eq(Tier.EMERALD.name())))
+        .thenReturn(new ComputeBottomDuoRanking.Result(PATCH, 1));
+    when(cleanupUseCase.execute())
+        .thenReturn(new CleanupOldPatches.Result(0, 0, List.of(PATCH)));
+
+    scheduler.run();
+
+    verify(fromMatchUseCase, times(5)).execute(eq(PATCH), any(Tier.class), eq(true));
+    verify(rankingUseCase, times(5)).execute(eq(PATCH), any(String.class));
     verify(cleanupUseCase).execute();
   }
 
@@ -117,6 +160,8 @@ class BottomDuoAggregateSchedulerTest {
         .thenReturn(Optional.of(PatchVersion.of(PATCH, OffsetDateTime.now())));
     when(fromMatchUseCase.execute(eq(PATCH), any(Tier.class), eq(true)))
         .thenReturn(new AggregateBottomDuoFromMatch.Result(1, 1, 1, 1, 1, 1L, 1L));
+    when(rankingUseCase.execute(eq(PATCH), any(String.class)))
+        .thenReturn(new ComputeBottomDuoRanking.Result(PATCH, 1));
     when(cleanupUseCase.execute())
         .thenThrow(new RuntimeException("simulated cleanup error"));
 

--- a/src/test/java/com/bestduo_BE/aggregate/presentation/api/AggregateAdminControllerTest.java
+++ b/src/test/java/com/bestduo_BE/aggregate/presentation/api/AggregateAdminControllerTest.java
@@ -1,0 +1,108 @@
+package com.bestduo_BE.aggregate.presentation.api;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.then;
+import static org.mockito.Mockito.never;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.bestduo_BE.aggregate.application.ComputeBottomDuoRanking;
+import com.bestduo_BE.common.domain.model.Tier;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.webmvc.test.autoconfigure.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(AggregateAdminController.class)
+class AggregateAdminControllerTest {
+
+  private static final String PATCH = "16.10";
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @MockitoBean
+  private ComputeBottomDuoRanking rankingUseCase;
+
+  @Test
+  @DisplayName("POST /admin/aggregate/recompute-ranking — tiers 미지정 시 CHALLENGER~EMERALD 5개 tier 전부 실행")
+  void recomputeRanking_defaultTiers_invokesAllFiveTiers() throws Exception {
+    given(rankingUseCase.execute(eq(PATCH), eq(Tier.CHALLENGER.name())))
+        .willReturn(new ComputeBottomDuoRanking.Result(PATCH, 10));
+    given(rankingUseCase.execute(eq(PATCH), eq(Tier.GRANDMASTER.name())))
+        .willReturn(new ComputeBottomDuoRanking.Result(PATCH, 20));
+    given(rankingUseCase.execute(eq(PATCH), eq(Tier.MASTER.name())))
+        .willReturn(new ComputeBottomDuoRanking.Result(PATCH, 2053));
+    given(rankingUseCase.execute(eq(PATCH), eq(Tier.DIAMOND.name())))
+        .willReturn(new ComputeBottomDuoRanking.Result(PATCH, 1781));
+    given(rankingUseCase.execute(eq(PATCH), eq(Tier.EMERALD.name())))
+        .willReturn(new ComputeBottomDuoRanking.Result(PATCH, 0));
+
+    mockMvc.perform(post("/admin/aggregate/recompute-ranking")
+            .header("X-Admin-Key", "test-admin-key")
+            .param("patch", PATCH))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.patch").value(PATCH))
+        .andExpect(jsonPath("$.totalUpdated").value(10 + 20 + 2053 + 1781 + 0))
+        .andExpect(jsonPath("$.results.length()").value(5))
+        .andExpect(jsonPath("$.results[2].tier").value("MASTER"))
+        .andExpect(jsonPath("$.results[2].updatedRows").value(2053));
+
+    then(rankingUseCase).should().execute(PATCH, Tier.CHALLENGER.name());
+    then(rankingUseCase).should().execute(PATCH, Tier.GRANDMASTER.name());
+    then(rankingUseCase).should().execute(PATCH, Tier.MASTER.name());
+    then(rankingUseCase).should().execute(PATCH, Tier.DIAMOND.name());
+    then(rankingUseCase).should().execute(PATCH, Tier.EMERALD.name());
+  }
+
+  @Test
+  @DisplayName("POST /admin/aggregate/recompute-ranking — tiers 지정 시 해당 tier 만 실행")
+  void recomputeRanking_specifiedTiers_invokesOnlyThose() throws Exception {
+    given(rankingUseCase.execute(eq(PATCH), eq(Tier.MASTER.name())))
+        .willReturn(new ComputeBottomDuoRanking.Result(PATCH, 2053));
+    given(rankingUseCase.execute(eq(PATCH), eq(Tier.EMERALD.name())))
+        .willReturn(new ComputeBottomDuoRanking.Result(PATCH, 0));
+
+    mockMvc.perform(post("/admin/aggregate/recompute-ranking")
+            .header("X-Admin-Key", "test-admin-key")
+            .param("patch", PATCH)
+            .param("tiers", "MASTER", "EMERALD"))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.results.length()").value(2))
+        .andExpect(jsonPath("$.totalUpdated").value(2053));
+
+    then(rankingUseCase).should().execute(PATCH, Tier.MASTER.name());
+    then(rankingUseCase).should().execute(PATCH, Tier.EMERALD.name());
+    then(rankingUseCase).should(never()).execute(PATCH, Tier.CHALLENGER.name());
+    then(rankingUseCase).should(never()).execute(PATCH, Tier.GRANDMASTER.name());
+    then(rankingUseCase).should(never()).execute(PATCH, Tier.DIAMOND.name());
+  }
+
+  @Test
+  @DisplayName("POST /admin/aggregate/recompute-ranking — 특정 tier 가 예외를 던져도 나머지 tier 는 계속 진행한다")
+  void recomputeRanking_oneTierFails_othersContinue() throws Exception {
+    given(rankingUseCase.execute(eq(PATCH), eq(Tier.CHALLENGER.name())))
+        .willReturn(new ComputeBottomDuoRanking.Result(PATCH, 5));
+    given(rankingUseCase.execute(eq(PATCH), eq(Tier.GRANDMASTER.name())))
+        .willThrow(new RuntimeException("boom"));
+    given(rankingUseCase.execute(eq(PATCH), eq(Tier.MASTER.name())))
+        .willReturn(new ComputeBottomDuoRanking.Result(PATCH, 100));
+    given(rankingUseCase.execute(eq(PATCH), eq(Tier.DIAMOND.name())))
+        .willReturn(new ComputeBottomDuoRanking.Result(PATCH, 80));
+    given(rankingUseCase.execute(eq(PATCH), eq(Tier.EMERALD.name())))
+        .willReturn(new ComputeBottomDuoRanking.Result(PATCH, 0));
+
+    mockMvc.perform(post("/admin/aggregate/recompute-ranking")
+            .header("X-Admin-Key", "test-admin-key")
+            .param("patch", PATCH))
+        .andExpect(status().isOk())
+        .andExpect(jsonPath("$.results.length()").value(5))
+        .andExpect(jsonPath("$.results[1].tier").value("GRANDMASTER"))
+        .andExpect(jsonPath("$.results[1].error").value("boom"))
+        .andExpect(jsonPath("$.totalUpdated").value(5 + 100 + 80 + 0));
+  }
+}


### PR DESCRIPTION
## 배경

match.payload_json 기반 단일 집계 경로 (#78, #79) 로 리팩토링하면서 cron scheduler 에서 `ComputeBottomDuoRanking` 호출이 빠진 회귀가 있었습니다.

증상:
- `AggregateBottomDuoFromMatch` 는 row 를 `ranking_status = 'PENDING'` 으로 upsert
- `ComputeBottomDuoRanking` 만 PENDING → RANKED 로 승격시키며 `ranking`/`rank_score`/`duo_tier` 채움
- 그러나 scheduler 는 fromMatch → cleanup 만 호출, ranking 단계 누락
- `BottomDuoStatisticsController` 의 모든 `findTopXxx` 쿼리는 `ranking_status = 'RANKED'` 로 필터
- → 16.10 첫 aggregate 이후 모든 tier 의 신규 row 가 PENDING 상태로 남아 API 응답이 빈 결과

기존 16.9 / 16.8 데이터는 raw 경로 시절 RANKED 까지 진행된 상태라 영향 없음. 16.10 만 누락.

## 변경

### 1. `fix(aggregate)` — scheduler 회귀 수정
`BottomDuoAggregateScheduler` 각 tier 루프에 `ComputeBottomDuoRanking.execute(patch, tier)` 호출 추가:
- fromMatch 가 실패한 tier 는 해당 tier 의 ranking 을 건너뜀
- ranking 실패는 다른 tier 진행과 cleanup 을 막지 않음 (기존 정책 유지)

### 2. `feat(aggregate)` — 일회성 복구 admin endpoint
```
POST /admin/aggregate/recompute-ranking?patch=16.10[&tiers=...]
X-Admin-Key: <키>
```
- tiers 미지정 시 CHALLENGER~EMERALD 5개 전부 수행
- tier 단위 예외는 응답의 `error` 필드로 노출하고 다음 tier 진행
- 기존 admin endpoint 와 동일하게 `AdminApiKeyInterceptor` 로 보호

배포 즉시 호출해 16.10 의 PENDING row 를 RANKED 로 승격시킬 수 있음. cron 정상화 (commit 1) 후에도 과거 누락 patch 재처리/장애 복구용으로 남겨두는 게 안전.

## Test plan

- [x] `BottomDuoAggregateSchedulerTest` — 모든 5 tier 에서 fromMatch → ranking 순 호출 검증
- [x] `BottomDuoAggregateSchedulerTest` — fromMatch 실패 tier 는 ranking skip, 다음 tier 계속
- [x] `BottomDuoAggregateSchedulerTest` — ranking 실패해도 다른 tier 와 cleanup 진행
- [x] `AggregateAdminControllerTest` — tiers 미지정 시 5개 tier 전부 실행, totalUpdated 합산
- [x] `AggregateAdminControllerTest` — tiers 지정 시 해당 tier 만 실행
- [x] `AggregateAdminControllerTest` — 특정 tier 예외 시 다른 tier 계속 + error 응답
- [x] `./gradlew test` 전체 통과
- [ ] (배포 후) `/admin/aggregate/recompute-ranking?patch=16.10` 호출 → MASTER `updatedRows` ≈ 2053 확인
- [ ] (배포 후) `/bottom-duo/stats?tier=MASTER&patchVersion=16.10` 으로 즉시 노출 확인