### PR TITLE
feat: Stage 2 의 matches_enqueued 카운터 추가 (분배 정책 결정 데이터)

### DIFF
--- a/src/main/java/com/bestduo_BE/pipeline/application/CollectMatchIdsRunner.java
+++ b/src/main/java/com/bestduo_BE/pipeline/application/CollectMatchIdsRunner.java
@@ -38,6 +38,7 @@ public class CollectMatchIdsRunner {
   private final PatchVersionService patchVersionService;
   private final DailyBudgetTracker budgetTracker;
   private final PipelineProperties props;
+  private final PipelineMetrics pipelineMetrics;
 
   // ── public API ──────────────────────────────────────────────────────────
 
@@ -81,6 +82,7 @@ public class CollectMatchIdsRunner {
       try {
         int queued = collectForSummoner(summoner, ctx);
         matchIdsQueued += queued;
+        pipelineMetrics.recordMatchesEnqueued(queued);
         summonerRepository.markMatchIdsCollected(summoner.getPuuid(), OffsetDateTime.now());
         budgetTracker.recordCollectCall(1);
         apiCalls++;

--- a/src/main/java/com/bestduo_BE/pipeline/application/PipelineMetrics.java
+++ b/src/main/java/com/bestduo_BE/pipeline/application/PipelineMetrics.java
@@ -10,6 +10,7 @@ public class PipelineMetrics {
 
   private static final String STAGE_COMPLETED = "pipeline.stage.completed";
   private static final String MATCH_QUEUE_SIZE = "pipeline.match_queue.size";
+  private static final String COLLECT_MATCHES_ENQUEUED = "pipeline.collect.matches_enqueued";
 
   private final MeterRegistry registry;
 
@@ -20,6 +21,16 @@ public class PipelineMetrics {
   public void recordStageCompleted(int stage, String outcome) {
     registry.counter(STAGE_COMPLETED, "stage", String.valueOf(stage), "outcome", outcome)
         .increment();
+  }
+
+  /**
+   * Stage 2 가 match_queue 에 enqueue 한 match 수 카운트. Stage 2 호출 수 (stage.completed{stage=2})
+   * 와 비교해 호출당 평균 enqueue 수 추적 → Stage 2/3 분배 정책 결정의 입력.
+   */
+  public void recordMatchesEnqueued(int count) {
+    if (count > 0) {
+      registry.counter(COLLECT_MATCHES_ENQUEUED).increment(count);
+    }
   }
 
   public void registerMatchQueueGauge(Supplier<Number> sizeSupplier) {

--- a/src/test/java/com/bestduo_BE/pipeline/application/CollectMatchIdsRunnerTest.java
+++ b/src/test/java/com/bestduo_BE/pipeline/application/CollectMatchIdsRunnerTest.java
@@ -20,6 +20,7 @@ import com.bestduo_BE.common.infra.persistence.repository.SummonerJpaRepository;
 import com.bestduo_BE.common.infra.riot.budget.DailyBudgetTracker;
 import com.bestduo_BE.common.infra.riot.exception.RiotRateLimitedException;
 import com.bestduo_BE.config.PipelineProperties;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.OffsetDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -59,9 +60,10 @@ class CollectMatchIdsRunnerTest {
     tierMatchCount.setApexTiers(30);
     tierMatchCount.setDiamondEmerald(10);
     props.setTierMatchCount(tierMatchCount);
+    PipelineMetrics pipelineMetrics = new PipelineMetrics(new SimpleMeterRegistry());
     runner = new CollectMatchIdsRunner(
         summonerRepository, riotApiPort, matchQueueEnqueuer,
-        patchVersionService, budgetTracker, props);
+        patchVersionService, budgetTracker, props, pipelineMetrics);
   }
 
   // ── hasPending ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

이슈 #90 의 ② (Stage 2/3 regional limiter 공정성) 정책 결정에 필요한 운영 데이터 확보용 메트릭 추가. Stage 2 호출당 평균 enqueue 수 (matches/summoner) 를 실측해야 적정 `collect-daily-budget` 산출 가능.

## Why

PR4 머지 후 토론 — 현재 분배:
- Stage 2: 일일 12,000 호출 (collect-daily-budget)
- Stage 3: ASIA 잔여 ~52,800

이론적 균형: `X(Stage 2 quota) × M(matches/summoner) = ASIA_TOTAL - X`

| M 가정 | 균형 Stage 2 quota |
|---|---|
| 5 | 10,800 |
| 10 | 5,891 |
| 15 | 4,050 |
| 20 | 3,086 |

→ 현재 12,000 이 enqueue 과잉일 가능성. 실측 M 없이는 결정 불가능. 이 PR 로 데이터 수집 시작.

## Changes

- `PipelineMetrics.recordMatchesEnqueued(int count)` 추가
  - counter: `pipeline.collect.matches_enqueued`
- `CollectMatchIdsRunner`: `PipelineMetrics` 주입, `collectForSummoner` 성공 시 카운트 증가
- `CollectMatchIdsRunnerTest` 시그니처 갱신

## 운영 분석 plan (2일 후)

Grafana 에서 측정할 지표:

1. **`match_queue.size` 추세** (이미 있음)
   - 안정/감소 → 현 분배 OK
   - 증가 → Stage 2 quota 축소 필요

2. **호출당 평균 enqueue 수**
   ```
   rate(pipeline_collect_matches_enqueued_total[1h])
     / rate(pipeline_stage_completed_total{stage="2", outcome="success"}[1h])
   ```
   → 실제 M 값 산출

3. **균형 quota 산출**
   ```
   ASIA 일일 capacity = 64,800 (90% 운영 기준)
   균형 X = 64,800 / (M + 1)
   ```

4. **429 분포 확인** (PR #94 에서 추가됨)
   - `riot.api.rate_limited{type, endpoint}` — 90% 운영의 실제 안정성 검증

## Test plan

- [x] `./gradlew compileJava compileTestJava` 통과
- [x] `./gradlew test` 통과
- [ ] 머지 후 2일 운영 → 위 지표 분석
- [ ] 분석 결과로 PR6 결정:
  - 분배 OK → PR6 없음, 그대로 운영
  - 분배 조정 필요 → PR6 으로 `collect-daily-budget` env 변경

## Related

- #90 (② Stage 2/3 fairness — 이 PR 은 의사결정 입력 데이터 수집)
- #94 (90% 한도 + 429 메트릭, merged)
- #93 (controlled experiment, merged)