### PR TITLE
refactor: Stage 1 일일 예산 cap 제거 (KR limiter 자연 throttle 의존)

### DIFF
--- a/src/main/java/com/bestduo_BE/common/infra/riot/budget/DailyBudgetTracker.java
+++ b/src/main/java/com/bestduo_BE/common/infra/riot/budget/DailyBudgetTracker.java
@@ -10,9 +10,11 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 /**
- * Stage 1·2 일일 API 예산을 추적한다.
+ * Stage 2 일일 API 예산 및 Stage 1 호출량 (모니터링용) 을 추적한다.
+ * <p>Stage 1 은 platform(kr.api) 전용 limiter 의 자연 throttle 에 의존하므로
+ * 일일 cap 없이 호출 카운트만 누적한다 (운영 가시성 목적).
  * <p>자정마다 {@link DailyPipelineState}가 새로 생성되므로
- * 날짜가 바뀌면 예산은 자동으로 리셋된다.
+ * 날짜가 바뀌면 카운터는 자동으로 리셋된다.
  */
 @Component
 @RequiredArgsConstructor
@@ -22,23 +24,18 @@ public class DailyBudgetTracker {
   private final DailyPipelineStateJpaRepository stateRepository;
   private final PipelineProperties props;
 
-  /** Stage 1(SEED) 예산이 남아있으면 true */
-  public boolean canSeed() {
-    return getOrCreateTodayState().getSeedApiCallsUsed() < props.getSeedDailyBudget();
-  }
-
   /** Stage 2(COLLECT) 예산이 남아있으면 true */
   public boolean canCollect() {
     return getOrCreateTodayState().getCollectApiCallsUsed() < props.getCollectDailyBudget();
   }
 
-  /** Stage 1 API 호출 {@code count}회를 기록하고 DB에 저장한다. */
+  /** Stage 1 API 호출 {@code count}회를 기록하고 DB에 저장한다 (모니터링용). */
   public void recordSeedCall(int count) {
     recordSeedCall(count, null);
   }
 
   /**
-   * Stage 1 API 호출 {@code count}회를 기록하고, 완료된 apex 티어가 있으면 함께 저장한다.
+   * Stage 1 API 호출 {@code count}회를 기록하고, 완료된 apex 티어가 있으면 함께 저장한다 (모니터링용).
    * 단일 DB fetch로 seedApiCallsUsed와 seedCompletedTiers를 원자적으로 저장한다.
    */
   public void recordSeedCall(int count, Tier completedTier) {
@@ -48,8 +45,8 @@ public class DailyBudgetTracker {
       state.recordSeedCompletedTier(completedTier);
     }
     stateRepository.save(state);
-    log.debug("Seed 호출 기록: +{}, 완료 티어={}, 오늘 합계={}/{}", count, completedTier,
-        state.getSeedApiCallsUsed(), props.getSeedDailyBudget());
+    log.debug("Seed 호출 기록: +{}, 완료 티어={}, 오늘 누적={}", count, completedTier,
+        state.getSeedApiCallsUsed());
   }
 
   /** Stage 2 API 호출 {@code count}회를 기록하고 DB에 저장한다. */

--- a/src/main/java/com/bestduo_BE/config/PipelineProperties.java
+++ b/src/main/java/com/bestduo_BE/config/PipelineProperties.java
@@ -12,7 +12,8 @@ import org.springframework.validation.annotation.Validated;
 
 /**
  * 파이프라인 공통 설정.
- * <p>Stage별 일일 API 예산, 배치 크기, polling 간격, tier별 matchIds 수집 수를 관리한다.
+ * <p>Stage 2 일일 API 예산, 배치 크기, polling 간격, tier별 matchIds 수집 수를 관리한다.
+ * <p>Stage 1은 platform(kr.api) 전용 limiter 의 자연 throttle 에 의존하므로 별도 일일 cap이 없다.
  * <p>범위를 벗어난 env 주입 시 앱 시작이 거부된다 (운영 안전장치).
  */
 @Component
@@ -21,11 +22,6 @@ import org.springframework.validation.annotation.Validated;
 @Getter
 @Setter
 public class PipelineProperties {
-
-  /** Stage 1(SEED) 일일 API 호출 상한 */
-  @Min(1)
-  @Max(50_000)
-  private int seedDailyBudget = 2000;
 
   /** Stage 2(COLLECT_MATCH_IDS) 일일 API 호출 상한 */
   @Min(1)

--- a/src/main/java/com/bestduo_BE/pipeline/application/DailyLeagueEntriesRunner.java
+++ b/src/main/java/com/bestduo_BE/pipeline/application/DailyLeagueEntriesRunner.java
@@ -48,12 +48,8 @@ public class DailyLeagueEntriesRunner {
 
   /**
    * 오늘 처리할 seed 작업이 남아있으면 true.
-   * 예산 소진 시 항상 false.
    */
   public boolean hasWorkToday() {
-    if (!budgetTracker.canSeed()) {
-      return false;
-    }
     DailyPipelineState state = budgetTracker.getOrCreateTodayState();
     if (hasUncompletedApexTier(state)) {
       return true;
@@ -67,10 +63,6 @@ public class DailyLeagueEntriesRunner {
    * @return 청크 실행 결과
    */
   public ChunkResult runNextChunk() {
-    if (!budgetTracker.canSeed()) {
-      return ChunkResult.budgetExhausted();
-    }
-
     DailyPipelineState state = budgetTracker.getOrCreateTodayState();
 
     // Phase A: apex 티어 (CHALLENGER → GRANDMASTER → MASTER)
@@ -196,7 +188,6 @@ public class DailyLeagueEntriesRunner {
     public enum Type {
       APEX_TIER_CHUNK,
       NON_APEX_PAGE,
-      BUDGET_EXHAUSTED,
       NO_WORK
     }
 
@@ -206,10 +197,6 @@ public class DailyLeagueEntriesRunner {
 
     public static ChunkResult nonApexPage(Tier tier, int seeded) {
       return new ChunkResult(Type.NON_APEX_PAGE, tier, seeded);
-    }
-
-    public static ChunkResult budgetExhausted() {
-      return new ChunkResult(Type.BUDGET_EXHAUSTED, null, 0);
     }
 
     public static ChunkResult noWork() {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -67,7 +67,6 @@ archive:
 pipeline:
   runner:
     enabled: ${PIPELINE_RUNNER_ENABLED:false}
-  seed-daily-budget: ${PIPELINE_SEED_DAILY_BUDGET:2000}
   collect-daily-budget: ${PIPELINE_COLLECT_DAILY_BUDGET:12000}
   collect-batch-size: ${PIPELINE_COLLECT_BATCH_SIZE:20}
   ingest-batch-size: ${PIPELINE_INGEST_BATCH_SIZE:10}

--- a/src/test/java/com/bestduo_BE/common/infra/riot/budget/DailyBudgetTrackerTest.java
+++ b/src/test/java/com/bestduo_BE/common/infra/riot/budget/DailyBudgetTrackerTest.java
@@ -30,29 +30,8 @@ class DailyBudgetTrackerTest {
   @BeforeEach
   void setUp() {
     props = new PipelineProperties();
-    props.setSeedDailyBudget(100);
     props.setCollectDailyBudget(200);
     tracker = new DailyBudgetTracker(stateRepository, props);
-  }
-
-  @Test
-  @DisplayName("오늘 상태가 없으면 새로 생성하고 seed 예산이 남아있다")
-  void canSeed_whenNoStateExists_createsStateAndAllowsSeed() {
-    DailyPipelineState newState = DailyPipelineState.create(LocalDate.now());
-    given(stateRepository.findByPipelineDate(any(LocalDate.class))).willReturn(Optional.empty());
-    given(stateRepository.save(any(DailyPipelineState.class))).willReturn(newState);
-
-    assertThat(tracker.canSeed()).isTrue();
-  }
-
-  @Test
-  @DisplayName("seed 예산을 모두 소진하면 canSeed가 false")
-  void canSeed_whenBudgetExhausted_returnsFalse() {
-    DailyPipelineState exhausted = DailyPipelineState.create(LocalDate.now());
-    exhausted.incrementSeedCalls(100); // 예산 상한 100과 동일
-    given(stateRepository.findByPipelineDate(any(LocalDate.class))).willReturn(Optional.of(exhausted));
-
-    assertThat(tracker.canSeed()).isFalse();
   }
 
   @Test

--- a/src/test/java/com/bestduo_BE/config/PipelinePropertiesTest.java
+++ b/src/test/java/com/bestduo_BE/config/PipelinePropertiesTest.java
@@ -39,10 +39,10 @@ class PipelinePropertiesTest {
   }
 
   @Test
-  @DisplayName("seedDailyBudget이 0이면 검증 위반이 발생한다")
-  void validate_zeroSeedBudget_violates() {
+  @DisplayName("collectDailyBudget이 0이면 검증 위반이 발생한다")
+  void validate_zeroCollectBudget_violates() {
     PipelineProperties properties = new PipelineProperties();
-    properties.setSeedDailyBudget(0);
+    properties.setCollectDailyBudget(0);
 
     Set<ConstraintViolation<PipelineProperties>> violations = validator.validate(properties);
 
@@ -50,10 +50,10 @@ class PipelinePropertiesTest {
   }
 
   @Test
-  @DisplayName("seedDailyBudget이 상한을 초과하면 검증 위반이 발생한다")
-  void validate_tooLargeSeedBudget_violates() {
+  @DisplayName("collectDailyBudget이 상한을 초과하면 검증 위반이 발생한다")
+  void validate_tooLargeCollectBudget_violates() {
     PipelineProperties properties = new PipelineProperties();
-    properties.setSeedDailyBudget(50_001);
+    properties.setCollectDailyBudget(50_001);
 
     Set<ConstraintViolation<PipelineProperties>> violations = validator.validate(properties);
 

--- a/src/test/java/com/bestduo_BE/pipeline/application/DailyLeagueEntriesRunnerTest.java
+++ b/src/test/java/com/bestduo_BE/pipeline/application/DailyLeagueEntriesRunnerTest.java
@@ -55,17 +55,8 @@ class DailyLeagueEntriesRunnerTest {
   // ── hasWorkToday ────────────────────────────────────────────────────
 
   @Test
-  @DisplayName("seed 예산 소진 시 hasWorkToday는 false")
-  void hasWorkToday_whenBudgetExhausted_returnsFalse() {
-    given(budgetTracker.canSeed()).willReturn(false);
-
-    assertThat(runner.hasWorkToday()).isFalse();
-  }
-
-  @Test
   @DisplayName("apex 티어가 오늘 완료되지 않았으면 hasWorkToday는 true")
   void hasWorkToday_whenApexTierNotCompleted_returnsTrue() {
-    given(budgetTracker.canSeed()).willReturn(true);
     DailyPipelineState state = DailyPipelineState.create(LocalDate.now());
     given(budgetTracker.getOrCreateTodayState()).willReturn(state);
 
@@ -75,8 +66,6 @@ class DailyLeagueEntriesRunnerTest {
   @Test
   @DisplayName("모든 apex·DIA·EME quota 소진 시 hasWorkToday는 false")
   void hasWorkToday_whenAllQuotaExhausted_returnsFalse() {
-    given(budgetTracker.canSeed()).willReturn(true);
-
     DailyPipelineState state = DailyPipelineState.create(LocalDate.now());
     state.recordSeedCompletedTier(Tier.CHALLENGER);
     state.recordSeedCompletedTier(Tier.GRANDMASTER);
@@ -95,8 +84,6 @@ class DailyLeagueEntriesRunnerTest {
   @Test
   @DisplayName("DIA 버킷의 quota가 남아있으면 hasWorkToday는 true")
   void hasWorkToday_whenDiaBucketHasRemainingQuota_returnsTrue() {
-    given(budgetTracker.canSeed()).willReturn(true);
-
     DailyPipelineState state = DailyPipelineState.create(LocalDate.now());
     state.recordSeedCompletedTier(Tier.CHALLENGER);
     state.recordSeedCompletedTier(Tier.GRANDMASTER);
@@ -114,20 +101,8 @@ class DailyLeagueEntriesRunnerTest {
   // ── runNextChunk ────────────────────────────────────────────────────
 
   @Test
-  @DisplayName("seed 예산 소진 시 runNextChunk는 BUDGET_EXHAUSTED 반환")
-  void runNextChunk_whenBudgetExhausted_returnsBudgetExhausted() {
-    given(budgetTracker.canSeed()).willReturn(false);
-
-    DailyLeagueEntriesRunner.ChunkResult result = runner.runNextChunk();
-
-    assertThat(result.type()).isEqualTo(DailyLeagueEntriesRunner.ChunkResult.Type.BUDGET_EXHAUSTED);
-    verify(leagueEntriesFetcher, never()).execute(any());
-  }
-
-  @Test
   @DisplayName("CHALLENGER 티어가 미완료면 LeagueEntriesFetcher를 호출하고 완료 기록")
   void runNextChunk_whenChallengerNotDone_executesSeedAndRecordsCompletion() {
-    given(budgetTracker.canSeed()).willReturn(true);
 
     DailyPipelineState state = DailyPipelineState.create(LocalDate.now());
     given(budgetTracker.getOrCreateTodayState()).willReturn(state);
@@ -147,7 +122,6 @@ class DailyLeagueEntriesRunnerTest {
   @Test
   @DisplayName("apex 티어 모두 완료 후 DIA 버킷 미완료면 DIA 페이지 실행")
   void runNextChunk_whenApexDoneAndDiaPending_executesDiaPage() {
-    given(budgetTracker.canSeed()).willReturn(true);
 
     DailyPipelineState state = DailyPipelineState.create(LocalDate.now());
     state.recordSeedCompletedTier(Tier.CHALLENGER);
@@ -175,7 +149,6 @@ class DailyLeagueEntriesRunnerTest {
   @Test
   @DisplayName("DIA 페이지가 빈 응답이면 advanceToNextDivision을 호출하고 quota를 카운트한다")
   void runNextChunk_whenDiaPageEmpty_advancesToNextDivisionAndCountsQuota() {
-    given(budgetTracker.canSeed()).willReturn(true);
 
     DailyPipelineState state = DailyPipelineState.create(LocalDate.now());
     state.recordSeedCompletedTier(Tier.CHALLENGER);
@@ -205,7 +178,6 @@ class DailyLeagueEntriesRunnerTest {
   @Test
   @DisplayName("DIA 페이지가 정상 응답이면 seedPage가 증가하고 quota를 카운트한다")
   void runNextChunk_whenDiaPageNotEmpty_advancesPageAndCountsQuota() {
-    given(budgetTracker.canSeed()).willReturn(true);
 
     DailyPipelineState state = DailyPipelineState.create(LocalDate.now());
     state.recordSeedCompletedTier(Tier.CHALLENGER);
@@ -233,7 +205,6 @@ class DailyLeagueEntriesRunnerTest {
   @Test
   @DisplayName("모든 티어 quota 소진 시 runNextChunk는 NO_WORK 반환")
   void runNextChunk_whenAllQuotaExhausted_returnsNoWork() {
-    given(budgetTracker.canSeed()).willReturn(true);
 
     DailyPipelineState state = DailyPipelineState.create(LocalDate.now());
     state.recordSeedCompletedTier(Tier.CHALLENGER);
@@ -257,7 +228,6 @@ class DailyLeagueEntriesRunnerTest {
   @Test
   @DisplayName("DIA 버킷이 DB에 없으면 hasWorkToday는 true를 반환한다")
   void hasWorkToday_whenDiaBucketMissing_returnsTrue() {
-    given(budgetTracker.canSeed()).willReturn(true);
 
     DailyPipelineState state = DailyPipelineState.create(LocalDate.now());
     state.recordSeedCompletedTier(Tier.CHALLENGER);
@@ -274,7 +244,6 @@ class DailyLeagueEntriesRunnerTest {
   @Test
   @DisplayName("DIA 버킷이 DB에 없으면 runNextChunk는 버킷을 생성하고 DIA 페이지를 실행한다")
   void runNextChunk_whenDiaBucketMissing_createsBucketAndExecutesDiaPage() {
-    given(budgetTracker.canSeed()).willReturn(true);
 
     DailyPipelineState state = DailyPipelineState.create(LocalDate.now());
     state.recordSeedCompletedTier(Tier.CHALLENGER);
@@ -308,7 +277,6 @@ class DailyLeagueEntriesRunnerTest {
   @Test
   @DisplayName("currentPatch가 null이면 DIA/EME seed를 스킵하고 NO_WORK 반환")
   void runNextChunk_whenCurrentPatchNull_skipsDiaEmeAndReturnsNoWork() {
-    given(budgetTracker.canSeed()).willReturn(true);
 
     DailyPipelineState state = DailyPipelineState.create(LocalDate.now());
     state.recordSeedCompletedTier(Tier.CHALLENGER);
@@ -329,7 +297,6 @@ class DailyLeagueEntriesRunnerTest {
   @Test
   @DisplayName("DIA quota가 소진됐으면 hasWorkToday는 false를 반환한다")
   void hasWorkToday_whenDiaQuotaExhausted_returnsFalse() {
-    given(budgetTracker.canSeed()).willReturn(true);
 
     DailyPipelineState state = DailyPipelineState.create(LocalDate.now());
     state.recordSeedCompletedTier(Tier.CHALLENGER);
@@ -351,7 +318,6 @@ class DailyLeagueEntriesRunnerTest {
   @Test
   @DisplayName("어제 quota 소진된 DIA 버킷은 자정 후 hasWorkToday=true (resetDailyPagesIfNeeded 호출)")
   void hasWorkToday_whenDiaBucketExhaustedYesterday_returnsTrue() {
-    given(budgetTracker.canSeed()).willReturn(true);
 
     DailyPipelineState state = DailyPipelineState.create(LocalDate.now());
     state.recordSeedCompletedTier(Tier.CHALLENGER);
@@ -369,7 +335,6 @@ class DailyLeagueEntriesRunnerTest {
   @Test
   @DisplayName("어제 quota 소진된 DIA 버킷은 runNextChunk에서 reset 후 새 페이지를 실행한다")
   void runNextChunk_whenDiaBucketExhaustedYesterday_resetsAndRunsPage() {
-    given(budgetTracker.canSeed()).willReturn(true);
 
     DailyPipelineState state = DailyPipelineState.create(LocalDate.now());
     state.recordSeedCompletedTier(Tier.CHALLENGER);


### PR DESCRIPTION
## Summary

Host 별 limiter 분리(#89) 이후 Stage 1 은 platform(`kr.api`) 전용 limiter 한도 자체로 자연 throttle 됨. `DailyBudgetTracker.canSeed()` 기반의 일일 cap 은 더 이상 필요 없으므로 제거.

Issue #90 의 ① ② 본격 작업(`PlatformPipelineRunner` 분리) 전 사전 cleanup PR.

## 배경

- 기존: Stage 1 호출량 ≤ `seedDailyBudget` (기본 2000/day) cap. 단일 limiter 가정 하에 Stage 2/3 에게 budget 양보 정책의 일부.
- 변경 후 (PR #89): Stage 1 은 KR 호스트 전용 (72,000 req/day 한도). 실제 호출량은 ~200/day 로 KR 한도의 0.3%.
- 결론: cap 이 도달할 일이 정상 운영에선 없음. 양보할 다른 stage 도 없음.

## Changes

- ❌ `application.yml` 의 `seed-daily-budget` 제거
- ❌ `PipelineProperties.seedDailyBudget` 필드 제거
- ❌ `DailyBudgetTracker.canSeed()` 메서드 제거
- ❌ `DailyLeagueEntriesRunner.hasWorkToday() / runNextChunk()` 의 `canSeed()` 분기 제거
- ❌ `ChunkResult.Type.BUDGET_EXHAUSTED` + `budgetExhausted()` factory 제거
- ❌ 관련 테스트 정리 (`PipelinePropertiesTest`, `DailyBudgetTrackerTest`, `DailyLeagueEntriesRunnerTest`)

## 유지된 것 (모니터링/관측 가치)

- ✅ `DailyBudgetTracker.recordSeedCall(...)` — Stage 1 호출 카운트 누적
- ✅ `DailyPipelineState.seedApiCallsUsed` 컬럼 — 운영 가시성 (스키마 migration 불필요)
- ✅ `DailyLeagueEntriesRunner` 의 `recordSeedCall()` 호출 — 카운트 추적 계속

## Stage 2/3 영향

Stage 2 의 `collectDailyBudget` 은 그대로 유지. ASIA limiter 안에서 Stage 3 와 budget 공유 정책은 별개 결정 (#90 의 ② 항목).

`CollectMatchIdsRunner.BatchResult.Type.BUDGET_EXHAUSTED` 는 `DailyLeagueEntriesRunner.ChunkResult.Type.BUDGET_EXHAUSTED` 와 별개 inner record 의 enum 이라 영향 없음.

## Test plan

- [x] `./gradlew compileJava compileTestJava` 통과
- [x] `./gradlew test` 통과
- [ ] 머지 후 운영에서 Stage 1 호출량 비정상 증가 없는지 1-2일 모니터링 (`DailyPipelineState.seedApiCallsUsed`)

## Related

- #90 — pipeline 성능 향상 (이번 PR 은 사전 cleanup, 이후 ① ② 본격 작업 예정)
- #89 — host 별 limiter 분리