### PR TITLE
refactor: drop unused MatchQueue.priority field

### DIFF
--- a/src/main/java/com/bestduo_BE/common/infra/persistence/MatchQueueEnqueuer.java
+++ b/src/main/java/com/bestduo_BE/common/infra/persistence/MatchQueueEnqueuer.java
@@ -14,10 +14,10 @@ public class MatchQueueEnqueuer {
   private final MatchQueueJpaRepository repo;
 
   @Transactional
-  public void enqueueAllIdempotent(List<String> matchIds, Tier tier, int priority, String patch) {
+  public void enqueueAllIdempotent(List<String> matchIds, Tier tier, String patch) {
     for (String matchId : matchIds) {
       if (repo.existsById(matchId)) continue;
-      repo.save(MatchQueue.newReady(matchId, tier, priority, patch));
+      repo.save(MatchQueue.newReady(matchId, tier, patch));
     }
   }
 }

--- a/src/main/java/com/bestduo_BE/common/infra/persistence/entity/MatchQueue.java
+++ b/src/main/java/com/bestduo_BE/common/infra/persistence/entity/MatchQueue.java
@@ -33,9 +33,6 @@ public class MatchQueue {
   @Column(name = "status", nullable = false)
   private QueueStatus status;
 
-  @Column(name = "priority", nullable = false)
-  private int priority;
-
   @Enumerated(EnumType.STRING)
   @Column(name = "collection_tier", nullable = false)
   private Tier collectionTier;
@@ -58,12 +55,11 @@ public class MatchQueue {
   @Column(name = "updated_at", nullable = false)
   private OffsetDateTime updatedAt;
 
-  public static MatchQueue newReady(String matchId, Tier collectionTier, int priority, String patch) {
+  public static MatchQueue newReady(String matchId, Tier collectionTier, String patch) {
     OffsetDateTime now = OffsetDateTime.now();
     return MatchQueue.builder()
         .matchId(matchId)
         .status(QueueStatus.READY)
-        .priority(priority)
         .collectionTier(collectionTier)
         .patch(patch)
         .retryCount(0)

--- a/src/main/java/com/bestduo_BE/common/infra/persistence/repository/MatchQueueJpaRepository.java
+++ b/src/main/java/com/bestduo_BE/common/infra/persistence/repository/MatchQueueJpaRepository.java
@@ -17,7 +17,6 @@ public interface MatchQueueJpaRepository extends JpaRepository<MatchQueue, Strin
         or (mq.status = 'ERROR' and mq.updated_at <= now() - interval '2 minutes')
       order by
         case when mq.status = 'ERROR' then 0 else 1 end,
-        mq.priority asc,
         mq.updated_at asc
       limit :limit
       """, nativeQuery = true)
@@ -46,7 +45,7 @@ public interface MatchQueueJpaRepository extends JpaRepository<MatchQueue, Strin
       from match_queue mq
       where mq.status = 'READY'
         and (:collectionTier is null or mq.collection_tier = :collectionTier)
-      order by mq.priority asc, mq.updated_at asc
+      order by mq.updated_at asc
       limit :limit
     )
     update match_queue mq
@@ -71,7 +70,7 @@ public interface MatchQueueJpaRepository extends JpaRepository<MatchQueue, Strin
         and mq.retry_count < :maxRetry
         and mq.updated_at <= now() - (:cooldownMinutes * interval '1 minute')
         and (:collectionTier is null or mq.collection_tier = :collectionTier)
-      order by mq.priority asc, mq.updated_at asc
+      order by mq.updated_at asc
       limit :limit
     )
     update match_queue mq
@@ -111,7 +110,6 @@ public interface MatchQueueJpaRepository extends JpaRepository<MatchQueue, Strin
    * <ol>
    *   <li>currentPatch와 일치하는 항목 우선 (불일치 또는 null이면 후순위)</li>
    *   <li>tier 우선순위: CHALLENGER(0) → GRANDMASTER(1) → MASTER(2) → DIAMOND(3) → EMERALD(4) → 기타(5)</li>
-   *   <li>priority ASC</li>
    *   <li>updated_at ASC</li>
    * </ol>
    */
@@ -133,7 +131,6 @@ public interface MatchQueueJpaRepository extends JpaRepository<MatchQueue, Strin
           when 'EMERALD'      then 4
           else 5
         end asc,
-        mq.priority asc,
         mq.updated_at asc
       limit :limit
     )

--- a/src/main/java/com/bestduo_BE/config/PipelineProperties.java
+++ b/src/main/java/com/bestduo_BE/config/PipelineProperties.java
@@ -52,11 +52,6 @@ public class PipelineProperties {
   @Max(600_000)
   private long errorBackoffMs = 5000;
 
-  /** Stage 2에서 match_queue에 enqueue할 때 사용하는 기본 우선순위 */
-  @Min(0)
-  @Max(1000)
-  private int collectPriority = 50;
-
   /**
    * DIA/EME CoverageBucket에서 한 division 내 최대 page 수.
    * 이 수에 도달하면 다음 division으로 이동한다.

--- a/src/main/java/com/bestduo_BE/ingest/infra/persistence/MatchQueueDispatcher.java
+++ b/src/main/java/com/bestduo_BE/ingest/infra/persistence/MatchQueueDispatcher.java
@@ -80,7 +80,7 @@ public class MatchQueueDispatcher {
   private List<Item> toItems(List<MatchQueue> list) {
     List<Item> out = new ArrayList<>();
     for (MatchQueue mq : list) {
-      out.add(new Item(mq.getMatchId(), mq.getCollectionTier(), mq.getPriority(), mq.getPatch()));
+      out.add(new Item(mq.getMatchId(), mq.getCollectionTier(), mq.getPatch()));
     }
     return out;
   }
@@ -92,5 +92,5 @@ public class MatchQueueDispatcher {
     return requestedTier.name();
   }
 
-  public record Item(String matchId, Tier tier, int priority, String patch) {}
+  public record Item(String matchId, Tier tier, String patch) {}
 }

--- a/src/main/java/com/bestduo_BE/pipeline/application/CollectMatchIdsRunner.java
+++ b/src/main/java/com/bestduo_BE/pipeline/application/CollectMatchIdsRunner.java
@@ -119,7 +119,7 @@ public class CollectMatchIdsRunner {
 
     String patch = ctx != null ? ctx.patch() : null;
     Tier tier = summoner.getLastKnownTier();
-    matchQueueEnqueuer.enqueueAllIdempotent(matchIds, tier, props.getCollectPriority(), patch);
+    matchQueueEnqueuer.enqueueAllIdempotent(matchIds, tier, patch);
     return matchIds.size();
   }
 

--- a/src/main/resources/db/migration/V6__drop_match_queue_priority.sql
+++ b/src/main/resources/db/migration/V6__drop_match_queue_priority.sql
@@ -1,0 +1,16 @@
+-- V6: match_queue.priority 컬럼 제거.
+--
+-- 배경:
+--   - priority 컬럼은 모든 enqueue에서 동일한 값(PipelineProperties.collectPriority = 50)
+--     으로만 들어가, ORDER BY mq.priority ASC 가 사실상 ORDER BY mq.updated_at ASC
+--     와 동일하게 동작하는 죽은 우선순위였다.
+--   - Stage 3 우선 처리는 priorityTier(WHERE collection_tier = ?) 로 동작하며,
+--     match_queue.priority 와 무관하다.
+--   - YAGNI 원칙에 따라 차별화되지 않는 컬럼을 제거하여 스키마와 쿼리를 단순화한다.
+--
+-- 동작:
+--   - priority 컬럼을 drop 한다. NOT NULL 이지만 코드에서 더 이상 read/write 하지
+--     않으므로 운영 영향 없음. 관련 쿼리(ORDER BY mq.priority asc) 는 동일 PR 에서
+--     함께 제거된다.
+
+ALTER TABLE match_queue DROP COLUMN IF EXISTS priority;

--- a/src/test/java/com/bestduo_BE/common/infra/persistence/MatchQueueEnqueuerTest.java
+++ b/src/test/java/com/bestduo_BE/common/infra/persistence/MatchQueueEnqueuerTest.java
@@ -37,14 +37,13 @@ class MatchQueueEnqueuerTest {
     given(repository.existsById("m-1")).willReturn(false);
     given(repository.existsById("m-2")).willReturn(true);
 
-    enqueuer.enqueueAllIdempotent(List.of("m-1", "m-2"), Tier.EMERALD, 80, "15.23");
+    enqueuer.enqueueAllIdempotent(List.of("m-1", "m-2"), Tier.EMERALD, "15.23");
 
     ArgumentCaptor<MatchQueue> captor = ArgumentCaptor.forClass(MatchQueue.class);
     verify(repository).save(captor.capture());
     MatchQueue saved = captor.getValue();
     assertThat(saved.getMatchId()).isEqualTo("m-1");
     assertThat(saved.getCollectionTier()).isEqualTo(Tier.EMERALD);
-    assertThat(saved.getPriority()).isEqualTo(80);
     assertThat(saved.getPatch()).isEqualTo("15.23");
     verify(repository).existsById("m-1");
     verify(repository).existsById("m-2");
@@ -55,7 +54,7 @@ class MatchQueueEnqueuerTest {
   void skipSavingWhenAllIdsExist() {
     given(repository.existsById("m-3")).willReturn(true);
 
-    enqueuer.enqueueAllIdempotent(List.of("m-3"), Tier.GOLD, 5, "15.23");
+    enqueuer.enqueueAllIdempotent(List.of("m-3"), Tier.GOLD, "15.23");
 
     verify(repository, never()).save(any());
   }

--- a/src/test/java/com/bestduo_BE/common/infra/persistence/entity/MatchQueueTest.java
+++ b/src/test/java/com/bestduo_BE/common/infra/persistence/entity/MatchQueueTest.java
@@ -14,11 +14,10 @@ class MatchQueueTest {
   @Test
   @DisplayName("newReady — 패치 정보를 포함한 READY 상태 엔트리를 생성한다")
   void newReadyIncludesPatch() {
-    MatchQueue queue = MatchQueue.newReady("match-1", Tier.EMERALD, 20, "15.23");
+    MatchQueue queue = MatchQueue.newReady("match-1", Tier.EMERALD, "15.23");
 
     assertThat(queue.getMatchId()).isEqualTo("match-1");
     assertThat(queue.getCollectionTier()).isEqualTo(Tier.EMERALD);
-    assertThat(queue.getPriority()).isEqualTo(20);
     assertThat(queue.getPatch()).isEqualTo("15.23");
     assertThat(queue.getStatus()).isEqualTo(QueueStatus.READY);
   }
@@ -26,7 +25,7 @@ class MatchQueueTest {
   @Test
   @DisplayName("markRunning — READY 상태가 아니면 IllegalStateTransitionException을 던진다")
   void markRunning_whenNotReady_throws() {
-    MatchQueue queue = MatchQueue.newReady("match-1", Tier.EMERALD, 20, "15.23");
+    MatchQueue queue = MatchQueue.newReady("match-1", Tier.EMERALD, "15.23");
     queue.markRunning(); // READY → RUNNING
 
     assertThatThrownBy(queue::markRunning)
@@ -36,7 +35,7 @@ class MatchQueueTest {
   @Test
   @DisplayName("markDone — RUNNING 상태가 아니면 IllegalStateTransitionException을 던진다")
   void markDone_whenNotRunning_throws() {
-    MatchQueue queue = MatchQueue.newReady("match-1", Tier.EMERALD, 20, "15.23");
+    MatchQueue queue = MatchQueue.newReady("match-1", Tier.EMERALD, "15.23");
 
     assertThatThrownBy(queue::markDone)
         .isInstanceOf(IllegalStateTransitionException.class);
@@ -45,7 +44,7 @@ class MatchQueueTest {
   @Test
   @DisplayName("markError — RUNNING 상태가 아니면 IllegalStateTransitionException을 던진다")
   void markError_whenNotRunning_throws() {
-    MatchQueue queue = MatchQueue.newReady("match-1", Tier.EMERALD, 20, "15.23");
+    MatchQueue queue = MatchQueue.newReady("match-1", Tier.EMERALD, "15.23");
 
     assertThatThrownBy(() -> queue.markError("boom"))
         .isInstanceOf(IllegalStateTransitionException.class);

--- a/src/test/java/com/bestduo_BE/ingest/application/MatchIngestRunnerTest.java
+++ b/src/test/java/com/bestduo_BE/ingest/application/MatchIngestRunnerTest.java
@@ -37,7 +37,7 @@ class MatchIngestRunnerTest {
   @Test
   @DisplayName("executeWithPriority — 요청된 tier를 큐 락에 전달하고 처리 결과를 반환한다")
   void executeForwardsRequestedTierToQueueLocking() {
-    MatchQueueDispatcher.Item item = new MatchQueueDispatcher.Item("match-1", Tier.GOLD, 1, "15.23");
+    MatchQueueDispatcher.Item item = new MatchQueueDispatcher.Item("match-1", Tier.GOLD, "15.23");
     given(queue.recoverStaleRunning(10)).willReturn(0);
     given(queue.pickAndLockWithPriority(3, 2, 10, Tier.GOLD, null)).willReturn(List.of(item));
     given(ingestMatchDetail.execute("match-1", Tier.GOLD, "15.23"))
@@ -69,7 +69,7 @@ class MatchIngestRunnerTest {
   @Test
   @DisplayName("item.patch()를 ingestMatchDetail에 전달한다")
   void execute_forwardsPatchFromItemToIngestMatchDetail() {
-    MatchQueueDispatcher.Item item = new MatchQueueDispatcher.Item("match-2", Tier.EMERALD, 2, "15.24");
+    MatchQueueDispatcher.Item item = new MatchQueueDispatcher.Item("match-2", Tier.EMERALD, "15.24");
     given(queue.recoverStaleRunning(10)).willReturn(0);
     given(queue.pickAndLockWithPriority(1, 2, 10, Tier.EMERALD, null)).willReturn(List.of(item));
     given(ingestMatchDetail.execute("match-2", Tier.EMERALD, "15.24"))
@@ -83,7 +83,7 @@ class MatchIngestRunnerTest {
   @Test
   @DisplayName("item.patch() null이면 null 전달")
   void execute_withNullPatch_forwardsNullToIngestMatchDetail() {
-    MatchQueueDispatcher.Item item = new MatchQueueDispatcher.Item("match-3", Tier.GOLD, 1, null);
+    MatchQueueDispatcher.Item item = new MatchQueueDispatcher.Item("match-3", Tier.GOLD, null);
     given(queue.recoverStaleRunning(10)).willReturn(0);
     given(queue.pickAndLockWithPriority(1, 2, 10, Tier.GOLD, null)).willReturn(List.of(item));
     given(ingestMatchDetail.execute("match-3", Tier.GOLD, null))

--- a/src/test/java/com/bestduo_BE/ingest/infra/persistence/MatchQueueDispatcherPhase5Test.java
+++ b/src/test/java/com/bestduo_BE/ingest/infra/persistence/MatchQueueDispatcherPhase5Test.java
@@ -48,7 +48,7 @@ class MatchQueueDispatcherPhase5Test {
   @Test
   @DisplayName("pickAndLockWithPriority 결과를 Item으로 변환한다")
   void pickAndLockWithPriority_convertsToItems() {
-    MatchQueue mq = MatchQueue.newReady("match-1", Tier.DIAMOND, 50, "15.23");
+    MatchQueue mq = MatchQueue.newReady("match-1", Tier.DIAMOND, "15.23");
     given(repo.pickReadyWithPriorityAndLock(anyInt(), any(), anyString()))
         .willReturn(List.of(mq));
     given(repo.pickRetryableErrorAndLock(anyInt(), anyInt(), anyInt(), any())).willReturn(List.of());

--- a/src/test/java/com/bestduo_BE/ingest/infra/persistence/MatchQueueDispatcherTest.java
+++ b/src/test/java/com/bestduo_BE/ingest/infra/persistence/MatchQueueDispatcherTest.java
@@ -48,9 +48,9 @@ class MatchQueueDispatcherTest {
   @Test
   @DisplayName("pickAndLock — READY 아이템을 재시도 오류보다 우선 선택한다")
   void pickAndLockPrefersReadyBeforeRetryableErrors() {
-    MatchQueue ready1 = match("m-1", Tier.GOLD, 1, "15.23");
-    MatchQueue ready2 = match("m-2", Tier.SILVER, 2, "15.23");
-    MatchQueue error = match("m-3", Tier.BRONZE, 3, "15.23");
+    MatchQueue ready1 = match("m-1", Tier.GOLD, "15.23");
+    MatchQueue ready2 = match("m-2", Tier.SILVER, "15.23");
+    MatchQueue error = match("m-3", Tier.BRONZE, "15.23");
     given(repository.pickReadyAndLock(3, null)).willReturn(List.of(ready1, ready2));
     given(repository.pickRetryableErrorAndLock(1, 2, 5, null)).willReturn(List.of(error));
 
@@ -59,17 +59,17 @@ class MatchQueueDispatcherTest {
     verify(repository).pickReadyAndLock(3, null);
     verify(repository).pickRetryableErrorAndLock(1, 2, 5, null);
     assertThat(items).containsExactly(
-        new Item("m-1", Tier.GOLD, 1, "15.23"),
-        new Item("m-2", Tier.SILVER, 2, "15.23"),
-        new Item("m-3", Tier.BRONZE, 3, "15.23")
+        new Item("m-1", Tier.GOLD, "15.23"),
+        new Item("m-2", Tier.SILVER, "15.23"),
+        new Item("m-3", Tier.BRONZE, "15.23")
     );
   }
 
   @Test
   @DisplayName("pickAndLock — READY 아이템이 limit을 채우면 재시도 오류를 건너뛴다")
   void skipsRetryableErrorsWhenReadyFillLimit() {
-    MatchQueue ready1 = match("m-1", Tier.EMERALD, 1, "15.23");
-    MatchQueue ready2 = match("m-2", Tier.EMERALD, 2, "15.23");
+    MatchQueue ready1 = match("m-1", Tier.EMERALD, "15.23");
+    MatchQueue ready2 = match("m-2", Tier.EMERALD, "15.23");
     given(repository.pickReadyAndLock(2, null)).willReturn(List.of(ready1, ready2));
 
     List<Item> items = coordinator.pickAndLock(2, 2, 5);
@@ -77,15 +77,15 @@ class MatchQueueDispatcherTest {
     verify(repository).pickReadyAndLock(2, null);
     verify(repository, never()).pickRetryableErrorAndLock(anyInt(), anyInt(), anyInt(), org.mockito.ArgumentMatchers.<String>any());
     assertThat(items).containsExactly(
-        new Item("m-1", Tier.EMERALD, 1, "15.23"),
-        new Item("m-2", Tier.EMERALD, 2, "15.23")
+        new Item("m-1", Tier.EMERALD, "15.23"),
+        new Item("m-2", Tier.EMERALD, "15.23")
     );
   }
 
   @Test
   @DisplayName("pickAndLock — 요청된 tier로 필터링한다")
   void pickAndLockFiltersByRequestedTier() {
-    MatchQueue ready = match("m-gold", Tier.GOLD, 1, "15.23");
+    MatchQueue ready = match("m-gold", Tier.GOLD, "15.23");
     given(repository.pickReadyAndLock(2, "GOLD")).willReturn(List.of(ready));
     given(repository.pickRetryableErrorAndLock(1, 2, 5, "GOLD")).willReturn(List.of());
 
@@ -93,13 +93,13 @@ class MatchQueueDispatcherTest {
 
     verify(repository).pickReadyAndLock(2, "GOLD");
     verify(repository).pickRetryableErrorAndLock(1, 2, 5, "GOLD");
-    assertThat(items).containsExactly(new Item("m-gold", Tier.GOLD, 1, "15.23"));
+    assertThat(items).containsExactly(new Item("m-gold", Tier.GOLD, "15.23"));
   }
 
   @Test
   @DisplayName("markDone — 엔티티 상태를 DONE으로 업데이트한다")
   void markDoneUpdatesEntityStatus() {
-    MatchQueue mq = match("done", Tier.GOLD, 1, "15.23");
+    MatchQueue mq = match("done", Tier.GOLD, "15.23");
     mq.markRunning();
     given(repository.findById("done")).willReturn(Optional.of(mq));
 
@@ -112,7 +112,7 @@ class MatchQueueDispatcherTest {
   @Test
   @DisplayName("markError — 실패 메시지를 기록하고 상태를 ERROR로 설정한다")
   void markErrorRegistersFailureMessage() {
-    MatchQueue mq = match("err", Tier.GOLD, 1, "15.23");
+    MatchQueue mq = match("err", Tier.GOLD, "15.23");
     mq.markRunning();
     given(repository.findById("err")).willReturn(Optional.of(mq));
 
@@ -131,12 +131,11 @@ class MatchQueueDispatcherTest {
     verify(repository).unlockToReady("match");
   }
 
-  private MatchQueue match(String matchId, Tier tier, int priority, String patch) {
+  private MatchQueue match(String matchId, Tier tier, String patch) {
     OffsetDateTime now = OffsetDateTime.now();
     return MatchQueue.builder()
         .matchId(matchId)
         .status(QueueStatus.READY)
-        .priority(priority)
         .collectionTier(tier)
         .patch(patch)
         .retryCount(0)

--- a/src/test/java/com/bestduo_BE/pipeline/application/CollectMatchIdsRunnerTest.java
+++ b/src/test/java/com/bestduo_BE/pipeline/application/CollectMatchIdsRunnerTest.java
@@ -187,7 +187,7 @@ class CollectMatchIdsRunnerTest {
 
     runner.runBatch();
 
-    verify(matchQueueEnqueuer).enqueueAllIdempotent(any(), any(), anyInt(), eq("16.7"));
+    verify(matchQueueEnqueuer).enqueueAllIdempotent(any(), any(), eq("16.7"));
   }
 
   @Test
@@ -294,7 +294,7 @@ class CollectMatchIdsRunnerTest {
 
     runner.runBatch();
 
-    verify(matchQueueEnqueuer, never()).enqueueAllIdempotent(any(), any(), anyInt(), any());
+    verify(matchQueueEnqueuer, never()).enqueueAllIdempotent(any(), any(), any());
     verify(summonerRepository).markMatchIdsCollected(eq("p-empty"), any(OffsetDateTime.class));
   }
 


### PR DESCRIPTION
## Summary

MatchQueue 엔티티의 `priority` 필드를 제거합니다. 현재 모든 enqueue에서 동일 상수(`PipelineProperties.collectPriority = 50`)만 사용되어 `ORDER BY mq.priority ASC` 가 사실상 `ORDER BY mq.updated_at ASC` 와 동일하게 동작하던 **죽은 우선순위**입니다. YAGNI 원칙에 따라 차별화되지 않는 컬럼을 제거하고 스키마와 쿼리를 단순화합니다.

## Motivation

- `MatchQueueEnqueuer.enqueueAllIdempotent()` 호출처는 `CollectMatchIdsRunner` 단 한 곳이며 항상 `props.getCollectPriority()` (= 50)를 넘김
- JPA 쿼리 4곳의 `ORDER BY mq.priority ASC, mq.updated_at ASC` 가 사실상 `updated_at` 단독 정렬과 동일
- Stage 3 우선 처리(특정 티어 먼저 처리)는 별도 메커니즘 `priorityTier` (`WHERE collection_tier = ?`)로 작동하며, MatchQueue의 priority 컬럼과 무관

## Scope (Surgical)

`MatchQueue.priority` **필드만** 제거합니다. 살아있는 우선순위 메커니즘은 모두 유지:
- ✅ 유지: `Stage 3 priorityTier` 라운드로빈 (`PipelineRunner.buildTierOrder`)
- ✅ 유지: `executeWithPriority`, `pickAndLockWithPriority`, `pickReadyWithPriorityAndLock` 메서드 이름 (patch + tier 우선순위 의미)
- ✅ 유지: `application.yml` 의 `stage3-priority-tier` 설정

## Changes

**Main 코드 (6)**
- `MatchQueue.java` — `priority` 컬럼/필드 + `newReady()` 시그니처 축소
- `MatchQueueEnqueuer.java` — `enqueueAllIdempotent()` 시그니처 축소
- `MatchQueueJpaRepository.java` — `ORDER BY mq.priority ASC` 4곳 제거 + javadoc 정리
- `MatchQueueDispatcher.java` — `Item` record + `toItems()` 호출 축소
- `CollectMatchIdsRunner.java` — `enqueueAllIdempotent()` 호출 인자 축소
- `PipelineProperties.java` — `collectPriority` 필드 + `@Min`/`@Max` validation 제거

**테스트 (6)**
- `MatchQueueTest`, `MatchQueueEnqueuerTest`, `MatchQueueDispatcherTest`, `MatchQueueDispatcherPhase5Test`, `MatchIngestRunnerTest`, `CollectMatchIdsRunnerTest` — priority 인자/검증 제거

**DB 마이그레이션 (1 신규)**
- `V6__drop_match_queue_priority.sql` — `ALTER TABLE match_queue DROP COLUMN IF EXISTS priority`

## Test plan

- [x] `./gradlew compileJava compileTestJava` 통과
- [x] `./gradlew test` 통과 (전체 그린)
- [ ] 운영 환경 배포 후 Flyway V6 마이그레이션 정상 적용 확인
- [ ] Stage 3 dequeue 동작이 기존과 동일하게 동작하는지 운영 메트릭(`PipelineMetrics.stage_completed`) 확인