### PR TITLE
feat(debug): /dumps hprof 를 R2 로 업로드하는 admin endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ out/
 ### Local env (secrets) ###
 .env
 riot.txt
+
+### Heap dumps (large debugging artifact) ###
+*.hprof

--- a/src/main/java/com/bestduo_BE/debug/application/HeapDumpUploader.java
+++ b/src/main/java/com/bestduo_BE/debug/application/HeapDumpUploader.java
@@ -1,0 +1,82 @@
+package com.bestduo_BE.debug.application;
+
+import com.bestduo_BE.config.ArchiveProperties;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Stream;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Service;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+/**
+ * Railway volume 의 {@code /dumps/*.hprof} 파일을 R2 로 업로드한다.
+ *
+ * <p>운영 흐름: JVM 의 {@code -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/dumps} 가 OOM
+ * 발생 시 자동으로 hprof 파일을 만들고, 앱이 재시작된 뒤 operator 가 이 uploader 를 호출해
+ * hprof 를 R2 로 옮겨 로컬에서 분석 가능하게 한다.
+ *
+ * <p>archive R2 인프라 (S3Client + bucket) 를 그대로 재사용 — debug 전용 별도 bucket 분리는
+ * 일회성 디버그 도구라 over-engineering.
+ */
+@Service
+@ConditionalOnProperty(name = "archive.r2.enabled", havingValue = "true")
+@Slf4j
+public class HeapDumpUploader {
+
+  private static final String R2_KEY_PREFIX = "debug/";
+  private static final String HPROF_SUFFIX = ".hprof";
+
+  private final Path dumpDir;
+  private final S3Client s3Client;
+  private final ArchiveProperties props;
+
+  public HeapDumpUploader(
+      @Value("${debug.heap-dump.dir:/dumps}") String dumpDir,
+      S3Client s3Client,
+      ArchiveProperties props) {
+    this.dumpDir = Path.of(dumpDir);
+    this.s3Client = s3Client;
+    this.props = props;
+  }
+
+  public List<UploadResult> uploadAllHprofFiles() throws IOException {
+    if (!Files.isDirectory(dumpDir)) {
+      log.warn("[HeapDumpUploader] dump dir not found: {}", dumpDir);
+      return List.of();
+    }
+
+    List<Path> hprofs;
+    try (Stream<Path> files = Files.list(dumpDir)) {
+      hprofs = files
+          .filter(p -> p.getFileName().toString().endsWith(HPROF_SUFFIX))
+          .sorted(Comparator.comparing(p -> p.getFileName().toString()))
+          .toList();
+    }
+
+    List<UploadResult> results = new ArrayList<>();
+    for (Path file : hprofs) {
+      String key = R2_KEY_PREFIX + file.getFileName().toString();
+      long bytes = Files.size(file);
+      s3Client.putObject(
+          PutObjectRequest.builder()
+              .bucket(props.getR2().getBucket())
+              .key(key)
+              .contentType("application/octet-stream")
+              .build(),
+          RequestBody.fromFile(file));
+      log.info("[HeapDumpUploader] uploaded {} ({} bytes) -> {}", file, bytes, key);
+      results.add(new UploadResult(file.toString(), key, bytes));
+    }
+    return results;
+  }
+
+  public record UploadResult(String localPath, String r2Key, long bytes) {}
+}

--- a/src/main/java/com/bestduo_BE/debug/presentation/api/DebugAdminController.java
+++ b/src/main/java/com/bestduo_BE/debug/presentation/api/DebugAdminController.java
@@ -1,0 +1,41 @@
+package com.bestduo_BE.debug.presentation.api;
+
+import com.bestduo_BE.debug.application.HeapDumpUploader;
+import java.io.IOException;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 일회성 디버깅 도구 endpoint.
+ *
+ * <p>현재는 heap dump 업로드만 제공. 분석 끝나면 통째로 제거 예정.
+ *
+ * <p>인증: {@code AdminApiKeyInterceptor} 가 {@code X-Admin-Key} 헤더를 검증한다.
+ */
+@RestController
+@RequestMapping("/admin/debug")
+@RequiredArgsConstructor
+@ConditionalOnProperty(name = "archive.r2.enabled", havingValue = "true")
+@Slf4j
+public class DebugAdminController {
+
+  private final HeapDumpUploader heapDumpUploader;
+
+  /**
+   * Railway volume 의 {@code /dumps/*.hprof} 파일을 모두 R2 로 업로드한다.
+   *
+   * <p>JVM 의 {@code HeapDumpOnOutOfMemoryError} 가 만든 hprof 파일을 외부에서 받아볼 수 있게
+   * 하기 위함. 업로드 후 파일은 그대로 둠 — 같은 hprof 가 R2 에 덮어쓰여도 무해 (idempotent).
+   */
+  @PostMapping("/upload-heap-dump")
+  public List<HeapDumpUploader.UploadResult> uploadHeapDump() throws IOException {
+    List<HeapDumpUploader.UploadResult> results = heapDumpUploader.uploadAllHprofFiles();
+    log.info("[DebugAdmin/upload-heap-dump] uploaded {} hprof file(s)", results.size());
+    return results;
+  }
+}

--- a/src/test/java/com/bestduo_BE/debug/application/HeapDumpUploaderTest.java
+++ b/src/test/java/com/bestduo_BE/debug/application/HeapDumpUploaderTest.java
@@ -1,0 +1,134 @@
+package com.bestduo_BE.debug.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import com.bestduo_BE.config.ArchiveProperties;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.io.TempDir;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectResponse;
+
+@ExtendWith(MockitoExtension.class)
+class HeapDumpUploaderTest {
+
+  private static final String BUCKET = "test-bucket";
+
+  @Mock
+  private S3Client s3Client;
+
+  @TempDir
+  Path dumpDir;
+
+  private HeapDumpUploader uploader;
+
+  @BeforeEach
+  void setUp() {
+    ArchiveProperties props = new ArchiveProperties();
+    props.getR2().setBucket(BUCKET);
+    uploader = new HeapDumpUploader(dumpDir.toString(), s3Client, props);
+  }
+
+  @Test
+  @DisplayName("uploadAllHprofFiles — 디렉토리에 .hprof 파일이 없으면 빈 리스트 반환하고 S3 호출 안 함")
+  void emptyDirReturnsEmptyList() throws IOException {
+    List<HeapDumpUploader.UploadResult> results = uploader.uploadAllHprofFiles();
+
+    assertThat(results).isEmpty();
+    verifyNoInteractions(s3Client);
+  }
+
+  @Test
+  @DisplayName("uploadAllHprofFiles — .hprof 1개면 R2 PUT 1회 호출되고 key=debug/<filename>")
+  void singleHprofIsUploaded() throws IOException {
+    Path hprof = dumpDir.resolve("java_pid1.hprof");
+    Files.write(hprof, new byte[]{0x01, 0x02, 0x03});
+    when(s3Client.putObject(any(PutObjectRequest.class), any(RequestBody.class)))
+        .thenReturn(PutObjectResponse.builder().build());
+
+    List<HeapDumpUploader.UploadResult> results = uploader.uploadAllHprofFiles();
+
+    ArgumentCaptor<PutObjectRequest> reqCaptor = ArgumentCaptor.forClass(PutObjectRequest.class);
+    verify(s3Client).putObject(reqCaptor.capture(), any(RequestBody.class));
+    assertThat(reqCaptor.getValue().bucket()).isEqualTo(BUCKET);
+    assertThat(reqCaptor.getValue().key()).isEqualTo("debug/java_pid1.hprof");
+
+    assertThat(results).hasSize(1);
+    assertThat(results.get(0).r2Key()).isEqualTo("debug/java_pid1.hprof");
+    assertThat(results.get(0).bytes()).isEqualTo(3L);
+    assertThat(results.get(0).localPath()).isEqualTo(hprof.toString());
+  }
+
+  @Test
+  @DisplayName("uploadAllHprofFiles — .hprof 여러 개면 파일명 정렬 순서로 모두 업로드")
+  void multipleHprofsUploadedInSortedOrder() throws IOException {
+    Files.write(dumpDir.resolve("java_pid2.hprof"), new byte[]{0x10});
+    Files.write(dumpDir.resolve("java_pid1.hprof"), new byte[]{0x20, 0x21});
+    Files.write(dumpDir.resolve("java_pid3.hprof"), new byte[]{0x30, 0x31, 0x32});
+    when(s3Client.putObject(any(PutObjectRequest.class), any(RequestBody.class)))
+        .thenReturn(PutObjectResponse.builder().build());
+
+    List<HeapDumpUploader.UploadResult> results = uploader.uploadAllHprofFiles();
+
+    verify(s3Client, times(3)).putObject(any(PutObjectRequest.class), any(RequestBody.class));
+    assertThat(results).extracting(HeapDumpUploader.UploadResult::r2Key)
+        .containsExactly(
+            "debug/java_pid1.hprof",
+            "debug/java_pid2.hprof",
+            "debug/java_pid3.hprof");
+    assertThat(results).extracting(HeapDumpUploader.UploadResult::bytes)
+        .containsExactly(2L, 1L, 3L);
+  }
+
+  @Test
+  @DisplayName("uploadAllHprofFiles — .hprof 아닌 파일은 무시")
+  void nonHprofFilesAreIgnored() throws IOException {
+    Files.write(dumpDir.resolve("java_pid1.hprof"), new byte[]{0x01});
+    Files.write(dumpDir.resolve("readme.txt"), new byte[]{0x02});
+    Files.write(dumpDir.resolve("app.log"), new byte[]{0x03});
+    when(s3Client.putObject(any(PutObjectRequest.class), any(RequestBody.class)))
+        .thenReturn(PutObjectResponse.builder().build());
+
+    List<HeapDumpUploader.UploadResult> results = uploader.uploadAllHprofFiles();
+
+    verify(s3Client, times(1)).putObject(any(PutObjectRequest.class), any(RequestBody.class));
+    assertThat(results).hasSize(1);
+    assertThat(results.get(0).r2Key()).isEqualTo("debug/java_pid1.hprof");
+  }
+
+  @Test
+  @DisplayName("uploadAllHprofFiles — dump 디렉토리 자체가 없으면 빈 리스트 반환하고 S3 호출 안 함")
+  void missingDumpDirReturnsEmptyList() throws IOException {
+    HeapDumpUploader withMissingDir = new HeapDumpUploader(
+        dumpDir.resolve("nonexistent").toString(),
+        s3Client,
+        uploaderProps());
+
+    List<HeapDumpUploader.UploadResult> results = withMissingDir.uploadAllHprofFiles();
+
+    assertThat(results).isEmpty();
+    verifyNoInteractions(s3Client);
+  }
+
+  private ArchiveProperties uploaderProps() {
+    ArchiveProperties props = new ArchiveProperties();
+    props.getR2().setBucket(BUCKET);
+    return props;
+  }
+}


### PR DESCRIPTION
## Summary
- `POST /admin/debug/upload-heap-dump` — Railway Volume `/dumps/*.hprof` 파일을 R2 의 `debug/<filename>` 로 PUT
- JVM 의 `-XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/dumps` 와 짝지어 사용 — OOM 시 자동 생성된 hprof 파일을 외부에서 받아 MAT 으로 분석할 수 있게 함
- prod 의 실제 OOM 메커니즘을 확정하기 위한 일회성 디버그 도구

## 운영 흐름
```
1. (사전) Railway Volume 1~2GB 를 /dumps 에 마운트 + env 에 JAVA_TOOL_OPTIONS 추가 (완료)
2. Swagger 로 POST /admin/archive/match-payload?patches=16.8&tiers=EMERALD 호출
3. OOM 발생 → JVM 이 /dumps/java_pidNNN.hprof 자동 생성 + 앱 종료 + Railway auto-restart
4. POST /admin/debug/upload-heap-dump  ← 이 PR
   → R2 의 debug/java_pidNNN.hprof 로 업로드
5. R2 console 또는 aws s3 cp 로 로컬 다운로드
6. Eclipse MAT 으로 분석 → 진짜 OOM 범인 확정
```

## 의사결정
- archive 의 R2 인프라 (S3Client, bucket) 재사용 — 디버그 전용 별도 bucket 분리는 over-engineering
- `archive.r2.enabled=true` 조건으로 빈 등록 (local/test 환경 자동 보호)
- dump 디렉토리는 `debug.heap-dump.dir` 로 외부화 (기본 `/dumps`) — 테스트에서 @TempDir 사용 가능
- 업로드 후 로컬 파일은 그대로 둠 — 같은 hprof 가 R2 에 덮어쓰여도 무해 (idempotent)

## 분석 끝나면 제거 예정
이 endpoint 는 prod OOM 원인 분석을 위한 일회성 도구. 분석 끝나면 controller/service/test 통째로 제거.

## Test plan
- [x] `HeapDumpUploaderTest` 5 케이스 (빈 디렉토리 / hprof 1개 / 여러 개 정렬 / 비-hprof 무시 / 디렉토리 부재)
- [x] `./gradlew test` 전체 통과
- [ ] (수동) prod 배포 후 endpoint 호출 → R2 에 객체 생성 확인
- [ ] (수동) archive endpoint → OOM → 재시작 후 endpoint 호출 → hprof 다운로드 → MAT 분석

🤖 Generated with [Claude Code](https://claude.com/claude-code)