### PR TITLE
refactor: Riot rate limiter 를 호스트별 인스턴스로 분리

### DIFF
--- a/src/main/java/com/bestduo_BE/common/infra/riot/RiotApiConfig.java
+++ b/src/main/java/com/bestduo_BE/common/infra/riot/RiotApiConfig.java
@@ -3,16 +3,32 @@ package com.bestduo_BE.common.infra.riot;
 import com.bestduo_BE.config.RiotApiProperties;
 import java.time.Clock;
 import java.time.Duration;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.restclient.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.client.RestTemplate;
 
+/**
+ * Riot API 클라이언트 빈 구성.
+ *
+ * <p>kr.api(platform) 와 asia.api(regional) 는 Riot 측에서 별도 rate limit 버킷으로 카운팅되므로
+ * (RiotRegionRateLimitProbeTest 로 검증), 인터셉터/limiter 도 호스트별로 분리한다.
+ */
 @Configuration
 public class RiotApiConfig {
 
   @Bean
-  public RiotRateLimitInterceptor riotRateLimitInterceptor(RiotApiProperties properties) {
+  public RiotRateLimitInterceptor riotPlatformRateLimitInterceptor(RiotApiProperties properties) {
+    return new RiotRateLimitInterceptor(
+        properties.getApiKey(),
+        new DualWindowRateLimiter(10, Duration.ofSeconds(1), 60, Duration.ofMinutes(2)),
+        Clock.systemUTC()
+    );
+  }
+
+  @Bean
+  public RiotRateLimitInterceptor riotRegionalRateLimitInterceptor(RiotApiProperties properties) {
     return new RiotRateLimitInterceptor(
         properties.getApiKey(),
         new DualWindowRateLimiter(10, Duration.ofSeconds(1), 60, Duration.ofMinutes(2)),
@@ -23,7 +39,8 @@ public class RiotApiConfig {
   @Bean(name = "riotPlatformRestTemplate")
   public RestTemplate riotPlatformRestTemplate(
       RestTemplateBuilder restTemplateBuilder,
-      RiotRateLimitInterceptor rateLimitInterceptor,
+      @Qualifier("riotPlatformRateLimitInterceptor")
+          RiotRateLimitInterceptor rateLimitInterceptor,
       RiotApiProperties properties) {
     return buildRiotRestTemplate(restTemplateBuilder, properties.getPlatformBaseUrl(), rateLimitInterceptor);
   }
@@ -31,7 +48,8 @@ public class RiotApiConfig {
   @Bean(name = "riotRegionalRestTemplate")
   public RestTemplate riotRegionalRestTemplate(
       RestTemplateBuilder restTemplateBuilder,
-      RiotRateLimitInterceptor rateLimitInterceptor,
+      @Qualifier("riotRegionalRateLimitInterceptor")
+          RiotRateLimitInterceptor rateLimitInterceptor,
       RiotApiProperties properties) {
     return buildRiotRestTemplate(restTemplateBuilder, properties.getRegionalBaseUrl(), rateLimitInterceptor);
   }

--- a/src/test/java/com/bestduo_BE/common/infra/riot/RiotApiConfigTest.java
+++ b/src/test/java/com/bestduo_BE/common/infra/riot/RiotApiConfigTest.java
@@ -13,14 +13,13 @@ class RiotApiConfigTest {
   private final RiotApiConfig config = new RiotApiConfig();
 
   @Test
-  @DisplayName("riotRateLimitInterceptor — 설정된 API 키를 요청 헤더에 주입한다")
-  void riotRateLimitInterceptorUsesConfiguredApiKey() throws Exception {
+  @DisplayName("riotPlatformRateLimitInterceptor — 설정된 API 키를 요청 헤더에 주입한다")
+  void platformInterceptorUsesConfiguredApiKey() throws Exception {
     RiotApiProperties properties = new RiotApiProperties();
     properties.setApiKey("my-key");
 
-    RiotRateLimitInterceptor interceptor = config.riotRateLimitInterceptor(properties);
+    RiotRateLimitInterceptor interceptor = config.riotPlatformRateLimitInterceptor(properties);
 
-    // 헤더 주입 확인: mock execution으로 인터셉트 실행
     var request = new org.springframework.mock.http.client.MockClientHttpRequest();
     request.setURI(java.net.URI.create("https://kr.api.riotgames.com/test"));
     var execution = org.mockito.Mockito.mock(
@@ -36,16 +35,35 @@ class RiotApiConfigTest {
   }
 
   @Test
+  @DisplayName("platform / regional 인터셉터 — 호스트별 독립 인스턴스로 생성된다")
+  void platformAndRegionalInterceptorsAreSeparateInstances() {
+    RiotApiProperties properties = new RiotApiProperties();
+    properties.setApiKey("my-key");
+
+    RiotRateLimitInterceptor platform = config.riotPlatformRateLimitInterceptor(properties);
+    RiotRateLimitInterceptor regional = config.riotRegionalRateLimitInterceptor(properties);
+
+    // 호스트별 rate limit 버킷 독립을 위해 인스턴스가 분리되어야 함
+    assertThat(platform).isNotSameAs(regional);
+  }
+
+  @Test
   @DisplayName("riotPlatformRestTemplate / riotRegionalRestTemplate — 빈이 정상 생성된다")
   void restTemplateBeansAreCreatedWithCorrectNames() {
     RiotApiProperties properties = new RiotApiProperties();
     properties.setPlatformBaseUrl("https://kr.api.riotgames.com");
     properties.setRegionalBaseUrl("https://asia.api.riotgames.com");
     properties.setApiKey("my-key");
-    RiotRateLimitInterceptor interceptor = config.riotRateLimitInterceptor(properties);
 
-    RestTemplate platform = config.riotPlatformRestTemplate(new RestTemplateBuilder(), interceptor, properties);
-    RestTemplate regional = config.riotRegionalRestTemplate(new RestTemplateBuilder(), interceptor, properties);
+    RiotRateLimitInterceptor platformInterceptor =
+        config.riotPlatformRateLimitInterceptor(properties);
+    RiotRateLimitInterceptor regionalInterceptor =
+        config.riotRegionalRateLimitInterceptor(properties);
+
+    RestTemplate platform =
+        config.riotPlatformRestTemplate(new RestTemplateBuilder(), platformInterceptor, properties);
+    RestTemplate regional =
+        config.riotRegionalRestTemplate(new RestTemplateBuilder(), regionalInterceptor, properties);
 
     assertThat(platform).isNotNull();
     assertThat(regional).isNotNull();


### PR DESCRIPTION
## Summary
- `kr.api`(platform) 와 `asia.api`(regional) 가 Riot 측에서 **독립 rate limit 버킷**임이 #88 (`RiotRegionRateLimitProbeTest`) 로 검증됨
- 이를 활용하여 두 호스트가 단일 limiter 를 공유하던 구조를 **호스트별 인스턴스**로 분리

## Changes
- `riotRateLimitInterceptor` 단일 빈 → `riotPlatformRateLimitInterceptor` / `riotRegionalRateLimitInterceptor` 두 빈
- 각 인터셉터는 **독립적인 `DualWindowRateLimiter`** 보유 (한도값은 동일: 10/1s, 60/2min)
- `riotPlatformRestTemplate` / `riotRegionalRestTemplate` 는 각자 `@Qualifier` 로 자기 호스트용 인터셉터에 결선
- 인스턴스 분리 검증 테스트 (`platformAndRegionalInterceptorsAreSeparateInstances`) 추가

## Impact
- 동일 한도가 **호스트별로 독립 적용** → 두 호스트를 동시에 사용하는 워크로드의 실효 처리량 약 2배
- App-level 한도값 자체는 변경하지 않음 (보수적 마진 유지)
- 외부에 노출된 `riotPlatformRestTemplate` / `riotRegionalRestTemplate` 빈 이름은 변경 없음 → 호출부 코드 변경 불필요

## Test plan
- [x] `./gradlew test --tests "com.bestduo_BE.common.infra.riot.*"` 통과
- [x] Dev key 로 `RiotRegionRateLimitProbeTest` 재실행 → 단독 부하 시 각 호스트에서 429 발생, 병렬 부하 시 429=0 유지 (refactor 후에도 가설 유효)
- [ ] CI 빌드 통과

## Related
- 검증 PR: #88
- Pipeline 성능 향상 트래킹: #90 (이 PR 은 후속 병렬화/공정성 작업의 전제 조건)
