### PR TITLE
feat(archive): R2 검증 후 match row 삭제 cleanup endpoint

### DIFF
--- a/src/main/java/com/bestduo_BE/archive/application/MatchPayloadCleaner.java
+++ b/src/main/java/com/bestduo_BE/archive/application/MatchPayloadCleaner.java
@@ -1,0 +1,137 @@
+package com.bestduo_BE.archive.application;
+
+import com.bestduo_BE.common.domain.model.Tier;
+import com.bestduo_BE.common.infra.persistence.repository.MatchJpaRepository;
+import com.bestduo_BE.config.ArchiveProperties;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+
+/**
+ * R2 에 archive 가 완료된 (patch, tier) 의 match 행을 디스크에서 회수한다.
+ *
+ * <p>판정 기준: 개수가 아니라 R2 에 {@code match-archive/patch=X/tier=Y.jsonl.gz} 객체가 실제로
+ * 존재하는지 (HEAD 200). 그래야 이전 실행에서 archive 만 끝나고 DELETE 가 실패한 경우의 재시도가 안전하다.
+ *
+ * <p>가드: 최신 2 개 patch 는 operator 가 실수로 지정해도 거부한다.
+ */
+@Service
+@RequiredArgsConstructor
+@ConditionalOnProperty(name = "archive.r2.enabled", havingValue = "true")
+@Slf4j
+public class MatchPayloadCleaner {
+
+  private static final int PROTECTED_LATEST_COUNT = 2;
+  private static final String OBJECT_KEY_PATTERN = "match-archive/patch=%s/tier=%s.jsonl.gz";
+  private static final Pattern PATCH_PATTERN = Pattern.compile("^(\\d+)\\.(\\d+)$");
+
+  private final MatchJpaRepository matchRepository;
+  private final S3Client s3Client;
+  private final ArchiveProperties props;
+
+  public Result execute(List<String> patches, List<Tier> tiers) {
+    Set<String> protectedPatches = computeProtectedLatest();
+    List<PairResult> results = new ArrayList<>();
+    int totalDeleted = 0;
+
+    for (String patch : patches) {
+      if (protectedPatches.contains(patch)) {
+        for (Tier tier : tiers) {
+          results.add(new PairResult(patch, tier.name(), "protected_latest", 0L, 0));
+        }
+        continue;
+      }
+      for (Tier tier : tiers) {
+        results.add(processPair(patch, tier));
+      }
+    }
+
+    for (PairResult r : results) {
+      totalDeleted += r.deletedRows();
+    }
+
+    log.info("[MatchPayloadCleaner] protected={} totalDeleted={} pairs={}",
+        protectedPatches, totalDeleted, results.size());
+    return new Result(totalDeleted, results);
+  }
+
+  private PairResult processPair(String patch, Tier tier) {
+    String key = OBJECT_KEY_PATTERN.formatted(patch, tier.name());
+
+    long objectBytes;
+    try {
+      HeadObjectResponse head = s3Client.headObject(
+          HeadObjectRequest.builder().bucket(props.getR2().getBucket()).key(key).build());
+      objectBytes = head.contentLength() == null ? 0L : head.contentLength();
+    } catch (NoSuchKeyException nfe) {
+      return new PairResult(patch, tier.name(), "no_archive_found", 0L, 0);
+    } catch (RuntimeException ex) {
+      log.warn("[MatchPayloadCleaner] head failed key={} err={}", key, ex.toString());
+      return new PairResult(patch, tier.name(), "head_failed", 0L, 0);
+    }
+
+    int deleted;
+    try {
+      deleted = matchRepository.deleteByTierAndPatch(tier.name(), patch);
+    } catch (RuntimeException ex) {
+      log.error("[MatchPayloadCleaner] delete failed tier={} patch={}", tier, patch, ex);
+      return new PairResult(patch, tier.name(), "delete_failed", objectBytes, 0);
+    }
+
+    log.info("[MatchPayloadCleaner] ok tier={} patch={} bytes={} deleted={}",
+        tier, patch, objectBytes, deleted);
+    return new PairResult(patch, tier.name(), "ok", objectBytes, deleted);
+  }
+
+  private Set<String> computeProtectedLatest() {
+    return matchRepository.findDistinctPatches().stream()
+        .filter(MatchPayloadCleaner::isParseable)
+        .sorted(Comparator
+            .comparingInt(MatchPayloadCleaner::major)
+            .thenComparingInt(MatchPayloadCleaner::minor)
+            .reversed())
+        .limit(PROTECTED_LATEST_COUNT)
+        .collect(Collectors.toCollection(java.util.LinkedHashSet::new));
+  }
+
+  private static boolean isParseable(String patch) {
+    return patch != null && PATCH_PATTERN.matcher(patch).matches();
+  }
+
+  private static int major(String patch) {
+    return parseGroup(patch, 1);
+  }
+
+  private static int minor(String patch) {
+    return parseGroup(patch, 2);
+  }
+
+  private static int parseGroup(String patch, int group) {
+    Matcher m = PATCH_PATTERN.matcher(patch);
+    if (!m.matches()) {
+      throw new IllegalArgumentException("Unparseable patch: " + patch);
+    }
+    return Integer.parseInt(m.group(group));
+  }
+
+  public record Result(int totalDeleted, List<PairResult> results) {}
+
+  public record PairResult(
+      String patch,
+      String tier,
+      String status,
+      long objectBytes,
+      int deletedRows) {}
+}

--- a/src/main/java/com/bestduo_BE/archive/presentation/api/ArchiveAdminController.java
+++ b/src/main/java/com/bestduo_BE/archive/presentation/api/ArchiveAdminController.java
@@ -1,6 +1,7 @@
 package com.bestduo_BE.archive.presentation.api;
 
 import com.bestduo_BE.archive.application.MatchArchiver;
+import com.bestduo_BE.archive.application.MatchPayloadCleaner;
 import com.bestduo_BE.common.domain.model.Tier;
 import java.util.ArrayList;
 import java.util.List;
@@ -31,6 +32,7 @@ public class ArchiveAdminController {
       Tier.CHALLENGER, Tier.GRANDMASTER, Tier.MASTER, Tier.DIAMOND, Tier.EMERALD);
 
   private final MatchArchiver archiver;
+  private final MatchPayloadCleaner cleaner;
 
   @PostMapping("/match-payload")
   public ArchiveResponse archiveMatchPayload(
@@ -57,7 +59,31 @@ public class ArchiveAdminController {
     return new ArchiveResponse(totalArchived, totalBytes, results);
   }
 
+  /**
+   * R2 에 archive 가 완료된 (patch, tier) 의 match 행을 삭제한다.
+   *
+   * <p>각 (patch, tier) 마다 R2 객체 존재 (HEAD 200) 를 먼저 확인한 후 match 행을 지운다.
+   * 최신 2 개 patch 는 실수 방지를 위해 자동 거부 (status="protected_latest").
+   *
+   * <p>archive 와 분리된 endpoint 인 이유: operator 가 R2 콘솔에서 객체 + 크기를 눈으로 확인한 뒤
+   * 두 번째 단계로 호출하도록 하기 위함. 둘 다 멱등 — 같은 요청을 여러 번 보내도 안전.
+   */
+  @PostMapping("/cleanup-archived")
+  public CleanupResponse cleanupArchived(
+      @RequestParam List<String> patches,
+      @RequestParam(required = false) List<Tier> tiers) {
+
+    List<Tier> targetTiers = (tiers == null || tiers.isEmpty()) ? DEFAULT_TIERS : tiers;
+    MatchPayloadCleaner.Result result = cleaner.execute(patches, targetTiers);
+
+    log.info("[ArchiveAdmin/cleanup] complete patches={} tiers={} totalDeleted={} pairs={}",
+        patches, targetTiers, result.totalDeleted(), result.results().size());
+    return new CleanupResponse(result.totalDeleted(), result.results());
+  }
+
   public record ArchiveResponse(int totalArchived, long totalBytes, List<TierResult> results) {}
 
   public record TierResult(String patch, String tier, int archivedCount, long bytes, String objectKey) {}
+
+  public record CleanupResponse(int totalDeleted, List<MatchPayloadCleaner.PairResult> results) {}
 }

--- a/src/main/java/com/bestduo_BE/common/infra/persistence/repository/MatchJpaRepository.java
+++ b/src/main/java/com/bestduo_BE/common/infra/persistence/repository/MatchJpaRepository.java
@@ -4,8 +4,10 @@ package com.bestduo_BE.common.infra.persistence.repository;
 import com.bestduo_BE.common.infra.persistence.entity.Match;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.transaction.annotation.Transactional;
 
 public interface MatchJpaRepository extends JpaRepository<Match, String> {
 
@@ -29,4 +31,27 @@ public interface MatchJpaRepository extends JpaRepository<Match, String> {
       @Param("afterId") String afterId,
       @Param("pageSize") int pageSize
   );
+
+  /**
+   * match 테이블에 실제로 존재하는 distinct patch 목록.
+   * <p>archive cleanup endpoint 에서 "최신 N 개" protected 목록을 계산하기 위함.
+   */
+  @Query(value = """
+      select distinct split_part(game_version, '.', 1) || '.' || split_part(game_version, '.', 2)
+      from match
+      """, nativeQuery = true)
+  List<String> findDistinctPatches();
+
+  /**
+   * (tier, patch) 조건의 match 행을 일괄 삭제한다.
+   * <p>R2 archive 가 끝난 후 디스크 회수용. 자체 트랜잭션이므로 호출 측은 비-@Transactional 이어도 안전.
+   */
+  @Modifying
+  @Transactional
+  @Query(value = """
+      delete from match
+      where collection_tier = :tier
+        and split_part(game_version, '.', 1) || '.' || split_part(game_version, '.', 2) = :patch
+      """, nativeQuery = true)
+  int deleteByTierAndPatch(@Param("tier") String tier, @Param("patch") String patch);
 }

--- a/src/test/java/com/bestduo_BE/archive/application/MatchPayloadCleanerTest.java
+++ b/src/test/java/com/bestduo_BE/archive/application/MatchPayloadCleanerTest.java
@@ -1,0 +1,191 @@
+package com.bestduo_BE.archive.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.bestduo_BE.common.domain.model.Tier;
+import com.bestduo_BE.common.infra.persistence.repository.MatchJpaRepository;
+import com.bestduo_BE.config.ArchiveProperties;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.awscore.exception.AwsServiceException;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
+import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
+import software.amazon.awssdk.services.s3.model.NoSuchKeyException;
+
+@ExtendWith(MockitoExtension.class)
+class MatchPayloadCleanerTest {
+
+  private static final String BUCKET = "test-bucket";
+
+  @Mock
+  private MatchJpaRepository matchRepository;
+
+  @Mock
+  private S3Client s3Client;
+
+  private MatchPayloadCleaner cleaner;
+
+  @BeforeEach
+  void setUp() {
+    ArchiveProperties props = new ArchiveProperties();
+    props.getR2().setBucket(BUCKET);
+    cleaner = new MatchPayloadCleaner(matchRepository, s3Client, props);
+  }
+
+  @Test
+  @DisplayName("execute — 최신 2개 patch 는 protected_latest 로 거부되고 HEAD/DELETE 호출 안 함")
+  void protectedLatestPatchesAreRejected() {
+    when(matchRepository.findDistinctPatches())
+        .thenReturn(List.of("16.10", "16.9", "16.8", "16.5"));
+
+    MatchPayloadCleaner.Result result = cleaner.execute(
+        List.of("16.10", "16.9"), List.of(Tier.MASTER));
+
+    assertThat(result.totalDeleted()).isZero();
+    assertThat(result.results()).hasSize(2);
+    assertThat(result.results()).allSatisfy(r ->
+        assertThat(r.status()).isEqualTo("protected_latest"));
+    verify(s3Client, never()).headObject(any(HeadObjectRequest.class));
+    verify(matchRepository, never()).deleteByTierAndPatch(any(), any());
+  }
+
+  @Test
+  @DisplayName("execute — HEAD 성공 시 deleteByTierAndPatch 호출되고 status=ok")
+  void okFlowDeletesMatchRows() {
+    when(matchRepository.findDistinctPatches())
+        .thenReturn(List.of("16.10", "16.9", "16.5"));
+    when(s3Client.headObject(any(HeadObjectRequest.class)))
+        .thenReturn(HeadObjectResponse.builder().contentLength(1024L).build());
+    when(matchRepository.deleteByTierAndPatch("MASTER", "16.5")).thenReturn(50);
+
+    MatchPayloadCleaner.Result result = cleaner.execute(
+        List.of("16.5"), List.of(Tier.MASTER));
+
+    assertThat(result.totalDeleted()).isEqualTo(50);
+    assertThat(result.results()).hasSize(1);
+    var r0 = result.results().get(0);
+    assertThat(r0.status()).isEqualTo("ok");
+    assertThat(r0.patch()).isEqualTo("16.5");
+    assertThat(r0.tier()).isEqualTo("MASTER");
+    assertThat(r0.objectBytes()).isEqualTo(1024L);
+    assertThat(r0.deletedRows()).isEqualTo(50);
+    verify(matchRepository).deleteByTierAndPatch("MASTER", "16.5");
+  }
+
+  @Test
+  @DisplayName("execute — HEAD 가 NoSuchKeyException 이면 no_archive_found, DELETE 호출 안 함")
+  void noArchiveFoundWhenHeadReturns404() {
+    when(matchRepository.findDistinctPatches())
+        .thenReturn(List.of("16.10", "16.9", "16.5"));
+    when(s3Client.headObject(any(HeadObjectRequest.class)))
+        .thenThrow(NoSuchKeyException.builder().message("not found").build());
+
+    MatchPayloadCleaner.Result result = cleaner.execute(
+        List.of("16.5"), List.of(Tier.MASTER));
+
+    assertThat(result.totalDeleted()).isZero();
+    assertThat(result.results().get(0).status()).isEqualTo("no_archive_found");
+    assertThat(result.results().get(0).objectBytes()).isZero();
+    assertThat(result.results().get(0).deletedRows()).isZero();
+    verify(matchRepository, never()).deleteByTierAndPatch(any(), any());
+  }
+
+  @Test
+  @DisplayName("execute — HEAD 가 다른 예외 던지면 head_failed, DELETE 호출 안 함")
+  void headFailedOnOtherException() {
+    when(matchRepository.findDistinctPatches())
+        .thenReturn(List.of("16.10", "16.9", "16.5"));
+    when(s3Client.headObject(any(HeadObjectRequest.class)))
+        .thenThrow(AwsServiceException.builder().message("access denied").build());
+
+    MatchPayloadCleaner.Result result = cleaner.execute(
+        List.of("16.5"), List.of(Tier.MASTER));
+
+    assertThat(result.totalDeleted()).isZero();
+    assertThat(result.results().get(0).status()).isEqualTo("head_failed");
+    verify(matchRepository, never()).deleteByTierAndPatch(any(), any());
+  }
+
+  @Test
+  @DisplayName("execute — DELETE 가 예외 던지면 delete_failed, 다음 (patch, tier) 는 계속 진행")
+  void deleteFailedDoesNotBlockOthers() {
+    when(matchRepository.findDistinctPatches())
+        .thenReturn(List.of("16.10", "16.9", "16.5", "16.4"));
+    when(s3Client.headObject(any(HeadObjectRequest.class)))
+        .thenReturn(HeadObjectResponse.builder().contentLength(2048L).build());
+    when(matchRepository.deleteByTierAndPatch("MASTER", "16.5"))
+        .thenThrow(new RuntimeException("db down"));
+    when(matchRepository.deleteByTierAndPatch("MASTER", "16.4")).thenReturn(30);
+
+    MatchPayloadCleaner.Result result = cleaner.execute(
+        List.of("16.5", "16.4"), List.of(Tier.MASTER));
+
+    assertThat(result.results()).hasSize(2);
+    assertThat(result.results().get(0).status()).isEqualTo("delete_failed");
+    assertThat(result.results().get(0).objectBytes()).isEqualTo(2048L);
+    assertThat(result.results().get(0).deletedRows()).isZero();
+    assertThat(result.results().get(1).status()).isEqualTo("ok");
+    assertThat(result.results().get(1).deletedRows()).isEqualTo(30);
+    assertThat(result.totalDeleted()).isEqualTo(30);
+  }
+
+  @Test
+  @DisplayName("execute — patches × tiers 카르테시안 곱으로 모든 조합 반환")
+  void cartesianProductOverPatchesAndTiers() {
+    when(matchRepository.findDistinctPatches())
+        .thenReturn(List.of("16.10", "16.9", "16.5", "16.4"));
+    when(s3Client.headObject(any(HeadObjectRequest.class)))
+        .thenReturn(HeadObjectResponse.builder().contentLength(100L).build());
+    when(matchRepository.deleteByTierAndPatch(any(), any())).thenReturn(10);
+
+    MatchPayloadCleaner.Result result = cleaner.execute(
+        List.of("16.5", "16.4"),
+        List.of(Tier.MASTER, Tier.EMERALD));
+
+    assertThat(result.results()).hasSize(4);
+    assertThat(result.totalDeleted()).isEqualTo(40);
+    verify(s3Client, times(4)).headObject(any(HeadObjectRequest.class));
+    verify(matchRepository, times(4)).deleteByTierAndPatch(any(), any());
+  }
+
+  @Test
+  @DisplayName("execute — 정수 split 정렬로 \"15.10\" 이 \"15.9\" 보다 최신으로 처리된다")
+  void protectedSortByIntegerNotString() {
+    when(matchRepository.findDistinctPatches())
+        .thenReturn(List.of("15.9", "15.10", "15.8", "15.7"));
+
+    MatchPayloadCleaner.Result result = cleaner.execute(
+        List.of("15.10", "15.9"), List.of(Tier.MASTER));
+
+    assertThat(result.results()).allSatisfy(r ->
+        assertThat(r.status()).isEqualTo("protected_latest"));
+    verify(s3Client, never()).headObject(any(HeadObjectRequest.class));
+  }
+
+  @Test
+  @DisplayName("execute — 비표준 patch (\"UNKNOWN\" 등) 는 protected 계산에서 제외")
+  void protectedListIgnoresNonStandardPatches() {
+    when(matchRepository.findDistinctPatches())
+        .thenReturn(List.of("16.10", "UNKNOWN", "16.9", "broken", "16.5"));
+    when(s3Client.headObject(any(HeadObjectRequest.class)))
+        .thenReturn(HeadObjectResponse.builder().contentLength(50L).build());
+    when(matchRepository.deleteByTierAndPatch(any(), any())).thenReturn(5);
+
+    // protectedLatest = [16.10, 16.9] — UNKNOWN/broken 은 정렬 대상 아님
+    MatchPayloadCleaner.Result result = cleaner.execute(
+        List.of("16.5"), List.of(Tier.MASTER));
+
+    assertThat(result.results().get(0).status()).isEqualTo("ok");
+  }
+}


### PR DESCRIPTION
## Summary
- `POST /admin/archive/cleanup-archived?patches=...&tiers=...` 추가 — R2 에 archive 가 완료된 (patch, tier) 의 match 행을 디스크에서 회수
- 판정 기준은 **R2 객체 존재 여부 (HEAD 200)** — 개수가 아니라 객체가 실제로 있는지로 판단해서 "이전 실행에서 archive 만 끝나고 DELETE 실패" 시나리오의 재시도가 안전
- 가드: 최신 2 개 patch 는 `protected_latest` 로 자동 거부 (operator 가 실수로 현재 패치 적어도 데이터 손실 방지)

## 의사결정 매핑
| 결정 | 구현 |
|---|---|
| `archive.r2.enabled=false` 환경 보호 | controller + cleaner 둘 다 `@ConditionalOnProperty` → 빈 미등록 → 404 |
| R2 PUT 과 DB DELETE 별도 tx | controller/cleaner 비-`@Transactional` + repo delete 만 `@Modifying @Transactional` |
| 부분 실패 격리 | 각 (patch, tier) per-iteration try/catch |

## 응답 status 종류
- `ok`: HEAD 200 + DELETE 성공
- `protected_latest`: 최신 2 개 patch — HEAD/DELETE 안 함
- `no_archive_found`: HEAD 404 — DELETE 안 함
- `head_failed`: HEAD 가 기타 예외 (권한 / 네트워크 등) — DELETE 안 함
- `delete_failed`: HEAD 통과했으나 DB DELETE 가 예외 — 다음 (patch, tier) 진행

## 운영 흐름 (의도된 시퀀스)
```
1. POST /admin/archive/match-payload?patches=16.5,16.4
   → R2 PUT (기존 endpoint)
2. R2 console / aws s3 ls 로 객체 + 크기 확인
3. POST /admin/archive/cleanup-archived?patches=16.5,16.4
   → 각 (patch, tier) HEAD → 통과한 것만 DELETE
   → 최신 패치 실수로 적어도 protected_latest 로 자동 거부
```

## Test plan
- [x] `MatchPayloadCleanerTest` 8 케이스 (protected_latest / ok / no_archive_found / head_failed / delete_failed / cartesian product / 정수 split 정렬 / 비표준 patch 필터)
- [x] `./gradlew test` 전체 통과
- [ ] (수동) 배포 후 staging 에서 archive 안 된 patch 로 호출 → `no_archive_found` 응답 확인
- [ ] (수동) 배포 후 archive 된 patch 로 호출 → `ok` + `deletedRows > 0` 응답 확인
- [ ] (수동) 최신 patch 로 호출 → `protected_latest` 응답 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)