### PR TITLE
refactor: PipelineRunner 를 host 별 2개 runner 로 분리 (Stage 1 ↔ Stage 2/3 병렬)

### DIFF
--- a/src/main/java/com/bestduo_BE/common/infra/persistence/entity/DailyPipelineState.java
+++ b/src/main/java/com/bestduo_BE/common/infra/persistence/entity/DailyPipelineState.java
@@ -83,11 +83,6 @@ public class DailyPipelineState {
         .build();
   }
 
-  public void incrementSeedCalls(int delta) {
-    this.seedApiCallsUsed += delta;
-    this.updatedAt = OffsetDateTime.now();
-  }
-
   public void incrementCollectCalls(int delta) {
     this.collectApiCallsUsed += delta;
     this.updatedAt = OffsetDateTime.now();

--- a/src/main/java/com/bestduo_BE/common/infra/persistence/repository/DailyPipelineStateJpaRepository.java
+++ b/src/main/java/com/bestduo_BE/common/infra/persistence/repository/DailyPipelineStateJpaRepository.java
@@ -8,4 +8,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 public interface DailyPipelineStateJpaRepository extends JpaRepository<DailyPipelineState, Long> {
 
   Optional<DailyPipelineState> findByPipelineDate(LocalDate pipelineDate);
+
+  /** 해당 날짜의 row 가 있으면 반환, 없으면 새로 만들어 저장 후 반환. */
+  default DailyPipelineState getOrCreateForDate(LocalDate date) {
+    return findByPipelineDate(date).orElseGet(() -> save(DailyPipelineState.create(date)));
+  }
 }

--- a/src/main/java/com/bestduo_BE/common/infra/riot/budget/DailyBudgetTracker.java
+++ b/src/main/java/com/bestduo_BE/common/infra/riot/budget/DailyBudgetTracker.java
@@ -1,6 +1,5 @@
 package com.bestduo_BE.common.infra.riot.budget;
 
-import com.bestduo_BE.common.domain.model.Tier;
 import com.bestduo_BE.common.infra.persistence.entity.DailyPipelineState;
 import com.bestduo_BE.common.infra.persistence.repository.DailyPipelineStateJpaRepository;
 import com.bestduo_BE.config.PipelineProperties;
@@ -10,11 +9,13 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
 
 /**
- * Stage 2 일일 API 예산 및 Stage 1 호출량 (모니터링용) 을 추적한다.
- * <p>Stage 1 은 platform(kr.api) 전용 limiter 의 자연 throttle 에 의존하므로
- * 일일 cap 없이 호출 카운트만 누적한다 (운영 가시성 목적).
- * <p>자정마다 {@link DailyPipelineState}가 새로 생성되므로
- * 날짜가 바뀌면 카운터는 자동으로 리셋된다.
+ * Stage 2(COLLECT_MATCH_IDS) 일일 API 예산을 추적한다.
+ *
+ * <p>Stage 1 은 platform(kr.api) 전용 limiter 의 자연 throttle 에 의존하므로 cap 이 없고,
+ * 진행 상태 (`seedCompletedTiers`) 는 {@code DailyLeagueEntriesRunner} 가
+ * {@link DailyPipelineStateJpaRepository} 를 통해 직접 관리한다.
+ *
+ * <p>자정마다 {@link DailyPipelineState} row 가 새로 생성되므로 날짜가 바뀌면 카운터가 자동으로 리셋된다.
  */
 @Component
 @RequiredArgsConstructor
@@ -26,45 +27,16 @@ public class DailyBudgetTracker {
 
   /** Stage 2(COLLECT) 예산이 남아있으면 true */
   public boolean canCollect() {
-    return getOrCreateTodayState().getCollectApiCallsUsed() < props.getCollectDailyBudget();
-  }
-
-  /** Stage 1 API 호출 {@code count}회를 기록하고 DB에 저장한다 (모니터링용). */
-  public void recordSeedCall(int count) {
-    recordSeedCall(count, null);
-  }
-
-  /**
-   * Stage 1 API 호출 {@code count}회를 기록하고, 완료된 apex 티어가 있으면 함께 저장한다 (모니터링용).
-   * 단일 DB fetch로 seedApiCallsUsed와 seedCompletedTiers를 원자적으로 저장한다.
-   */
-  public void recordSeedCall(int count, Tier completedTier) {
-    DailyPipelineState state = getOrCreateTodayState();
-    state.incrementSeedCalls(count);
-    if (completedTier != null) {
-      state.recordSeedCompletedTier(completedTier);
-    }
-    stateRepository.save(state);
-    log.debug("Seed 호출 기록: +{}, 완료 티어={}, 오늘 누적={}", count, completedTier,
-        state.getSeedApiCallsUsed());
+    return stateRepository.getOrCreateForDate(LocalDate.now())
+        .getCollectApiCallsUsed() < props.getCollectDailyBudget();
   }
 
   /** Stage 2 API 호출 {@code count}회를 기록하고 DB에 저장한다. */
   public void recordCollectCall(int count) {
-    DailyPipelineState state = getOrCreateTodayState();
+    DailyPipelineState state = stateRepository.getOrCreateForDate(LocalDate.now());
     state.incrementCollectCalls(count);
     stateRepository.save(state);
     log.debug("Collect 호출 기록: +{}, 오늘 합계={}/{}", count, state.getCollectApiCallsUsed(),
         props.getCollectDailyBudget());
-  }
-
-  /**
-   * 오늘 날짜의 {@link DailyPipelineState}를 조회하거나 없으면 새로 생성한다.
-   * 재시작 복구에도 사용된다.
-   */
-  public DailyPipelineState getOrCreateTodayState() {
-    LocalDate today = LocalDate.now();
-    return stateRepository.findByPipelineDate(today)
-        .orElseGet(() -> stateRepository.save(DailyPipelineState.create(today)));
   }
 }

--- a/src/main/java/com/bestduo_BE/config/PipelineProperties.java
+++ b/src/main/java/com/bestduo_BE/config/PipelineProperties.java
@@ -66,7 +66,7 @@ public class PipelineProperties {
   /** DIA/EME 버킷당 하루에 처리할 최대 페이지 수 (per-bucket). */
   @Min(1)
   @Max(10_000)
-  private int diaEmeDailyPageQuota = 10;
+  private int diaEmeDailyPageQuota = 1000;
 
   /** Stage 3(INGEST)에서 그날 먼저 처리할 tier. null이면 기존 우선순위(CHALLENGER→…→기타) 유지. */
   private Tier stage3PriorityTier = null;

--- a/src/main/java/com/bestduo_BE/pipeline/application/DailyLeagueEntriesRunner.java
+++ b/src/main/java/com/bestduo_BE/pipeline/application/DailyLeagueEntriesRunner.java
@@ -5,7 +5,7 @@ import com.bestduo_BE.common.domain.model.EffectivePatchContext;
 import com.bestduo_BE.common.domain.model.LeagueEntriesFetchCommand;
 import com.bestduo_BE.common.domain.model.Tier;
 import com.bestduo_BE.common.infra.persistence.entity.DailyPipelineState;
-import com.bestduo_BE.common.infra.riot.budget.DailyBudgetTracker;
+import com.bestduo_BE.common.infra.persistence.repository.DailyPipelineStateJpaRepository;
 import com.bestduo_BE.config.PipelineProperties;
 import com.bestduo_BE.coverage.infra.persistence.entity.CoverageBucket;
 import com.bestduo_BE.coverage.infra.persistence.repository.CoverageBucketJpaRepository;
@@ -40,7 +40,7 @@ public class DailyLeagueEntriesRunner {
 
   private final LeagueEntriesFetcher leagueEntriesFetcher;
   private final CoverageBucketJpaRepository coverageBucketRepository;
-  private final DailyBudgetTracker budgetTracker;
+  private final DailyPipelineStateJpaRepository stateRepository;
   private final PatchVersionService patchVersionService;
   private final PipelineProperties props;
 
@@ -50,7 +50,7 @@ public class DailyLeagueEntriesRunner {
    * 오늘 처리할 seed 작업이 남아있으면 true.
    */
   public boolean hasWorkToday() {
-    DailyPipelineState state = budgetTracker.getOrCreateTodayState();
+    DailyPipelineState state = stateRepository.getOrCreateForDate(LocalDate.now());
     if (hasUncompletedApexTier(state)) {
       return true;
     }
@@ -63,7 +63,7 @@ public class DailyLeagueEntriesRunner {
    * @return 청크 실행 결과
    */
   public ChunkResult runNextChunk() {
-    DailyPipelineState state = budgetTracker.getOrCreateTodayState();
+    DailyPipelineState state = stateRepository.getOrCreateForDate(LocalDate.now());
 
     // Phase A: apex 티어 (CHALLENGER → GRANDMASTER → MASTER)
     for (Tier tier : Tier.APEX_TIERS) {
@@ -143,9 +143,10 @@ public class DailyLeagueEntriesRunner {
         QUEUE, tier.name(), "I", tier, 1, 0);
     LeagueEntriesFetchResult result = leagueEntriesFetcher.execute(cmd);
 
-    // tier 완료 기록과 seed 호출 수를 단일 DB fetch로 원자적으로 저장
-    int pages = result.pagesProcessed() > 0 ? result.pagesProcessed() : 1;
-    budgetTracker.recordSeedCall(pages, tier);
+    // tier 완료 기록 (호출량 카운트는 PipelineMetrics 가 stage 카운터로 추적)
+    DailyPipelineState state = stateRepository.getOrCreateForDate(LocalDate.now());
+    state.recordSeedCompletedTier(tier);
+    stateRepository.save(state);
     log.info("Stage1 apex 완료: tier={} seeded={}", tier, result.summonersSeeded());
     return ChunkResult.apexTier(tier, result.summonersSeeded());
   }
@@ -163,8 +164,6 @@ public class DailyLeagueEntriesRunner {
         0
     );
     LeagueEntriesFetchResult result = leagueEntriesFetcher.execute(cmd);
-
-    budgetTracker.recordSeedCall(1);
 
     if (result.entriesFetched() == 0) {
       // 빈 응답 = 해당 division 소진 → 다음 division으로 이동

--- a/src/main/java/com/bestduo_BE/pipeline/application/PlatformPipelineRunner.java
+++ b/src/main/java/com/bestduo_BE/pipeline/application/PlatformPipelineRunner.java
@@ -1,0 +1,103 @@
+package com.bestduo_BE.pipeline.application;
+
+import com.bestduo_BE.common.infra.riot.exception.RiotRateLimitedException;
+import com.bestduo_BE.config.PipelineProperties;
+import jakarta.annotation.PostConstruct;
+import jakarta.annotation.PreDestroy;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Component;
+
+/**
+ * Platform host(kr.api) 전담 파이프라인 루프.
+ *
+ * <p>Stage 1 — {@link DailyLeagueEntriesRunner}: league-v4 기반 summoner 등록/갱신.
+ *
+ * <p>{@link RegionalPipelineRunner}와 독립된 가상 스레드에서 실행되며, KR limiter 의
+ * 429 가 발생해도 regional 루프는 영향받지 않는다 (host 별 격리).
+ *
+ * <p>idle 상태 (오늘 할 work 없음) 에서는 {@code pollingIntervalMs} sleep.
+ * 429 발생 시 {@link #RATE_LIMIT_SLEEP_MS} sleep 후 재시도.
+ */
+@Component
+@ConditionalOnProperty(prefix = "pipeline.runner", name = "enabled", havingValue = "true", matchIfMissing = true)
+@RequiredArgsConstructor
+@Slf4j
+public class PlatformPipelineRunner {
+
+  private static final long RATE_LIMIT_SLEEP_MS = 60_000L;
+
+  private final DailyLeagueEntriesRunner dailyLeagueEntriesRunner;
+  private final PipelineProperties props;
+  private final PipelineMetrics pipelineMetrics;
+
+  private Thread thread;
+
+  @PostConstruct
+  public void start() {
+    thread = Thread.ofVirtual().name("platform-pipeline-runner").start(this::loop);
+  }
+
+  @PreDestroy
+  public void stop() {
+    if (thread != null) {
+      thread.interrupt();
+      log.info("PlatformPipelineRunner 종료 요청 (interrupt)");
+      try {
+        thread.join(30_000L);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+      if (thread.isAlive()) {
+        log.warn("PlatformPipelineRunner 30초 내 종료되지 않음");
+      }
+    }
+  }
+
+  private void loop() {
+    log.info("PlatformPipelineRunner 시작 (가상 스레드)");
+    while (!Thread.currentThread().isInterrupted()) {
+      try {
+        executeTick();
+      } catch (RiotRateLimitedException e) {
+        log.warn("[platform] 429 Rate limited. {}ms 대기 후 재시도", RATE_LIMIT_SLEEP_MS);
+        sleep(RATE_LIMIT_SLEEP_MS);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        log.info("PlatformPipelineRunner 종료 (interrupted)");
+        break;
+      } catch (Exception e) {
+        log.error("PlatformPipelineRunner 예기치 않은 오류. {}ms 후 재시도",
+            props.getErrorBackoffMs(), e);
+        sleep(props.getErrorBackoffMs());
+      }
+    }
+  }
+
+  /** Stage 1 한 단위를 실행한다. 테스트에서 직접 호출 가능하도록 package-private. */
+  void executeTick() throws InterruptedException {
+    if (dailyLeagueEntriesRunner.hasWorkToday()) {
+      log.debug("Stage 1 실행");
+      try {
+        dailyLeagueEntriesRunner.runNextChunk();
+        pipelineMetrics.recordStageCompleted(1, "success");
+      } catch (RuntimeException e) {
+        pipelineMetrics.recordStageCompleted(1, "error");
+        throw e;
+      }
+      return;
+    }
+
+    log.debug("Stage 1 할 일 없음. {}ms 대기", props.getPollingIntervalMs());
+    Thread.sleep(props.getPollingIntervalMs());
+  }
+
+  private void sleep(long ms) {
+    try {
+      Thread.sleep(ms);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
+  }
+}

--- a/src/main/java/com/bestduo_BE/pipeline/application/RegionalPipelineRunner.java
+++ b/src/main/java/com/bestduo_BE/pipeline/application/RegionalPipelineRunner.java
@@ -17,94 +17,80 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
 /**
- * 단일 가상 스레드 파이프라인 루프.
+ * Regional host(asia.api) 전담 파이프라인 루프.
  *
  * <p>Stage 우선순위:
  * <ol>
- *   <li>Stage 1 — {@link DailyLeagueEntriesRunner}: summoner 등록/갱신 (일일 예산 소진 전)</li>
- *   <li>Stage 2 — {@link CollectMatchIdsRunner}: matchIds 수집 (일일 예산 소진 전)</li>
- *   <li>Stage 3 — {@link MatchIngestRunner}: match 상세 수집 (상시)</li>
+ *   <li>Stage 2 — {@link CollectMatchIdsRunner}: matchIds 수집 (일일 예산 내)</li>
+ *   <li>Stage 3 — {@link MatchIngestRunner}: match 상세 수집 (상시, patch+tier 우선순위)</li>
  * </ol>
  *
- * <p>429 발생 시 {@code rateLimitSleepMs}(기본 60초) sleep 후 재시도.
- * match_queue가 비어있으면 {@code pollingIntervalMs} sleep.
+ * <p>{@link PlatformPipelineRunner}와 독립된 가상 스레드에서 실행되며, ASIA limiter 의
+ * 429 가 발생해도 platform 루프는 영향받지 않는다 (host 별 격리).
+ *
+ * <p>match_queue 가 비어있으면 {@code pollingIntervalMs} sleep.
+ * 429 발생 시 {@link #RATE_LIMIT_SLEEP_MS} sleep 후 재시도.
  */
 @Component
 @ConditionalOnProperty(prefix = "pipeline.runner", name = "enabled", havingValue = "true", matchIfMissing = true)
 @RequiredArgsConstructor
 @Slf4j
-public class PipelineRunner {
+public class RegionalPipelineRunner {
 
   private static final long RATE_LIMIT_SLEEP_MS = 60_000L;
   private static final Tier ROUND_ROBIN_LOWEST_TIER = Tier.EMERALD;
 
-  private final DailyLeagueEntriesRunner dailyLeagueEntriesRunner;
   private final CollectMatchIdsRunner collectMatchIdsRunner;
   private final MatchIngestRunner matchIngestRunner;
   private final PatchVersionService patchVersionService;
   private final PipelineProperties props;
   private final PipelineMetrics pipelineMetrics;
 
-  private Thread pipelineThread;
+  private Thread thread;
 
   @PostConstruct
   public void start() {
-    pipelineThread = Thread.ofVirtual().name("pipeline-runner").start(this::loop);
+    thread = Thread.ofVirtual().name("regional-pipeline-runner").start(this::loop);
   }
 
   @PreDestroy
   public void stop() {
-    if (pipelineThread != null) {
-      pipelineThread.interrupt();
-      log.info("PipelineRunner 종료 요청 (interrupt)");
+    if (thread != null) {
+      thread.interrupt();
+      log.info("RegionalPipelineRunner 종료 요청 (interrupt)");
       try {
-        pipelineThread.join(30_000L);
+        thread.join(30_000L);
       } catch (InterruptedException e) {
         Thread.currentThread().interrupt();
       }
-      if (pipelineThread.isAlive()) {
-        log.warn("PipelineRunner 30초 내 종료되지 않음");
+      if (thread.isAlive()) {
+        log.warn("RegionalPipelineRunner 30초 내 종료되지 않음");
       }
     }
   }
 
   private void loop() {
-    log.info("PipelineRunner 시작 (가상 스레드)");
+    log.info("RegionalPipelineRunner 시작 (가상 스레드)");
     while (!Thread.currentThread().isInterrupted()) {
       try {
         executeTick();
       } catch (RiotRateLimitedException e) {
-        log.warn("429 Rate limited. {}ms 대기 후 재시도", RATE_LIMIT_SLEEP_MS);
+        log.warn("[regional] 429 Rate limited. {}ms 대기 후 재시도", RATE_LIMIT_SLEEP_MS);
         sleep(RATE_LIMIT_SLEEP_MS);
       } catch (InterruptedException e) {
         Thread.currentThread().interrupt();
-        log.info("PipelineRunner 종료 (interrupted)");
+        log.info("RegionalPipelineRunner 종료 (interrupted)");
         break;
       } catch (Exception e) {
-        log.error("PipelineRunner 예기치 않은 오류. {}ms 후 재시도", props.getErrorBackoffMs(), e);
+        log.error("RegionalPipelineRunner 예기치 않은 오류. {}ms 후 재시도",
+            props.getErrorBackoffMs(), e);
         sleep(props.getErrorBackoffMs());
       }
     }
   }
 
-  /**
-   * Stage 1 → 2 → 3 우선순위 판단 후 한 단위를 실행한다.
-   * 테스트에서 직접 호출 가능하도록 package-private.
-   */
+  /** Stage 2 → 3 우선순위 판단 후 한 단위를 실행한다. 테스트에서 직접 호출 가능하도록 package-private. */
   void executeTick() throws InterruptedException {
-    // Stage 1: Seed (일일 예산 내)
-    if (dailyLeagueEntriesRunner.hasWorkToday()) {
-      log.debug("Stage 1 실행");
-      try {
-        dailyLeagueEntriesRunner.runNextChunk();
-        pipelineMetrics.recordStageCompleted(1, "success");
-      } catch (RuntimeException e) {
-        pipelineMetrics.recordStageCompleted(1, "error");
-        throw e;
-      }
-      return;
-    }
-
     // Stage 2: CollectMatchIds (일일 예산 내)
     if (collectMatchIdsRunner.hasPending()) {
       log.debug("Stage 2 실행");

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -72,6 +72,7 @@ pipeline:
   ingest-batch-size: ${PIPELINE_INGEST_BATCH_SIZE:10}
   polling-interval-ms: ${PIPELINE_POLLING_INTERVAL_MS:5000}
   max-pages-per-division: ${PIPELINE_MAX_PAGES_PER_DIVISION:100}
+  dia-eme-daily-page-quota: ${PIPELINE_DIA_EME_DAILY_PAGE_QUOTA:1000}
   tier-match-count:
     apex-tiers: ${PIPELINE_TIER_APEX:100}
     diamond-emerald: ${PIPELINE_TIER_DIA_EME:100}

--- a/src/test/java/com/bestduo_BE/common/infra/persistence/entity/DailyPipelineStateTest.java
+++ b/src/test/java/com/bestduo_BE/common/infra/persistence/entity/DailyPipelineStateTest.java
@@ -25,17 +25,6 @@ class DailyPipelineStateTest {
   }
 
   @Test
-  @DisplayName("incrementSeedCalls() — seedApiCallsUsed가 delta만큼 증가한다")
-  void incrementSeedCallsAddsToCount() {
-    DailyPipelineState state = DailyPipelineState.create(LocalDate.now());
-
-    state.incrementSeedCalls(3);
-    state.incrementSeedCalls(2);
-
-    assertThat(state.getSeedApiCallsUsed()).isEqualTo(5);
-  }
-
-  @Test
   @DisplayName("incrementCollectCalls() — collectApiCallsUsed가 delta만큼 증가한다")
   void incrementCollectCallsAddsToCount() {
     DailyPipelineState state = DailyPipelineState.create(LocalDate.now());

--- a/src/test/java/com/bestduo_BE/common/infra/riot/budget/DailyBudgetTrackerTest.java
+++ b/src/test/java/com/bestduo_BE/common/infra/riot/budget/DailyBudgetTrackerTest.java
@@ -5,12 +5,10 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
-import com.bestduo_BE.common.domain.model.Tier;
 import com.bestduo_BE.common.infra.persistence.entity.DailyPipelineState;
 import com.bestduo_BE.common.infra.persistence.repository.DailyPipelineStateJpaRepository;
 import com.bestduo_BE.config.PipelineProperties;
 import java.time.LocalDate;
-import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -39,7 +37,7 @@ class DailyBudgetTrackerTest {
   void canCollect_whenBudgetExhausted_returnsFalse() {
     DailyPipelineState exhausted = DailyPipelineState.create(LocalDate.now());
     exhausted.incrementCollectCalls(200);
-    given(stateRepository.findByPipelineDate(any(LocalDate.class))).willReturn(Optional.of(exhausted));
+    given(stateRepository.getOrCreateForDate(any(LocalDate.class))).willReturn(exhausted);
 
     assertThat(tracker.canCollect()).isFalse();
   }
@@ -49,61 +47,21 @@ class DailyBudgetTrackerTest {
   void canCollect_whenBudgetRemains_returnsTrue() {
     DailyPipelineState state = DailyPipelineState.create(LocalDate.now());
     state.incrementCollectCalls(50);
-    given(stateRepository.findByPipelineDate(any(LocalDate.class))).willReturn(Optional.of(state));
+    given(stateRepository.getOrCreateForDate(any(LocalDate.class))).willReturn(state);
 
     assertThat(tracker.canCollect()).isTrue();
-  }
-
-  @Test
-  @DisplayName("recordSeedCall은 DailyPipelineState를 저장한다")
-  void recordSeedCall_persistsUpdatedState() {
-    DailyPipelineState state = DailyPipelineState.create(LocalDate.now());
-    given(stateRepository.findByPipelineDate(any(LocalDate.class))).willReturn(Optional.of(state));
-    given(stateRepository.save(any(DailyPipelineState.class))).willReturn(state);
-
-    tracker.recordSeedCall(1);
-
-    verify(stateRepository).save(state);
-    assertThat(state.getSeedApiCallsUsed()).isEqualTo(1);
   }
 
   @Test
   @DisplayName("recordCollectCall은 DailyPipelineState를 저장한다")
   void recordCollectCall_persistsUpdatedState() {
     DailyPipelineState state = DailyPipelineState.create(LocalDate.now());
-    given(stateRepository.findByPipelineDate(any(LocalDate.class))).willReturn(Optional.of(state));
+    given(stateRepository.getOrCreateForDate(any(LocalDate.class))).willReturn(state);
     given(stateRepository.save(any(DailyPipelineState.class))).willReturn(state);
 
     tracker.recordCollectCall(3);
 
     verify(stateRepository).save(state);
     assertThat(state.getCollectApiCallsUsed()).isEqualTo(3);
-  }
-
-  @Test
-  @DisplayName("recordSeedCall(count, tier)는 호출 수와 완료 티어를 함께 저장한다")
-  void recordSeedCall_withTier_persistsCallCountAndCompletedTier() {
-    DailyPipelineState state = DailyPipelineState.create(LocalDate.now());
-    given(stateRepository.findByPipelineDate(any(LocalDate.class))).willReturn(Optional.of(state));
-    given(stateRepository.save(any(DailyPipelineState.class))).willReturn(state);
-
-    tracker.recordSeedCall(1, Tier.CHALLENGER);
-
-    verify(stateRepository).save(state);
-    assertThat(state.getSeedApiCallsUsed()).isEqualTo(1);
-    assertThat(state.getSeedCompletedTiers()).contains(Tier.CHALLENGER);
-  }
-
-  @Test
-  @DisplayName("getOrCreateTodayState는 없으면 새 상태를 저장하고 반환한다")
-  void getOrCreateTodayState_whenAbsent_savesAndReturnsNew() {
-    DailyPipelineState newState = DailyPipelineState.create(LocalDate.now());
-    given(stateRepository.findByPipelineDate(any(LocalDate.class))).willReturn(Optional.empty());
-    given(stateRepository.save(any(DailyPipelineState.class))).willReturn(newState);
-
-    DailyPipelineState result = tracker.getOrCreateTodayState();
-
-    verify(stateRepository).save(any(DailyPipelineState.class));
-    assertThat(result).isNotNull();
   }
 }

--- a/src/test/java/com/bestduo_BE/pipeline/application/DailyLeagueEntriesRunnerTest.java
+++ b/src/test/java/com/bestduo_BE/pipeline/application/DailyLeagueEntriesRunnerTest.java
@@ -12,7 +12,7 @@ import com.bestduo_BE.common.application.PatchVersionService;
 import com.bestduo_BE.common.domain.model.EffectivePatchContext;
 import com.bestduo_BE.common.domain.model.Tier;
 import com.bestduo_BE.common.infra.persistence.entity.DailyPipelineState;
-import com.bestduo_BE.common.infra.riot.budget.DailyBudgetTracker;
+import com.bestduo_BE.common.infra.persistence.repository.DailyPipelineStateJpaRepository;
 import com.bestduo_BE.config.PipelineProperties;
 import com.bestduo_BE.coverage.infra.persistence.entity.CoverageBucket;
 import com.bestduo_BE.coverage.infra.persistence.repository.CoverageBucketJpaRepository;
@@ -37,7 +37,7 @@ class DailyLeagueEntriesRunnerTest {
   private CoverageBucketJpaRepository coverageBucketRepository;
 
   @Mock
-  private DailyBudgetTracker budgetTracker;
+  private DailyPipelineStateJpaRepository stateRepository;
 
   @Mock
   private PatchVersionService patchVersionService;
@@ -49,7 +49,7 @@ class DailyLeagueEntriesRunnerTest {
   void setUp() {
     props = new PipelineProperties();
     runner = new DailyLeagueEntriesRunner(
-        leagueEntriesFetcher, coverageBucketRepository, budgetTracker, patchVersionService, props);
+        leagueEntriesFetcher, coverageBucketRepository, stateRepository, patchVersionService, props);
   }
 
   // ── hasWorkToday ────────────────────────────────────────────────────
@@ -58,7 +58,7 @@ class DailyLeagueEntriesRunnerTest {
   @DisplayName("apex 티어가 오늘 완료되지 않았으면 hasWorkToday는 true")
   void hasWorkToday_whenApexTierNotCompleted_returnsTrue() {
     DailyPipelineState state = DailyPipelineState.create(LocalDate.now());
-    given(budgetTracker.getOrCreateTodayState()).willReturn(state);
+    given(stateRepository.getOrCreateForDate(any(LocalDate.class))).willReturn(state);
 
     assertThat(runner.hasWorkToday()).isTrue();
   }
@@ -70,7 +70,7 @@ class DailyLeagueEntriesRunnerTest {
     state.recordSeedCompletedTier(Tier.CHALLENGER);
     state.recordSeedCompletedTier(Tier.GRANDMASTER);
     state.recordSeedCompletedTier(Tier.MASTER);
-    given(budgetTracker.getOrCreateTodayState()).willReturn(state);
+    given(stateRepository.getOrCreateForDate(any(LocalDate.class))).willReturn(state);
 
     CoverageBucket diaBucket = bucketWithQuotaExhausted(Tier.DIAMOND, "15.23");
     CoverageBucket emeBucket = bucketWithQuotaExhausted(Tier.EMERALD, "15.23");
@@ -88,7 +88,7 @@ class DailyLeagueEntriesRunnerTest {
     state.recordSeedCompletedTier(Tier.CHALLENGER);
     state.recordSeedCompletedTier(Tier.GRANDMASTER);
     state.recordSeedCompletedTier(Tier.MASTER);
-    given(budgetTracker.getOrCreateTodayState()).willReturn(state);
+    given(stateRepository.getOrCreateForDate(any(LocalDate.class))).willReturn(state);
 
     given(patchVersionService.resolveEffectivePatchContext()).willReturn(Optional.of(new EffectivePatchContext("15.23", 0L, null)));
     // fresh bucket: dailyPagesProcessed=0 < quota=10
@@ -105,7 +105,7 @@ class DailyLeagueEntriesRunnerTest {
   void runNextChunk_whenChallengerNotDone_executesSeedAndRecordsCompletion() {
 
     DailyPipelineState state = DailyPipelineState.create(LocalDate.now());
-    given(budgetTracker.getOrCreateTodayState()).willReturn(state);
+    given(stateRepository.getOrCreateForDate(any(LocalDate.class))).willReturn(state);
 
     LeagueEntriesFetchResult result = new LeagueEntriesFetchResult(1, 5, 5);
     given(leagueEntriesFetcher.execute(argThat(cmd ->
@@ -116,7 +116,8 @@ class DailyLeagueEntriesRunnerTest {
 
     assertThat(chunk.type()).isEqualTo(DailyLeagueEntriesRunner.ChunkResult.Type.APEX_TIER_CHUNK);
     assertThat(chunk.tier()).isEqualTo(Tier.CHALLENGER);
-    verify(budgetTracker).recordSeedCall(1, Tier.CHALLENGER);
+    assertThat(state.getSeedCompletedTiers()).contains(Tier.CHALLENGER);
+    verify(stateRepository).save(state);
   }
 
   @Test
@@ -127,7 +128,7 @@ class DailyLeagueEntriesRunnerTest {
     state.recordSeedCompletedTier(Tier.CHALLENGER);
     state.recordSeedCompletedTier(Tier.GRANDMASTER);
     state.recordSeedCompletedTier(Tier.MASTER);
-    given(budgetTracker.getOrCreateTodayState()).willReturn(state);
+    given(stateRepository.getOrCreateForDate(any(LocalDate.class))).willReturn(state);
 
     given(patchVersionService.resolveEffectivePatchContext()).willReturn(Optional.of(new EffectivePatchContext("15.23", 0L, null)));
 
@@ -143,7 +144,6 @@ class DailyLeagueEntriesRunnerTest {
 
     assertThat(chunk.type()).isEqualTo(DailyLeagueEntriesRunner.ChunkResult.Type.NON_APEX_PAGE);
     assertThat(chunk.tier()).isEqualTo(Tier.DIAMOND);
-    verify(budgetTracker).recordSeedCall(1);
   }
 
   @Test
@@ -154,7 +154,7 @@ class DailyLeagueEntriesRunnerTest {
     state.recordSeedCompletedTier(Tier.CHALLENGER);
     state.recordSeedCompletedTier(Tier.GRANDMASTER);
     state.recordSeedCompletedTier(Tier.MASTER);
-    given(budgetTracker.getOrCreateTodayState()).willReturn(state);
+    given(stateRepository.getOrCreateForDate(any(LocalDate.class))).willReturn(state);
 
     given(patchVersionService.resolveEffectivePatchContext()).willReturn(Optional.of(new EffectivePatchContext("15.23", 0L, null)));
 
@@ -183,7 +183,7 @@ class DailyLeagueEntriesRunnerTest {
     state.recordSeedCompletedTier(Tier.CHALLENGER);
     state.recordSeedCompletedTier(Tier.GRANDMASTER);
     state.recordSeedCompletedTier(Tier.MASTER);
-    given(budgetTracker.getOrCreateTodayState()).willReturn(state);
+    given(stateRepository.getOrCreateForDate(any(LocalDate.class))).willReturn(state);
 
     given(patchVersionService.resolveEffectivePatchContext()).willReturn(Optional.of(new EffectivePatchContext("15.23", 0L, null)));
 
@@ -210,7 +210,7 @@ class DailyLeagueEntriesRunnerTest {
     state.recordSeedCompletedTier(Tier.CHALLENGER);
     state.recordSeedCompletedTier(Tier.GRANDMASTER);
     state.recordSeedCompletedTier(Tier.MASTER);
-    given(budgetTracker.getOrCreateTodayState()).willReturn(state);
+    given(stateRepository.getOrCreateForDate(any(LocalDate.class))).willReturn(state);
 
     given(patchVersionService.resolveEffectivePatchContext()).willReturn(Optional.of(new EffectivePatchContext("15.23", 0L, null)));
     given(coverageBucketRepository.findByPatchAndTier("15.23", Tier.DIAMOND))
@@ -233,7 +233,7 @@ class DailyLeagueEntriesRunnerTest {
     state.recordSeedCompletedTier(Tier.CHALLENGER);
     state.recordSeedCompletedTier(Tier.GRANDMASTER);
     state.recordSeedCompletedTier(Tier.MASTER);
-    given(budgetTracker.getOrCreateTodayState()).willReturn(state);
+    given(stateRepository.getOrCreateForDate(any(LocalDate.class))).willReturn(state);
 
     given(patchVersionService.resolveEffectivePatchContext()).willReturn(Optional.of(new EffectivePatchContext("15.23", 0L, null)));
     given(coverageBucketRepository.findByPatchAndTier("15.23", Tier.DIAMOND)).willReturn(Optional.empty());
@@ -249,7 +249,7 @@ class DailyLeagueEntriesRunnerTest {
     state.recordSeedCompletedTier(Tier.CHALLENGER);
     state.recordSeedCompletedTier(Tier.GRANDMASTER);
     state.recordSeedCompletedTier(Tier.MASTER);
-    given(budgetTracker.getOrCreateTodayState()).willReturn(state);
+    given(stateRepository.getOrCreateForDate(any(LocalDate.class))).willReturn(state);
 
     given(patchVersionService.resolveEffectivePatchContext()).willReturn(Optional.of(new EffectivePatchContext("15.23", 0L, null)));
     given(coverageBucketRepository.findByPatchAndTier("15.23", Tier.DIAMOND)).willReturn(Optional.empty());
@@ -282,7 +282,7 @@ class DailyLeagueEntriesRunnerTest {
     state.recordSeedCompletedTier(Tier.CHALLENGER);
     state.recordSeedCompletedTier(Tier.GRANDMASTER);
     state.recordSeedCompletedTier(Tier.MASTER);
-    given(budgetTracker.getOrCreateTodayState()).willReturn(state);
+    given(stateRepository.getOrCreateForDate(any(LocalDate.class))).willReturn(state);
     given(patchVersionService.resolveEffectivePatchContext()).willReturn(Optional.empty());
 
     DailyLeagueEntriesRunner.ChunkResult result = runner.runNextChunk();
@@ -302,7 +302,7 @@ class DailyLeagueEntriesRunnerTest {
     state.recordSeedCompletedTier(Tier.CHALLENGER);
     state.recordSeedCompletedTier(Tier.GRANDMASTER);
     state.recordSeedCompletedTier(Tier.MASTER);
-    given(budgetTracker.getOrCreateTodayState()).willReturn(state);
+    given(stateRepository.getOrCreateForDate(any(LocalDate.class))).willReturn(state);
 
     given(patchVersionService.resolveEffectivePatchContext()).willReturn(Optional.of(new EffectivePatchContext("15.23", 0L, null)));
     given(coverageBucketRepository.findByPatchAndTier("15.23", Tier.DIAMOND))
@@ -323,7 +323,7 @@ class DailyLeagueEntriesRunnerTest {
     state.recordSeedCompletedTier(Tier.CHALLENGER);
     state.recordSeedCompletedTier(Tier.GRANDMASTER);
     state.recordSeedCompletedTier(Tier.MASTER);
-    given(budgetTracker.getOrCreateTodayState()).willReturn(state);
+    given(stateRepository.getOrCreateForDate(any(LocalDate.class))).willReturn(state);
 
     given(patchVersionService.resolveEffectivePatchContext()).willReturn(Optional.of(new EffectivePatchContext("15.23", 0L, null)));
     given(coverageBucketRepository.findByPatchAndTier("15.23", Tier.DIAMOND))
@@ -340,7 +340,7 @@ class DailyLeagueEntriesRunnerTest {
     state.recordSeedCompletedTier(Tier.CHALLENGER);
     state.recordSeedCompletedTier(Tier.GRANDMASTER);
     state.recordSeedCompletedTier(Tier.MASTER);
-    given(budgetTracker.getOrCreateTodayState()).willReturn(state);
+    given(stateRepository.getOrCreateForDate(any(LocalDate.class))).willReturn(state);
 
     given(patchVersionService.resolveEffectivePatchContext()).willReturn(Optional.of(new EffectivePatchContext("15.23", 0L, null)));
     CoverageBucket diaBucket = bucketExhaustedOn(Tier.DIAMOND, "15.23", LocalDate.now().minusDays(1));

--- a/src/test/java/com/bestduo_BE/pipeline/application/PlatformPipelineRunnerTest.java
+++ b/src/test/java/com/bestduo_BE/pipeline/application/PlatformPipelineRunnerTest.java
@@ -1,0 +1,68 @@
+package com.bestduo_BE.pipeline.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.bestduo_BE.common.infra.riot.exception.RiotRateLimitedException;
+import com.bestduo_BE.config.PipelineProperties;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class PlatformPipelineRunnerTest {
+
+  @Mock private DailyLeagueEntriesRunner dailyLeagueEntriesRunner;
+
+  private PipelineProperties props;
+  private PlatformPipelineRunner runner;
+
+  @BeforeEach
+  void setUp() {
+    props = new PipelineProperties();
+    props.setPollingIntervalMs(100);
+    PipelineMetrics pipelineMetrics = new PipelineMetrics(new SimpleMeterRegistry());
+    runner = new PlatformPipelineRunner(dailyLeagueEntriesRunner, props, pipelineMetrics);
+  }
+
+  @Test
+  @DisplayName("Stage 1 작업이 있으면 runNextChunk 호출 후 종료")
+  void executeTick_whenStage1HasWork_runsStage1() throws InterruptedException {
+    given(dailyLeagueEntriesRunner.hasWorkToday()).willReturn(true);
+
+    runner.executeTick();
+
+    verify(dailyLeagueEntriesRunner).runNextChunk();
+  }
+
+  @Test
+  @DisplayName("Stage 1 작업이 없으면 polling 간격만큼 대기한다")
+  void executeTick_whenNoWork_sleepsPollingInterval() throws InterruptedException {
+    given(dailyLeagueEntriesRunner.hasWorkToday()).willReturn(false);
+
+    long start = System.currentTimeMillis();
+    runner.executeTick();
+    long elapsed = System.currentTimeMillis() - start;
+
+    // pollingIntervalMs=100 으로 설정했으므로 최소 80ms 이상 sleep 해야 함
+    assertThat(elapsed).isGreaterThanOrEqualTo(80L);
+    verify(dailyLeagueEntriesRunner, never()).runNextChunk();
+  }
+
+  @Test
+  @DisplayName("Stage 1에서 429 발생 시 속도 제한 예외가 전파된다")
+  void executeTick_whenStage1Throws429_propagates() {
+    given(dailyLeagueEntriesRunner.hasWorkToday()).willReturn(true);
+    given(dailyLeagueEntriesRunner.runNextChunk()).willThrow(new RiotRateLimitedException("429"));
+
+    assertThatThrownBy(() -> runner.executeTick())
+        .isInstanceOf(RiotRateLimitedException.class);
+  }
+}

--- a/src/test/java/com/bestduo_BE/pipeline/application/RegionalPipelineRunnerTest.java
+++ b/src/test/java/com/bestduo_BE/pipeline/application/RegionalPipelineRunnerTest.java
@@ -26,15 +26,14 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-class PipelineRunnerTest {
+class RegionalPipelineRunnerTest {
 
-  @Mock private DailyLeagueEntriesRunner dailyLeagueEntriesRunner;
   @Mock private CollectMatchIdsRunner collectMatchIdsRunner;
   @Mock private MatchIngestRunner matchIngestRunner;
   @Mock private PatchVersionService patchVersionService;
 
   private PipelineProperties props;
-  private PipelineRunner runner;
+  private RegionalPipelineRunner runner;
 
   @BeforeEach
   void setUp() {
@@ -42,26 +41,13 @@ class PipelineRunnerTest {
     props.setIngestBatchSize(10);
     props.setPollingIntervalMs(100);
     PipelineMetrics pipelineMetrics = new PipelineMetrics(new SimpleMeterRegistry());
-    runner = new PipelineRunner(dailyLeagueEntriesRunner, collectMatchIdsRunner, matchIngestRunner,
+    runner = new RegionalPipelineRunner(collectMatchIdsRunner, matchIngestRunner,
         patchVersionService, props, pipelineMetrics);
   }
 
   @Test
-  @DisplayName("Stage 1 작업이 있으면 runNextChunk만 호출된다")
-  void executeTick_whenStage1HasWork_runsOnlyStage1() throws InterruptedException {
-    given(dailyLeagueEntriesRunner.hasWorkToday()).willReturn(true);
-
-    runner.executeTick();
-
-    verify(dailyLeagueEntriesRunner).runNextChunk();
-    verify(collectMatchIdsRunner, never()).runBatch();
-    verify(matchIngestRunner, never()).executeWithPriority(anyInt(), any(), any());
-  }
-
-  @Test
-  @DisplayName("Stage 1 없고 Stage 2 대기 중이면 runBatch만 호출된다")
+  @DisplayName("Stage 2 대기 중이면 runBatch만 호출된다")
   void executeTick_whenStage2HasPending_runsOnlyStage2() throws InterruptedException {
-    given(dailyLeagueEntriesRunner.hasWorkToday()).willReturn(false);
     given(collectMatchIdsRunner.hasPending()).willReturn(true);
 
     runner.executeTick();
@@ -73,7 +59,6 @@ class PipelineRunnerTest {
   @Test
   @DisplayName("유예 기간이 아닐 때 Stage 3는 최신 패치(유효 패치 == 최신 패치)로 우선순위를 결정한다")
   void executeTick_whenNotInGracePeriod_runsStage3WithCurrentPatch() throws InterruptedException {
-    given(dailyLeagueEntriesRunner.hasWorkToday()).willReturn(false);
     given(collectMatchIdsRunner.hasPending()).willReturn(false);
     given(patchVersionService.resolveEffectivePatchContext())
         .willReturn(Optional.of(new EffectivePatchContext("15.23", 1000L, null)));
@@ -88,7 +73,6 @@ class PipelineRunnerTest {
   @Test
   @DisplayName("유예 기간 중일 때 Stage 3는 직전 패치(유효 패치 == 직전 패치)로 우선순위를 결정한다")
   void executeTick_whenInGracePeriod_runsStage3WithPreviousPatch() throws InterruptedException {
-    given(dailyLeagueEntriesRunner.hasWorkToday()).willReturn(false);
     given(collectMatchIdsRunner.hasPending()).willReturn(false);
     // 유예 기간: endTimeEpochSeconds != null → 유효 패치 = "15.22" (직전 패치)
     given(patchVersionService.resolveEffectivePatchContext())
@@ -104,7 +88,6 @@ class PipelineRunnerTest {
   @Test
   @DisplayName("패치 정보가 없으면 null 패치로 Stage 3를 호출한다")
   void executeTick_whenNoPatch_callsStage3WithNullPatch() throws InterruptedException {
-    given(dailyLeagueEntriesRunner.hasWorkToday()).willReturn(false);
     given(collectMatchIdsRunner.hasPending()).willReturn(false);
     given(patchVersionService.resolveEffectivePatchContext()).willReturn(Optional.empty());
     given(matchIngestRunner.executeWithPriority(anyInt(), any(), any()))
@@ -120,7 +103,6 @@ class PipelineRunnerTest {
   void executeTick_whenStage3PriorityTierIsEmerald_callsStage3WithEmeraldTier()
       throws InterruptedException {
     props.setStage3PriorityTier(Tier.EMERALD);
-    given(dailyLeagueEntriesRunner.hasWorkToday()).willReturn(false);
     given(collectMatchIdsRunner.hasPending()).willReturn(false);
     given(patchVersionService.resolveEffectivePatchContext())
         .willReturn(Optional.of(new EffectivePatchContext("15.23", 1000L, null)));
@@ -135,7 +117,6 @@ class PipelineRunnerTest {
   @Test
   @DisplayName("Stage 3에서 처리된 항목이 없으면 폴링 간격만큼 대기한다")
   void executeTick_whenNothingInQueue_sleepsPollingInterval() throws InterruptedException {
-    given(dailyLeagueEntriesRunner.hasWorkToday()).willReturn(false);
     given(collectMatchIdsRunner.hasPending()).willReturn(false);
     given(patchVersionService.resolveEffectivePatchContext()).willReturn(Optional.empty());
     given(matchIngestRunner.executeWithPriority(anyInt(), any(), any()))
@@ -150,19 +131,8 @@ class PipelineRunnerTest {
   }
 
   @Test
-  @DisplayName("Stage 1에서 429 발생 시 속도 제한 예외가 전파된다")
-  void executeTick_whenStage1Throws429_propagates() {
-    given(dailyLeagueEntriesRunner.hasWorkToday()).willReturn(true);
-    given(dailyLeagueEntriesRunner.runNextChunk()).willThrow(new RiotRateLimitedException("429"));
-
-    assertThatThrownBy(() -> runner.executeTick())
-        .isInstanceOf(RiotRateLimitedException.class);
-  }
-
-  @Test
   @DisplayName("Stage 3에서 429 발생 시 속도 제한 예외가 전파된다")
   void executeTick_whenStage3Throws429_propagates() {
-    given(dailyLeagueEntriesRunner.hasWorkToday()).willReturn(false);
     given(collectMatchIdsRunner.hasPending()).willReturn(false);
     given(patchVersionService.resolveEffectivePatchContext()).willReturn(Optional.empty());
     given(matchIngestRunner.executeWithPriority(anyInt(), any(), any()))
@@ -176,7 +146,6 @@ class PipelineRunnerTest {
   @DisplayName("priority 티어가 비면 다음 티어로 순회하다가 잡힌 시점에 tick 종료")
   void executeTick_whenPriorityTierEmpty_fallsBackToNextTier() throws InterruptedException {
     props.setStage3PriorityTier(Tier.EMERALD);
-    given(dailyLeagueEntriesRunner.hasWorkToday()).willReturn(false);
     given(collectMatchIdsRunner.hasPending()).willReturn(false);
     given(patchVersionService.resolveEffectivePatchContext())
         .willReturn(Optional.of(new EffectivePatchContext("15.23", 1000L, null)));
@@ -201,7 +170,6 @@ class PipelineRunnerTest {
   void executeTick_whenPriorityTierSetAndAllTiersEmpty_sleepsPollingInterval()
       throws InterruptedException {
     props.setStage3PriorityTier(Tier.EMERALD);
-    given(dailyLeagueEntriesRunner.hasWorkToday()).willReturn(false);
     given(collectMatchIdsRunner.hasPending()).willReturn(false);
     given(patchVersionService.resolveEffectivePatchContext()).willReturn(Optional.empty());
     given(matchIngestRunner.executeWithPriority(anyInt(), any(), any()))
@@ -221,7 +189,6 @@ class PipelineRunnerTest {
   void executeTick_whenPriorityTierSetAndAllTiersEmpty_skipsPlatinumAndBelow()
       throws InterruptedException {
     props.setStage3PriorityTier(Tier.EMERALD);
-    given(dailyLeagueEntriesRunner.hasWorkToday()).willReturn(false);
     given(collectMatchIdsRunner.hasPending()).willReturn(false);
     given(patchVersionService.resolveEffectivePatchContext()).willReturn(Optional.empty());
     given(matchIngestRunner.executeWithPriority(anyInt(), any(), any()))
@@ -241,7 +208,6 @@ class PipelineRunnerTest {
   void executeTick_whenStage3PriorityTierIsAllTiers_singleCallWithNull()
       throws InterruptedException {
     props.setStage3PriorityTier(Tier.ALL_TIERS);
-    given(dailyLeagueEntriesRunner.hasWorkToday()).willReturn(false);
     given(collectMatchIdsRunner.hasPending()).willReturn(false);
     given(patchVersionService.resolveEffectivePatchContext())
         .willReturn(Optional.of(new EffectivePatchContext("15.23", 1000L, null)));


### PR DESCRIPTION
## Summary

기존 단일 `PipelineRunner` 를 host 별로 2개로 분할:

- `PlatformPipelineRunner` — Stage 1 전담 (`kr.api`)
- `RegionalPipelineRunner` — Stage 2 + Stage 3 전담 (`asia.api`)

두 runner 가 각자 가상 스레드와 자체 429 cooldown 을 갖기 때문에, host 한쪽의 rate limit 이슈가 다른 쪽 진행을 막지 않는다.

Issue #90 의 ① ② 우선항목 본 작업.

## Why

PR #89 (host 별 limiter 분리) + PR #91 (Stage 1 daily budget cap 제거) 사전 작업 완료. 그러나 단일 `PipelineRunner.executeTick()` 가 Stage 1 → 2 → 3 **순차 우선순위** 였기 때문에 분리한 limiter 의 효용이 살아나지 않았음.

- Stage 1 (KR) 이 도는 동안 → ASIA limiter idle
- Stage 2/3 (ASIA) 이 도는 동안 → KR limiter idle
- Stage 1 429 발생 → 전체 60s sleep → ASIA 도 같이 멈춤

이번 PR 로 두 host loop 가 **독립 실행** → 두 limiter 가 항상 일함 + 429 격리.

## Changes

### 새 파일
- `PlatformPipelineRunner.java`
  - `DailyLeagueEntriesRunner` 만 주입
  - 가상 스레드 `platform-pipeline-runner`
  - `executeTick()`: `hasWorkToday()` → `runNextChunk()` / polling sleep
  - 429 시 자체 60s sleep
- `RegionalPipelineRunner.java`
  - `CollectMatchIdsRunner` + `MatchIngestRunner` + `PatchVersionService` 주입
  - 가상 스레드 `regional-pipeline-runner`
  - `executeTick()`: Stage 2 우선 → Stage 3 tier round-robin (기존 로직 이동)
  - 429 시 자체 60s sleep
- `PlatformPipelineRunnerTest.java` (Stage 1 책임 검증)
- `RegionalPipelineRunnerTest.java` (Stage 2/3 책임 검증, 기존 PipelineRunnerTest 의 round-robin/patch 검증 이동)

### 삭제
- `PipelineRunner.java` (책임 분할)
- `PipelineRunnerTest.java` (두 신규 테스트로 분할)

### 유지
- `@ConditionalOnProperty(pipeline.runner.enabled)` — 두 runner 동일 적용. on/off 같이 토글
- `PipelineMetrics` — stage 라벨(1/2/3) 그대로
- ② Stage 2/3 fairness 정책: 현 순서 (Stage 2 우선 → Stage 3) 유지. 향후 운영 데이터 보고 결정 (#90 의 ② 후속)

## 격리 효과

| 시나리오 | 변경 전 | 변경 후 |
|---|---|---|
| Stage 1 (KR) 에서 429 | 전체 60s sleep, Stage 2/3 도 멈춤 | platform loop 만 60s sleep, ASIA 계속 진행 |
| Stage 2/3 (ASIA) 에서 429 | 전체 60s sleep, Stage 1 도 멈춤 | regional loop 만 60s sleep, KR 계속 진행 |
| 평상 운영 | Stage 우선순위로 직렬 | 두 host 가 동시에 일함 |

## Test plan

- [x] `./gradlew compileJava compileTestJava` 통과
- [x] `./gradlew test` 통과
- [x] 기존 `PipelineRunnerTest` 의 시나리오 모두 두 신규 테스트로 이전 + Platform 전용 케이스 추가
- [ ] 머지 후 운영에서 두 스레드 (`platform-pipeline-runner`, `regional-pipeline-runner`) 정상 기동 + 429 격리 작동 확인
- [ ] Grafana 에서 stage별 throughput 변화 모니터링 (#90 의 ⑥ 향후 메트릭 작업으로 연결)

## Related

- #90 — pipeline 성능 향상 (이 PR 이 ① ② 본 작업)
- #91 — Stage 1 daily budget cap 제거 (사전 cleanup, merged)
- #89 — host 별 limiter 분리 (merged)