### PR TITLE
feat: rate limit 한도 외부화 + 90% 적용 + 429 메트릭

### DIFF
--- a/src/main/java/com/bestduo_BE/common/infra/riot/RiotApiConfig.java
+++ b/src/main/java/com/bestduo_BE/common/infra/riot/RiotApiConfig.java
@@ -2,7 +2,6 @@ package com.bestduo_BE.common.infra.riot;
 
 import com.bestduo_BE.config.RiotApiProperties;
 import java.time.Clock;
-import java.time.Duration;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.restclient.RestTemplateBuilder;
 import org.springframework.context.annotation.Bean;
@@ -14,26 +13,31 @@ import org.springframework.web.client.RestTemplate;
  *
  * <p>kr.api(platform) 와 asia.api(regional) 는 Riot 측에서 별도 rate limit 버킷으로 카운팅되므로
  * (RiotRegionRateLimitProbeTest 로 검증), 인터셉터/limiter 도 호스트별로 분리한다.
+ *
+ * <p>한도값은 {@link RiotApiProperties.RateLimit} 에서 외부화되어 env 로 조정 가능
+ * (default 90% = 18/1s + 90/2min). controlled experiment 로 95% 까지 429=0 확인됨.
  */
 @Configuration
 public class RiotApiConfig {
 
   @Bean
-  public RiotRateLimitInterceptor riotPlatformRateLimitInterceptor(RiotApiProperties properties) {
+  public RiotRateLimitInterceptor riotPlatformRateLimitInterceptor(
+      RiotApiProperties properties, RiotApiMetrics metrics) {
     return new RiotRateLimitInterceptor(
         properties.getApiKey(),
-        new DualWindowRateLimiter(10, Duration.ofSeconds(1), 60, Duration.ofMinutes(2)),
-        Clock.systemUTC()
-    );
+        buildLimiter(properties.getRateLimit()),
+        Clock.systemUTC(),
+        metrics);
   }
 
   @Bean
-  public RiotRateLimitInterceptor riotRegionalRateLimitInterceptor(RiotApiProperties properties) {
+  public RiotRateLimitInterceptor riotRegionalRateLimitInterceptor(
+      RiotApiProperties properties, RiotApiMetrics metrics) {
     return new RiotRateLimitInterceptor(
         properties.getApiKey(),
-        new DualWindowRateLimiter(10, Duration.ofSeconds(1), 60, Duration.ofMinutes(2)),
-        Clock.systemUTC()
-    );
+        buildLimiter(properties.getRateLimit()),
+        Clock.systemUTC(),
+        metrics);
   }
 
   @Bean(name = "riotPlatformRestTemplate")
@@ -52,6 +56,12 @@ public class RiotApiConfig {
           RiotRateLimitInterceptor rateLimitInterceptor,
       RiotApiProperties properties) {
     return buildRiotRestTemplate(restTemplateBuilder, properties.getRegionalBaseUrl(), rateLimitInterceptor);
+  }
+
+  private DualWindowRateLimiter buildLimiter(RiotApiProperties.RateLimit cfg) {
+    return new DualWindowRateLimiter(
+        cfg.getShortLimit(), cfg.getShortWindow(),
+        cfg.getLongLimit(), cfg.getLongWindow());
   }
 
   private RestTemplate buildRiotRestTemplate(

--- a/src/main/java/com/bestduo_BE/common/infra/riot/RiotApiMetrics.java
+++ b/src/main/java/com/bestduo_BE/common/infra/riot/RiotApiMetrics.java
@@ -8,7 +8,8 @@ import org.springframework.stereotype.Component;
 @Component
 public class RiotApiMetrics {
 
-  private static final String METRIC_NAME = "riot.api.request";
+  private static final String REQUEST_METRIC = "riot.api.request";
+  private static final String RATE_LIMITED_METRIC = "riot.api.rate_limited";
 
   private final MeterRegistry registry;
 
@@ -20,11 +21,27 @@ public class RiotApiMetrics {
     Timer.Sample sample = Timer.start(registry);
     try {
       T result = call.get();
-      sample.stop(registry.timer(METRIC_NAME, "endpoint", endpoint, "outcome", "success"));
+      sample.stop(registry.timer(REQUEST_METRIC, "endpoint", endpoint, "outcome", "success"));
       return result;
     } catch (RuntimeException e) {
-      sample.stop(registry.timer(METRIC_NAME, "endpoint", endpoint, "outcome", "error"));
+      sample.stop(registry.timer(REQUEST_METRIC, "endpoint", endpoint, "outcome", "error"));
       throw e;
     }
+  }
+
+  /**
+   * 429 발생 카운터. Riot 의 {@code X-Rate-Limit-Type} 헤더로 원인 분류.
+   *
+   * @param type {@code application} (앱-level 한도) / {@code method} (endpoint 한도) /
+   *     {@code service} (Riot 서비스 부하) / {@code unknown} (헤더 결손)
+   * @param endpoint 정규화된 path (cardinality 폭발 방지)
+   */
+  public void recordRateLimited(String type, String endpoint) {
+    registry
+        .counter(
+            RATE_LIMITED_METRIC,
+            "type", type != null && !type.isBlank() ? type : "unknown",
+            "endpoint", endpoint != null && !endpoint.isBlank() ? endpoint : "unknown")
+        .increment();
   }
 }

--- a/src/main/java/com/bestduo_BE/common/infra/riot/RiotRateLimitInterceptor.java
+++ b/src/main/java/com/bestduo_BE/common/infra/riot/RiotRateLimitInterceptor.java
@@ -2,6 +2,7 @@ package com.bestduo_BE.common.infra.riot;
 
 import com.bestduo_BE.common.infra.riot.exception.RiotRateLimitedException;
 import java.io.IOException;
+import java.net.URI;
 import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
@@ -18,12 +19,15 @@ public class RiotRateLimitInterceptor implements ClientHttpRequestInterceptor {
   private final String apiKey;
   private final DualWindowRateLimiter rateLimiter;
   private final Clock clock;
+  private final RiotApiMetrics metrics;
   private volatile Instant rateLimitedUntil = Instant.EPOCH;
 
-  public RiotRateLimitInterceptor(String apiKey, DualWindowRateLimiter rateLimiter, Clock clock) {
+  public RiotRateLimitInterceptor(
+      String apiKey, DualWindowRateLimiter rateLimiter, Clock clock, RiotApiMetrics metrics) {
     this.apiKey = apiKey;
     this.rateLimiter = rateLimiter;
     this.clock = clock;
+    this.metrics = metrics;
   }
 
   @Override
@@ -44,9 +48,12 @@ public class RiotRateLimitInterceptor implements ClientHttpRequestInterceptor {
 
     if (response.getStatusCode() == HttpStatus.TOO_MANY_REQUESTS) {
       String retryAfter = response.getHeaders().getFirst("Retry-After");
+      String limitType = response.getHeaders().getFirst("X-Rate-Limit-Type");
       markRateLimited(parseRetryAfter(retryAfter));
-      String msg = "Riot API rate limited (429). retry-after=" + retryAfter
-          + ", uri=" + request.getURI();
+      String endpointTag = endpointTag(request.getURI());
+      metrics.recordRateLimited(limitType, endpointTag);
+      String msg = "Riot API rate limited (429). type=" + limitType
+          + ", retry-after=" + retryAfter + ", uri=" + request.getURI();
       response.close();
       throw new RiotRateLimitedException(msg);
     }
@@ -78,5 +85,21 @@ public class RiotRateLimitInterceptor implements ClientHttpRequestInterceptor {
     } catch (NumberFormatException e) {
       return DEFAULT_RETRY_AFTER;
     }
+  }
+
+  /**
+   * path 의 가변 segment(PUUID, matchId 등) 를 익명화해 메트릭 cardinality 폭발 방지.
+   * 예: {@code /lol/match/v5/matches/by-puuid/abc.../ids} → {@code match.v5.matches.by-puuid.{id}.ids}
+   */
+  static String endpointTag(URI uri) {
+    if (uri == null || uri.getPath() == null) {
+      return "unknown";
+    }
+    return uri.getPath()
+        .replaceAll("/[A-Za-z0-9_-]{20,}", "/{id}")
+        .replaceFirst("^/lol/", "")
+        .replaceFirst("^/riot/", "")
+        .replaceFirst("^/+", "")
+        .replace('/', '.');
   }
 }

--- a/src/main/java/com/bestduo_BE/config/RiotApiProperties.java
+++ b/src/main/java/com/bestduo_BE/config/RiotApiProperties.java
@@ -1,12 +1,19 @@
 package com.bestduo_BE.config;
 
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import java.time.Duration;
 import lombok.Getter;
 import lombok.Setter;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.stereotype.Component;
+import org.springframework.validation.annotation.Validated;
 
 @Component
 @ConfigurationProperties(prefix = "external.riot")
+@Validated
 @Getter
 @Setter
 public class RiotApiProperties {
@@ -14,4 +21,32 @@ public class RiotApiProperties {
   private String platformBaseUrl;
   private String regionalBaseUrl;
   private String apiKey;
+
+  /**
+   * Riot personal/dev key 의 app-level 한도(20/1s + 100/2min) 대비 사용 비율.
+   * host(kr.api / asia.api) 각각 독립 버킷으로 적용된다.
+   * <p>controlled experiment (RateLimitHeadroomProbeTest) 결과 95% 까지 429=0 확인.
+   * 보수적 단계 적용을 위해 default 90% 로 시작, 운영 안정 확인 후 95% 로 ramp 예정.
+   */
+  @Valid private RateLimit rateLimit = new RateLimit();
+
+  @Getter
+  @Setter
+  public static class RateLimit {
+    /** short window 요청 한도. personal key 20/1s 대비 설정값. default 18 (= 90%). */
+    @Min(1)
+    @Max(20)
+    private int shortLimit = 18;
+
+    /** short window 길이. default 1초. */
+    @NotNull private Duration shortWindow = Duration.ofSeconds(1);
+
+    /** long window 요청 한도. personal key 100/2min 대비 설정값. default 90 (= 90%). */
+    @Min(1)
+    @Max(100)
+    private int longLimit = 90;
+
+    /** long window 길이. default 2분. */
+    @NotNull private Duration longWindow = Duration.ofMinutes(2);
+  }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -44,6 +44,13 @@ external:
     platform-base-url: https://kr.api.riotgames.com
     regional-base-url: https://asia.api.riotgames.com
     api-key: ${EXTERNAL_RIOT_API_KEY:}
+    # personal/dev key 한도 (20/1s + 100/2min) 의 90% 시작. controlled experiment 로 95% 까지 안전 검증됨.
+    # host 별 (kr.api, asia.api) 독립 적용. 운영 안정 확인 후 95% (19/95) 로 ramp.
+    rate-limit:
+      short-limit: ${EXTERNAL_RIOT_RATE_LIMIT_SHORT:18}
+      short-window: ${EXTERNAL_RIOT_RATE_LIMIT_SHORT_WINDOW:1s}
+      long-limit: ${EXTERNAL_RIOT_RATE_LIMIT_LONG:90}
+      long-window: ${EXTERNAL_RIOT_RATE_LIMIT_LONG_WINDOW:2m}
 
 patch-sync:
   enabled: ${PATCH_SYNC_ENABLED:false}

--- a/src/test/java/com/bestduo_BE/common/infra/riot/RiotApiConfigTest.java
+++ b/src/test/java/com/bestduo_BE/common/infra/riot/RiotApiConfigTest.java
@@ -3,6 +3,7 @@ package com.bestduo_BE.common.infra.riot;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.bestduo_BE.config.RiotApiProperties;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.restclient.RestTemplateBuilder;
@@ -11,6 +12,7 @@ import org.springframework.web.client.RestTemplate;
 class RiotApiConfigTest {
 
   private final RiotApiConfig config = new RiotApiConfig();
+  private final RiotApiMetrics metrics = new RiotApiMetrics(new SimpleMeterRegistry());
 
   @Test
   @DisplayName("riotPlatformRateLimitInterceptor — 설정된 API 키를 요청 헤더에 주입한다")
@@ -18,7 +20,7 @@ class RiotApiConfigTest {
     RiotApiProperties properties = new RiotApiProperties();
     properties.setApiKey("my-key");
 
-    RiotRateLimitInterceptor interceptor = config.riotPlatformRateLimitInterceptor(properties);
+    RiotRateLimitInterceptor interceptor = config.riotPlatformRateLimitInterceptor(properties, metrics);
 
     var request = new org.springframework.mock.http.client.MockClientHttpRequest();
     request.setURI(java.net.URI.create("https://kr.api.riotgames.com/test"));
@@ -40,8 +42,8 @@ class RiotApiConfigTest {
     RiotApiProperties properties = new RiotApiProperties();
     properties.setApiKey("my-key");
 
-    RiotRateLimitInterceptor platform = config.riotPlatformRateLimitInterceptor(properties);
-    RiotRateLimitInterceptor regional = config.riotRegionalRateLimitInterceptor(properties);
+    RiotRateLimitInterceptor platform = config.riotPlatformRateLimitInterceptor(properties, metrics);
+    RiotRateLimitInterceptor regional = config.riotRegionalRateLimitInterceptor(properties, metrics);
 
     // 호스트별 rate limit 버킷 독립을 위해 인스턴스가 분리되어야 함
     assertThat(platform).isNotSameAs(regional);
@@ -56,9 +58,9 @@ class RiotApiConfigTest {
     properties.setApiKey("my-key");
 
     RiotRateLimitInterceptor platformInterceptor =
-        config.riotPlatformRateLimitInterceptor(properties);
+        config.riotPlatformRateLimitInterceptor(properties, metrics);
     RiotRateLimitInterceptor regionalInterceptor =
-        config.riotRegionalRateLimitInterceptor(properties);
+        config.riotRegionalRateLimitInterceptor(properties, metrics);
 
     RestTemplate platform =
         config.riotPlatformRestTemplate(new RestTemplateBuilder(), platformInterceptor, properties);

--- a/src/test/java/com/bestduo_BE/common/infra/riot/RiotApiSecretRedactionTest.java
+++ b/src/test/java/com/bestduo_BE/common/infra/riot/RiotApiSecretRedactionTest.java
@@ -50,16 +50,18 @@ class RiotApiSecretRedactionTest {
     logAppender.start();
     rootLogger.addAppender(logAppender);
 
+    RiotApiMetrics metrics = new RiotApiMetrics(new SimpleMeterRegistry());
     interceptor = new RiotRateLimitInterceptor(
         SECRET_KEY,
         new DualWindowRateLimiter(10, Duration.ofSeconds(1), 60, Duration.ofMinutes(2)),
-        Clock.systemUTC()
+        Clock.systemUTC(),
+        metrics
     );
     restTemplate = new RestTemplate();
     restTemplate.setInterceptors(List.of(interceptor));
     mockServer = MockRestServiceServer.bindTo(restTemplate).build();
 
-    adapter = new RiotApiHttpAdapter(restTemplate, restTemplate, new RiotApiMetrics(new SimpleMeterRegistry()));
+    adapter = new RiotApiHttpAdapter(restTemplate, restTemplate, metrics);
   }
 
   @AfterEach

--- a/src/test/java/com/bestduo_BE/common/infra/riot/RiotRateLimitInterceptorTest.java
+++ b/src/test/java/com/bestduo_BE/common/infra/riot/RiotRateLimitInterceptorTest.java
@@ -9,6 +9,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.bestduo_BE.common.infra.riot.exception.RiotRateLimitedException;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.net.URI;
 import java.time.Clock;
 import java.time.Duration;
@@ -26,16 +27,19 @@ import org.springframework.mock.http.client.MockClientHttpResponse;
 class RiotRateLimitInterceptorTest {
 
   private MutableClock clock;
+  private RiotApiMetrics metrics;
   private RiotRateLimitInterceptor interceptor;
   private MockClientHttpRequest request;
 
   @BeforeEach
   void setUp() {
     clock = new MutableClock(Instant.parse("2026-03-30T00:00:00Z"));
+    metrics = new RiotApiMetrics(new SimpleMeterRegistry());
     interceptor = new RiotRateLimitInterceptor(
         "test-key",
         new DualWindowRateLimiter(10, Duration.ofSeconds(1), 60, Duration.ofMinutes(2)),
-        clock
+        clock,
+        metrics
     );
     request = new MockClientHttpRequest();
     request.setURI(URI.create("https://riot.api/test"));
@@ -55,22 +59,38 @@ class RiotRateLimitInterceptorTest {
   }
 
   @Test
-  @DisplayName("intercept — 429 응답 시 RiotRateLimitedException을 던진다")
+  @DisplayName("intercept — 429 응답 시 RiotRateLimitedException 던지고 메트릭 카운트 증가")
   void throwsRiotRateLimitedExceptionOnTooManyRequests() throws Exception {
     ClientHttpRequestExecution execution = mock(ClientHttpRequestExecution.class);
     ClientHttpResponse tooMany = mock(ClientHttpResponse.class);
     var headers = new org.springframework.http.HttpHeaders();
     headers.set("Retry-After", "10");
+    headers.set("X-Rate-Limit-Type", "application");
     when(tooMany.getStatusCode()).thenReturn(HttpStatus.TOO_MANY_REQUESTS);
     when(tooMany.getHeaders()).thenReturn(headers);
     when(execution.execute(any(), any())).thenReturn(tooMany);
 
     assertThatThrownBy(() -> interceptor.intercept(request, new byte[0], execution))
         .isInstanceOf(RiotRateLimitedException.class)
+        .hasMessageContaining("type=application")
         .hasMessageContaining("retry-after=10")
         .hasMessageContaining("uri=" + request.getURI());
 
     verify(tooMany).close();
+  }
+
+  @Test
+  @DisplayName("endpointTag — PUUID/matchId 같은 가변 segment 가 {id} 로 정규화된다")
+  void endpointTagNormalizesIdSegments() {
+    assertThat(RiotRateLimitInterceptor.endpointTag(
+        URI.create("https://asia.api.riotgames.com/lol/match/v5/matches/by-puuid/abcdefghij1234567890/ids")))
+        .isEqualTo("match.v5.matches.by-puuid.{id}.ids");
+
+    assertThat(RiotRateLimitInterceptor.endpointTag(
+        URI.create("https://kr.api.riotgames.com/lol/league/v4/entries/RANKED_SOLO_5x5/DIAMOND/I")))
+        .isEqualTo("league.v4.entries.RANKED_SOLO_5x5.DIAMOND.I");
+
+    assertThat(RiotRateLimitInterceptor.endpointTag(null)).isEqualTo("unknown");
   }
 
   @Test


### PR DESCRIPTION
## Summary

Probe test (PR #93) 결과 기반으로 rate limit 한도를 60% → 90% 로 상향. 보수적 단계 적용 정책으로 시작값은 90%, 1주 운영 안정 확인 후 95% 로 ramp.

함께 응답 헤더 기반 429 메트릭 추가 — 효과 측정 + 이상 감지 + ④/⑤/⑥ 후속 작업의 기반.

## Background

이슈 #90 의 ③ (Limiter 임계값 상향). 이전 burst 경험으로 60% 운영 중이었음. PR #93 의 controlled experiment 결과:

| 한도 | 호출 | 429 |
|---|---|---|
| 50% | 51 | 0 (0%) |
| 70% | 71 | 0 (0%) |
| 80% | 81 | 0 (0%) |
| 90% | 91 | 0 (0%) |
| 95% | 96 | 0 (0%) |

→ DualWindowRateLimiter 의 timing 이 95% 까지 정확함을 데이터로 확인. 시계 jitter 가설 기각, 단순 한도 상향 path 채택.

## Changes

### 1. 한도 외부화
- `RiotApiProperties.RateLimit` 정적 내부 클래스 추가 (`@Valid` + `@Min/@Max`)
- default 18/1s + 90/2min (personal key 한도 20/100 의 90%)
- application.yml 에 env 외부화:
  - `EXTERNAL_RIOT_RATE_LIMIT_SHORT` (default 18)
  - `EXTERNAL_RIOT_RATE_LIMIT_LONG` (default 90)
  - `EXTERNAL_RIOT_RATE_LIMIT_SHORT_WINDOW` (default 1s)
  - `EXTERNAL_RIOT_RATE_LIMIT_LONG_WINDOW` (default 2m)
- `RiotApiConfig`: 하드코딩 제거, `RateLimit` properties 주입

### 2. 429 메트릭
- `RiotApiMetrics.recordRateLimited(type, endpoint)` 추가
- `riot.api.rate_limited` counter with `{type, endpoint}` 라벨
- type ∈ `application` | `method` | `service` | `unknown`
- endpoint 정규화 (PUUID/matchId → `{id}`) 로 cardinality 폭발 방지

### 3. 인터셉터 갱신
- `RiotRateLimitInterceptor` 가 `RiotApiMetrics` 주입받음
- 429 분기에서 `X-Rate-Limit-Type` 헤더 캡처 → 메트릭 노출
- 에러 메시지에도 `type=...` 포함

### 4. 테스트
- `RiotApiConfigTest`, `RiotRateLimitInterceptorTest`, `RiotApiSecretRedactionTest` 시그니처 갱신
- 429 메트릭 동작 검증
- endpoint 정규화 단위 테스트 추가

## 효과 (예상)

| 항목 | Before (60%) | After (90%) |
|---|---|---|
| host 당 일일 throughput 한도 | 43,200 | 64,800 (+50%) |
| KR + ASIA 합산 | 86,400 | 129,600 (+50%) |
| Stage 3 match_queue 소진 속도 | 기준 | ~1.5배 |

운영 메트릭으로 실측 결과 확인 예정.

## 다음 단계

### PR5 (1주 운영 후): 95% ramp
- env 만 변경: `EXTERNAL_RIOT_RATE_LIMIT_SHORT=19`, `EXTERNAL_RIOT_RATE_LIMIT_LONG=95`
- 코드 변경 0
- 메트릭으로 효과 측정

### 후속 (이슈 #90 의 ④/⑤/⑥)
- ④ Stage 내부 concurrency (fan-out)
- ⑤ 429 대응 정교화 (Retry-After 충실 + 호스트별 격리)
- ⑥ 메트릭/관측성 확장 (Grafana 대시보드)

## Test plan

- [x] `./gradlew compileJava compileTestJava` 통과
- [x] `./gradlew test` 통과
- [x] 429 메트릭 단위 테스트 통과
- [x] endpoint 정규화 단위 테스트 통과
- [ ] 머지 후 1-2일 운영에서 `riot.api.rate_limited` 메트릭 추세 확인 (Grafana)
- [ ] 1주 후 429 분포 보고 95% ramp 결정

## Related

- #90 — pipeline 성능 향상 (이 PR 은 ③ 의 implementation)
- #93 — RateLimitHeadroomProbeTest (data 근거, merged)