### PR TITLE
refactor: inline 파이프라인 전환 — 설계 문서 + 관측 메트릭 (Phase A)

### DIFF
--- a/docs/adr_remove_match_queue_inline_pipeline.md
+++ b/docs/adr_remove_match_queue_inline_pipeline.md
@@ -1,0 +1,205 @@
+# ADR-008: Stage 2→3 `match_queue` 영속 큐 제거 — inline 파이프라인 채택, 병렬 fan-out은 prod 키 수령 시 활성화
+
+> 작성일: 2026-06-05
+> 상태: 채택(Accepted) — 구현은 단계적(phased), 현재 미적용
+> 대상 모듈: `com.bestduo_BE.pipeline`, `com.bestduo_BE.ingest`, `com.bestduo_BE.common`
+> 관련 ADR: [ADR-006](./adr_aggregate_from_match_payload.md)(payload 기반 재집계), [daily_pipeline_redesign_plan §0](./daily_pipeline_redesign_plan.md)(WorkItem 큐 거부)
+
+---
+
+## 1. 결정 요약
+
+Stage 2(Collect) → Stage 3(Ingest) 사이의 DB 영속 큐 `match_queue` 를 제거하고, **summoner 단위 inline collect→ingest** 구조로 전환한다.
+
+- **선택안: Option C (inline + executor fan-out)** 를 목표 아키텍처로 채택.
+- **현재 범위(dev 키)**: 병렬 처리는 도입하지 않는다. inline **순차** 처리로 충분하다(단일 스레드가 dev 예산 천장에 이미 도달).
+- **prod 키 수령 시**: ingest를 `executor + 공유 rate limiter` 로 fan-out 하는 활성화 계획을 §8에 따로 기록한다. 지금 구현하지 않는다(YAGNI).
+- dedup·재시작 영속은 이미 존재하는 `match` 테이블 + `summoner.match_ids_collected_at` 로 흡수한다.
+- 제거 전 **3가지 보장 조건**(§6)을 반드시 충족하고 단계적으로(§7) 진행한다.
+
+---
+
+## 2. 배경 — `match_queue` 의 현재 역할
+
+`match_queue`(스키마: `V2__drop_and_recreate_summoner_and_match_queue.sql:35-47`)는 다음을 담당한다:
+
+| 역할 | 구현 |
+|---|---|
+| Dedup | `match_id` PK + enqueue 시 `existsById`(`MatchQueueEnqueuer:19`) |
+| Fan-out 버퍼 | collect 1콜 → matchId 10~30개를 적재, ingest가 1개씩 소비 |
+| 재시작 영속 | status/locked_at 영속, 재시작 시 백로그 보존 |
+| Tier 우선순위 | `collection_tier` 필터 + round-robin(`RegionalPipelineRunner:135`) |
+| 재시도/poison | `retry_count`/`last_error`/cooldown + ERROR 종결 |
+| 관측 | `IngestQueueStats`(status/error/throughput) → `MatchQueueGaugeRegistrar` Micrometer 게이지 |
+
+즉 `match_queue` 는 **작업 분배(coordination)** 와 **관측(observability)** 의 이중 역할을 한다.
+
+---
+
+## 3. `match_queue` 가 없어도 되는 이유
+
+### 3.1 5가지 역할 중 4개는 기존 테이블이 공짜로 흡수
+
+| 큐가 하던 일 | 큐 없이 대체 |
+|---|---|
+| Dedup | `match` 테이블 `existsById` (대상만 큐→match) |
+| 재시작 영속 | `summoner.match_ids_collected_at` + `match` 테이블 |
+| Fan-out 버퍼 | inline 루프 (단일 스레드라 rate 디커플링 불필요) |
+| 예산 배분(collect↔ingest) | summoner당 1:N 구조적 고정 |
+| **Poison 컷오프** | ⚠️ **이것만** 명시적 대체 필요 (미니 실패 테이블/카운터) |
+
+→ 큐의 *고유* 잔여 가치는 **poison 컷오프 + 동적 매치-우선순위 + 큐-깊이 관측** 셋뿐이며, 앞 둘은 런타임에 거의 쓰이지 않고 관측은 emit 메트릭으로 이전 가능(§3.4).
+
+### 3.2 큐가 *유일하게* 정당한 자리(멀티 프로세스)가 사라짐
+
+DB 영속 큐가 꼭 필요한 단 하나의 시나리오 = **프로세스를 넘는 작업 분배**. prod 키 수치가 이를 무력화한다:
+
+- `500 req/10s` = 50/s, `30,000 req/10min` = 50/s → **지속 천장 50 req/s**
+- 한 프로세스가 **동시 10~25 스레드**(Little's Law: 50 × 0.2~0.5s)로 천장을 포화
+- rate limit은 **키당 공유** → 프로세스를 늘려도 throughput 불변, 분산 rate limiting + 공유 큐 복잡도만 추가 → **순손해**
+
+→ 멀티 프로세스가 후보에서 빠지므로 DB 큐의 유일한 명분도 소멸. (멀티 머신이 의미 있으려면 *키를 추가로 받아 예산이 실제 N배가 될 때* — 별개 문제, §9.)
+
+### 3.3 현재 큐는 멀티워커 대비도 반쪽
+
+`pickReadyWithPriorityAndLock` 의 `candidates` CTE에 **`FOR UPDATE SKIP LOCKED` 가 없다**(`MatchQueueJpaRepository:118-145`). 정확성은 `AND status='READY'` 재검사로 보장되나, N워커가 같은 우선순위 행을 동시에 노려 lock 경합(thundering herd)으로 확장되지 않는다. → 멀티워커로 가는 순간 이 SQL을 다시 써야 하므로, 지금 큐 유지가 미래 작업을 적립해주지 않는다.
+
+### 3.4 보장해야 할 2가지가 큐 없이 충족됨
+
+| 보장 | 큐 없이 | 전제 조건 |
+|---|---|---|
+| 재시작 안전 | 손실 = in-flight summoner 1명 re-collect(1콜), 데이터 손실 0, 총 부하와 무관 | ①②(§6) |
+| 모니터링 | event-emitted Micrometer 메트릭(이미 스택 보유) | ③(§6) |
+
+메트릭 매핑: `ingest_success_total` / `ingest_failure_total{reason}` / `ingest_latency`(p99=느린 호출) / `ingest_inflight` / `collect_pending_summoners` / heartbeat. → 큐 스캔보다 표준적이고, "메트릭을 위해 DONE 행 보존"이라는 디스크 비용도 사라진다.
+
+> 참고: 실제 겪은 디스크풀 인시던트([incident_postgres_disk_full_recovery_mode.md](./incident_postgres_disk_full_recovery_mode.md))는 Postgres가 죽은 DB-레벨 장애라, 같은 DB의 `match_queue` 도 보호를 주지 못했다.
+
+### 3.5 유지 시의 실제 비용 (불필요 + 비용 누적)
+
+- **DONE 행 무한 증가**: `markDone` 만 있고 `match_queue` 삭제 경로가 없음. 5GB 디스크 제약 + 디스크풀 이력 box에서 단조 증가.
+- **dead `priority` 컬럼**: `V2:38` `NOT NULL` 이나 `MatchQueue.newReady:58-71` 가 set하지 않아 항상 0, 어떤 쿼리도 읽지 않음.
+
+→ "불필요하지만 무해"가 아니라 **"불필요하고 비용을 누적 중"**. 단, 제거는 §6 조건을 구현하며 §7 단계로만.
+
+---
+
+## 4. 검토한 대안 — 파이프라인 구조 trade-off
+
+비교 축: prod 예산 포화 / 재시작 / 모니터링 / 디스크·운영비 / 복잡도 / 멀티머신.
+
+| | A. DB 영속 큐(현재) | B. Inline 순차 | C. Inline + executor fan-out ★ | D. In-memory 큐 + 워커풀 | E. 멀티프로세스 + 브로커 |
+|---|---|---|---|---|---|
+| prod 50req/s 포화 | △ (멀티워커+SKIP LOCKED 필요) | ❌ (1스레드, 예산 놂) | ✅ (동시 10~25) | ✅ | ✅ (키당 공유라 무의미) |
+| 동시성 메커니즘 | DB claim | 없음 | executor+limiter | BlockingQueue+풀 | 브로커+분산limiter |
+| 재시작 안전 | ✅ 백로그 박제 | ✅ summoner 단위(1콜 손실) | ✅ 동일 | ⚠️ in-memory 증발 | ✅ 브로커 영속 |
+| dedup | 큐 PK | match 테이블 | match 테이블 | match 테이블 | 브로커/큐 |
+| poison | retry_count/ERROR | 미니가드 | 미니가드 | 미니가드 | 브로커 DLQ |
+| 모니터링 | 큐 스캔(현재 wired) | emit 메트릭 | emit 메트릭 | emit 메트릭 | 브로커+emit |
+| 디스크/운영비 | ❌ DONE 무한증가 | ✅ 최소 | ✅ 최소 | ✅ 최소 | ❌ 브로커 운영 |
+| 복잡도 | 중 | **최저** | 낮음 | 중 | **최고** |
+| 멀티머신 확장 | △ | ❌ | ❌ | ❌ | ✅ |
+
+- **A (현재)**: 단일 키·단일 스레드에선 이점 0 + DONE 무한증가 + SKIP LOCKED 미비. 진짜 멀티프로세스 분배 시에만 적합 — 이 시스템엔 해당 없음.
+- **B (Inline 순차)**: 가장 단순. dev 키엔 충분하나 prod 예산을 못 채움. → **현재(dev) 단계의 구현 형태.**
+- **C (Inline + executor fan-out)** ★: collector가 matchId 생산 → `Semaphore + virtual-thread executor` 가 ingest 병렬, 각 호출이 기존 `DualWindowRateLimiter.acquire()` 통과. prod 예산 포화 + 큐 없이 dedup/재시작/관측. → **채택안. C = B(now) + executor 활성화(prod 키 시).**
+- **D (In-memory 큐)**: 재시작 시 백로그 증발이라 C 대비 이점 거의 없음. DB 큐의 메모리판이라 어중간.
+- **E (멀티프로세스 + 브로커)**: 키당 예산 공유라 throughput 불변 + 분산 조율/운영비 + 최고 복잡도. 기획의 단일 스레드 전제와 충돌. 키 추가로 예산이 실제 N배 될 때만(§9).
+- **참고 F. Spring Batch / WorkItem 큐**: [daily_pipeline_redesign_plan §0](./daily_pipeline_redesign_plan.md)에서 이미 거부(끝없는 Stage3와 철학 불일치, 단일 워커 이중 큐). 재론 없음.
+
+---
+
+## 5. 채택 — 왜 C인가, 그리고 단계 분리
+
+**C를 목표로 하되, 구현을 두 단계로 분리한다:**
+
+- **C-now (현재, dev 키)** = Option B 형태. inline **순차** collect→ingest. `match_queue` 제거의 본체. 병렬 처리는 **도입하지 않는다**(단일 스레드가 dev 예산을 이미 채움 — 병렬화는 효과 0 + speculative).
+- **C-later (prod 키 수령 시)** = executor fan-out 활성화(§8). 지금은 설계만 기록.
+
+이렇게 분리하는 이유: 큐 제거의 가치(단순화·디스크·dead code 청소)는 *지금* 실현되고, 동시성은 *실제로 필요해지는 시점(prod 키)*에 최소 변경으로 켜는 것이 "pressure가 real해질 때 refactor" 원칙에 맞다.
+
+---
+
+## 6. 제거 전 반드시 충족할 보장 조건
+
+| # | 조건 | 이유 |
+|---|---|---|
+| ① | **patch context 항상 보장** (`ctx==null` fallback 차단) | 재시작 후 re-collect가 같은 매치 집합을 줘야 함. `findMatchIdsSince/Between(startTime)`(시간 경계)은 결정적이나 `findRecentMatchIds(count)`(`CollectMatchIdsRunner:108-116`)는 윈도우가 밀려 매치 누락 가능 |
+| ② | **`markMatchIdsCollected` 를 ingest 완료 *후*로 이동** | 현재는 enqueue 직후(`CollectMatchIdsRunner:86`). inline에선 summoner의 모든 매치 ingest 후 표시해야 중간 크래시 시 통째 재처리됨 |
+| ③ | **관측 메트릭을 먼저 깔고 큐와 병행 검증 후 제거** | 큐 관측 표면을 잃고 눈을 가린 채 인프라를 뽑는 것 방지 |
+
+> ①②를 지키면 재시작 손실은 in-flight summoner 1명당 1 collect 콜로 bounded(데이터 손실 0). ③을 지키면 관측 공백 없음.
+
+---
+
+## 6.5 실패/재시도 처리 — 옵션 A (전용 재시도 머신 없음)
+
+큐의 `retry_count`(max 2)/`cooldown`(10분)/terminal-ERROR 를 **재현하지 않는다.** 운영 실측상 재시도가 거의 발생하지 않았고, inline에는 두 가지 자연 redundancy가 있기 때문:
+
+1. **재수집 = 자연 재시도**: 같은 patch 내 summoner 재시드 시 실패 matchId가 다시 떠올라 `existsById` dedup 하에 재시도됨.
+2. **매치당 ~10 수집 경로**: 참가자 10명 전원이 시드 대상 → 한 경로 일시 실패는 다른 참가자 경로로 덮임(dedup 1회 저장).
+
+**정책:**
+- ingest **1회 시도** → non-429 예외면 `ingest_failure_total{reason}` 기록 + log + **skip**. retry_count/markError/poison 테이블 없음.
+- **429** → 기존 `RegionalPipelineRunner` backoff 유지(무변경).
+- **크래시** → 조건②(재수집)가 stale 복구 대체.
+- **⚠️ 시스템 실패(auth/대량 5xx)는 조용히 흡수 금지** → 실패율 급증 알람 + auth halt. (큐도 못 하던 부분 — 오히려 개선.)
+- **reversible**: poison이 실제 예산을 갉으면 `ingest_failure_total` 가 즉시 드러냄 → 그때 작은 skip-set 추가(YAGNI). 지금은 미반영.
+
+**롤백 flag 없음**: Phase A 메트릭 병행검증으로 안전성을 확보하므로 inline↔큐 토글 flag는 두지 않는다(단순성).
+
+---
+
+## 7. 단계적 마이그레이션 (4단계)
+
+1. **관측 이전**: `ingest_*`/`collect_pending_summoners`/heartbeat 메트릭을 emit 방식으로 추가. (큐와 **병행** 운영, 지표 parity 검증)
+2. **inline 경로 도입 + ①② 가드**: `collectForSummoner` 가 enqueue 대신 `match.existsById` 체크 후 inline ingest. 실패 처리 = §6.5 옵션 A(1회 시도 + metric + skip, flag 없음). (큐 경로와 병행 비교)
+3. **큐 경로 차단**: enqueue/dequeue 호출 제거, `RegionalPipelineRunner` 의 Stage2/Stage3 분기를 단일 단계로 통합.
+4. **스키마 drop**: `match_queue` 테이블 + `MatchQueue`/`QueueStatus`/`MatchQueueJpaRepository`/`MatchQueueDispatcher`/`MatchQueueEnqueuer`/`IngestQueueStats`/`MatchQueueGaugeRegistrar`/관련 admin 제거.
+
+---
+
+## 8. prod 키 수령 시 활성화 계획 (C-later, 지금 구현 안 함)
+
+prod 키(`500/10s`, `30,000/10min` = **50 req/s 지속**)를 받으면 단일 스레드로는 천장을 못 채우므로 ingest를 fan-out 한다.
+
+### 설계
+```
+단일 프로세스
+  ├─ collector (단일 스레드): pending summoner(tier 순) → matchIds fetch → bounded 채널 push
+  └─ ingest pool: Semaphore(maxInFlight) + virtual-thread executor
+                  → 각 task가 기존 DualWindowRateLimiter.acquire() 통과 → fetch + save
+```
+
+- **limiter 무변경**: `DualWindowRateLimiter.acquire()` 는 이미 thread-safe(`:33` synchronized 검사 + `:52` lock 밖 sleep). 숫자만 prod 값(short 500/10s, long 30000/10min)으로.
+- **maxInFlight ≈ 50 req/s × latency** (Little's Law) → 시작 ~16~32, p99 보며 튜닝. Semaphore로 in-flight를 묶어 스레드 폭발 방지.
+- **collector는 단일 스레드 유지**: collect와 ingest가 **같은 regional 예산을 공유**하므로 collector 병렬화는 ingest 예산을 뺏는 제로섬 + 백로그 재생성. collect는 ingest의 ~1/N(1~4.5 req/s) 볼륨이라 한 스레드로 충분. bounded 채널 + 공유 limiter가 collect↔ingest를 자동 균형.
+- **collector 동시성은 튜너블(기본 1)**: `ingest_inflight`/채널-empty 가 ingest starvation을 *측정으로* 보일 때만 1→2로 상향. 병렬 collector 풀을 미리 짓지 않는다(YAGNI).
+
+### 이때도 큐는 불필요
+희소자원 코디네이터는 limiter(전역 예산), 병렬성은 executor, dedup은 match 테이블 — 전부 프로세스 내 완결. DB 큐가 끼어들 자리 없음.
+
+---
+
+## 9. 언제 큐/멀티프로세스를 재도입하나
+
+다음 *측정된* 조건이 실제로 발생할 때만 재검토(그 전엔 speculative):
+
+- **API 키를 추가로 받아 예산이 실제 N배가 됨** → 키별 워커를 여러 프로세스/머신에 분산할 실익 발생 → 공유 큐/브로커(Redis/SQS) + 분산 rate limiting + `FOR UPDATE SKIP LOCKED` 기반 claim 설계.
+- **로컬 연산이 병목** (단일 인스턴스가 50 matches/s 처리/저장을 못 따라감) → 현재는 I/O 대기가 지배라 해당 없음.
+
+---
+
+## 10. 후속 영향
+
+- **디스크**: `match_queue`(특히 DONE 무한행) 제거로 단조 증가 한 축 제거. [bestduo_db_size_bytes](./portfolio_slides.md) 추이에 반영.
+- **관측 성숙도**: 상태-테이블 스캔 → event-emitted 메트릭으로 전환(표준 패턴).
+- **포기하는 것(명시)**: 동적 매치-단위 우선순위, per-item 큐-깊이/RUNNING-stuck 추적(→ latency p99 + 타임아웃 + heartbeat로 대체).
+- **코드**: pipeline/ingest 경계 단순화(Stage2/3 단일 단계화), dead `priority` 컬럼 동반 소멸.
+
+## 11. 참고
+
+- [ADR-006](./adr_aggregate_from_match_payload.md) — payload 기반 재집계(큐 없이 재처리 가능 전제와 정합)
+- [daily_pipeline_redesign_plan.md](./daily_pipeline_redesign_plan.md) §0 — WorkItem/Spring Batch 거부 근거
+- [incident_postgres_disk_full_recovery_mode.md](./incident_postgres_disk_full_recovery_mode.md) — 디스크 제약이 1급 운영 지표인 이유
+- [pipeline_implementation_map.md](./pipeline_implementation_map.md) — 현재 구현 맵(큐 동작 file:line)

--- a/docs/pipeline_implementation_map.md
+++ b/docs/pipeline_implementation_map.md
@@ -1,0 +1,156 @@
+# 데이터 파이프라인 구현 맵 (Implementation Map)
+
+> **목적**: 기획·ADR이 "무엇을 하려 했는가"를 적는다면, 이 문서는 **코드가 실제로 무엇을 하는가**를 file:line 근거로 기록한다. 기획 대비 정합성 평가의 기준선(ground truth)으로 쓴다.
+>
+> **작성 기준일**: 2026-06-05 (`feat/db-size-metric` 브랜치)
+> **검증 방식**: `src/` 직접 탐색 + `application.yml` 설정값 대조. file:line 은 작성 시점 기준.
+
+---
+
+## 0. 한눈에 보는 파이프라인
+
+```
+① Seed     DailyLeagueEntriesRunner   리그 엔트리 → summoner 시드
+② Collect  CollectMatchIdsRunner      summoner → 최근 matchId → match_queue(READY)
+③ Ingest   MatchIngestRunner          match_queue → match-v5 payload 저장(raw-first)
+④ Aggregate BottomDuoAggregateScheduler(cron) → AggregateBottomDuoFromMatch
+            payload_json 재읽기 → stat_agg / matchup_agg upsert
+④b Ranking  ComputeBottomDuoRanking    PENDING → RANKED 승격(rank_score)
+⑤ Cleanup  CleanupOldPatches          최신 N patch 만 stat/matchup 보존
+⑥ Archive  MatchArchiver / MatchPayloadCleaner  payload → R2(JSONL.GZ) 후 DB 행 삭제 (수동/admin)
+```
+
+핵심 전제: **단일 Riot API key → 단일 스레드**. 수평 확장 없음. Stage 3 는 종료 없는 상시 루프.
+
+---
+
+## 1. 활성화 상태 스냅샷 (가장 먼저 볼 것)
+
+대부분의 자동 단계는 **default `false`** 이며 환경변수로만 켜진다. 코드만 보면 "수동", prod env 가 켜야 "자동"이 된다.
+
+| 설정 | 기본값 | 위치 |
+|---|---|---|
+| `PIPELINE_RUNNER_ENABLED` (Seed/Collect/Ingest 루프) | **false** | `application.yml:76` |
+| `AGGREGATE_SCHEDULER_ENABLED` (집계 cron) | **false** | `application.yml:61` |
+| `PATCH_SYNC_ENABLED` (DataDragon patch 동기화) | **false** | `application.yml:56` |
+| `ARCHIVE_R2_ENABLED` (R2 아카이브) | **false** | `application.yml:68` |
+| `aggregate.scheduler.cron` | `0 0 4 * * *` (Asia/Seoul) | `application.yml:62` |
+| `AGGREGATE_RETENTION_PATCHES` | `3` | `application.yml:64` |
+| `PIPELINE_COLLECT_DAILY_BUDGET` | `12000` | `application.yml:77` |
+| `PIPELINE_COLLECT_BATCH_SIZE` | `20` | `application.yml:78` |
+| `PIPELINE_INGEST_BATCH_SIZE` | `10` | `application.yml:79` |
+| `PIPELINE_DIA_EME_DAILY_PAGE_QUOTA` | `1000` | `application.yml:82` |
+| Rate limit (short) | `18 / 1s` (20의 90%) | `application.yml:50` |
+| Rate limit (long) | `90 / 2min` (100의 90%) | `application.yml:52` |
+
+> ⚠️ **서사 정합성 주의**: 포트폴리오는 "자동 daily pipeline" 으로 서술하지만 코드 기본값은 전부 off. prod(Railway) env 가 실제로 켜는지 별도 확인 필요.
+
+---
+
+## 2. Stage 1 — Seed (`DailyLeagueEntriesRunner`)
+
+- **트리거**: 파이프라인 루프(`PIPELINE_RUNNER_ENABLED`)에서 호출. virtual thread 루프.
+- **동작**:
+  - Apex tier(CHALLENGER/GRANDMASTER/MASTER): tier 당 API 1회로 전체 엔트리 수신.
+  - Non-apex(DIAMOND/EMERALD): `league-v4 entries/{queue}/{tier}/{division}?page={n}` 페이지네이션.
+    - **일일 할당량(quota)**: 하루 `dia-eme-daily-page-quota`(기본 1000) 페이지 처리 후 정지.
+    - division 별 safety cap 존재. 응답이 비면(`entriesFetched == 0`) 해당 division 소진 → 다음 division.
+    - `seedPage` / `seedDivision` 은 날짜가 바뀌어도 리셋 안 함 — 사이클 위치 영속.
+- **상태**:
+  - `DailyPipelineState`(날짜별) + `CoverageBucket`(patch×tier별). 자정 리셋.
+  - **`CoverageBucket.create(patch, tier)` 는 프로덕션에서 호출됨** → `DailyLeagueEntriesRunner.java:133`.
+    (※ `plan_dia_eme_cycle_seed.md` 의 "한 곳도 호출 안 함" 서술은 stale.)
+
+---
+
+## 3. Stage 2 — Collect (`CollectMatchIdsRunner`)
+
+- **동작**: `seeded_at` 은 있고 `match_ids_collected_at` 은 없는 summoner 를 골라 최근 matchId 수집 → `match_queue`(status=READY)에 tier+patch 메타와 함께 적재.
+- **tier별 matchesPerSummoner 차등 구현됨**: `matchCountFor(summoner.getLastKnownTier())` → `CollectMatchIdsRunner.java:105`.
+- **일일 예산**: `collect-daily-budget`(기본 **12000**) API 호출. 소진 시 Stage 3 로 넘어감.
+  (※ `daily_pipeline_redesign_plan.md` 의 Stage2 "8000 req/day" 는 문서가 stale — 코드는 12000.)
+- **patch 필터**: enqueue 시 `startTime`(현재 patch 시작 시점) 필터로 이전 patch 매치 유입 차단(입구 게이트).
+
+---
+
+## 4. Stage 3 — Ingest (`MatchIngestRunner`)
+
+- **동작**: `match_queue` 에서 READY 또는 재시도 가능한 ERROR 행을 batch(`ingest-batch-size`=10)로 픽 → match-v5 상세 수집 → `RiotMatchDto` 를 `match.payload_json` 에 **그대로 저장(raw-first)**.
+- **patch 검증(출구 게이트)**: `expectedPatch` 와 불일치하면 폐기 — cross-patch 노이즈 차단.
+- **재시도/복구**:
+  - ERROR 행은 `retryCount < 2` 이고 `errorCooldownMinutes` 경과 시 재처리.
+  - stale 복구: RUNNING 상태가 10분 초과면 READY 로 되돌림.
+- **rate limit**: `DualWindowRateLimiter` + `RiotRateLimitInterceptor` — short/long 윈도우(18/1s, 90/2min). 429 시 즉시 `sleep → continue`.
+
+---
+
+## 5. Stage 4 — Aggregate (`AggregateBottomDuoFromMatch`)
+
+진입점: `BottomDuoAggregateScheduler.run()` (cron) — `@ConditionalOnProperty(aggregate.scheduler.enabled=true)`, `BottomDuoAggregateScheduler.java:25,41`.
+
+- **5 tier 순회**: 한 cron 실행에서 CHALLENGER~EMERALD 5개를 `for` 루프 → `BottomDuoAggregateScheduler.java:52`. tier 별로 `fromMatchUseCase.execute(patch, tier, true)` 호출 후 ranking 까지 수행. 한 tier 실패해도 나머지 진행.
+- **읽기 방식 (`AggregateBottomDuoFromMatch.java`)**:
+  - keyset 페이지네이션: `cursor` = 마지막 `matchId`, `PAGE_SIZE=500`.
+  - `matchRepository.findPageByTierAndPatch(...)` → **`List<Match>` 엔티티** 반환 → `AggregateBottomDuoFromMatch.java:131`.
+  - 페이지마다 `objectMapper.readValue(m.getPayloadJson(), RiotMatchDto.class)` → `BottomDuoExtractor.extract()` 로 듀오 추출 → in-memory `HashMap<StatKey,Counter>` / `HashMap<MatchupKey,Counter>` 누적.
+  - `execute()` 에 **`@Transactional` 없음** (클래스/메서드 모두).
+- **upsert**: `JdbcTemplate.batchUpdate`(UPSERT_BATCH_SIZE=500)로 `bottom_duo_stat_agg`, `bottom_duo_matchup_agg` 에 `on conflict do update`.
+  - `adjusted_win_rate = (wins + 50) / (games + 100)` — Bayesian smoothing. `ranking_status='PENDING'` 으로 insert.
+
+> 🔴 **설계 일관성 이슈 (ADR-007 대비)**: archive 경로는 `MatchPayloadProjection`(L1 캐시 우회)으로 하드닝됐지만, aggregate 읽기 경로는 같은 `payload_json` 을 더 많은 행(tier 전체)에 대해 **full 엔티티로 로딩**한다. 같은 repository 에 projection 메서드가 나란히 존재(아래 §8). 현재는 cron 전용 호출 + 스케줄 스레드(OSIV 미적용) + `@Transactional` 부재 덕에 페이지마다 detach→GC 되어 **우연히 안전**하지만, `@Transactional` 추가나 HTTP 트리거 도입 시 ADR-007 이 문서화한 OOM 이 재발할 수 있는 latent 구조다. 자세한 내용은 ADR-007 §7 참조.
+
+### 5b. Ranking (`ComputeBottomDuoRanking`)
+- `@Transactional` (`ComputeBottomDuoRanking.java:25`). tier×patch 의 `stat_agg` 를 `rank_score` 로 정렬해 `ranking_status='PENDING' → 'RANKED'` 승격.
+- 별도 admin 경로 존재: `POST /admin/aggregate/recompute-ranking` (`AggregateAdminController.java:33`) — **ranking 만** 재계산(과거 스케줄러가 ranking 호출을 빠뜨린 회귀 대응용). from-match 집계 자체를 HTTP 로 트리거하는 엔드포인트는 **없음**.
+
+---
+
+## 6. Stage 5 — Cleanup (`CleanupOldPatches`)
+
+- cron 끝에서 실행. 최신 `AGGREGATE_RETENTION_PATCHES`(기본 3)개 patch 의 stat/matchup 행만 보존, 그 외 삭제.
+
+---
+
+## 7. Stage 6 — Archive / Cleanup (수동 · admin)
+
+- **트리거**: admin 엔드포인트(`/admin/archive/*`). cron 상시화는 미구현(기획 slide 14 "자동 아카이브 상시화" = future work).
+- **`MatchArchiver`**: `match.payload_json` 을 `MatchPayloadProjection`(interface projection) + temp file 스트리밍으로 gzip JSONL 화 → R2(S3 호환) 업로드. L1 캐시 우회로 대용량 OOM 회피(ADR-007).
+- **`MatchPayloadCleaner`**: R2 `HEAD` 검증 후 DB 행 삭제. **최신 2 patch 보호**(`protected_latest=2`).
+
+> 🟡 **재집계 범위 주의**: ADR-006 의 "payload 만 있으면 과거 재집계 가능" 가치는, archive cleanup 이 payload 를 DB 에서 지우고 **R2 → 재집계 reload 경로가 없으므로**, 실제로는 *DB 에 payload 가 남은 최근 patch 한정*. retention(stat 3 patch)상 실무 영향은 작음.
+
+---
+
+## 8. 핵심 Repository — `MatchJpaRepository`
+
+같은 (tier, patch) keyset 쿼리가 **엔티티용**과 **projection용** 두 벌 존재.
+
+| 메서드 | 반환 | 용도 | 위치 |
+|---|---|---|---|
+| `findPageByTierAndPatch` | `List<Match>` (엔티티) | **aggregate** 경로 | `MatchJpaRepository.java:29` |
+| `findPayloadPageByTierAndPatch` | `List<MatchPayloadProjection>` (L1 우회) | **archive** 경로 | `MatchJpaRepository.java:50` |
+| `findDistinctPatches` | `List<String>` | archive cleanup 의 protected 목록 계산 | `MatchJpaRepository.java:61` |
+| `deleteByTierAndPatch` | `int` (`@Modifying @Transactional`) | archive 후 디스크 회수 | `MatchJpaRepository.java:71` |
+
+- projection 메서드 주석(`:37-39`)이 직접 명시: *"L1 캐시에 엔티티가 등록되지 않도록 … OSIV 가 세션을 잡고 있어도 페이지가 GC 대상이 되어 OOM 을 피한다."* → archive 엔 적용, aggregate 엔 미적용(§5 이슈).
+- **OSIV**: `open-in-view` 미설정 → Spring Boot 기본값 `true`. (단, @Scheduled 스레드엔 미적용.)
+
+---
+
+## 9. half-wired / 주의 항목 요약
+
+| 항목 | 상태 |
+|---|---|
+| 자동 단계 플래그(pipeline/aggregate/patch/archive) | 전부 default **off** — prod env 의존 |
+| 자동 아카이브 cron | 미구현(수동 admin only) — 기획상 future work |
+| aggregate 읽기 경로 projection 미적용 | latent OOM 구조(현재는 우연히 안전) — §5 / ADR-007 §7 |
+| from-match 강제 재집계 admin 엔드포인트 | 없음(YAGNI, ADR-006 §8) |
+| 문서 stale | collect budget 8000(문서) vs 12000(코드); `CoverageBucket.create` "호출 안 함"(문서) vs 호출됨(코드) |
+| TODO/FIXME | 파이프라인 코드 내 없음. magic number 는 대부분 config 외부화됨 |
+
+---
+
+### 관련 문서
+- 기획/의도: `daily_pipeline_redesign_plan.md`, `architecture.md`, `portfolio_slides.md`
+- ADR: `adr_aggregate_from_match_payload.md`(ADR-006), `adr_archive_oom_projection.md`(ADR-007)
+- 인시던트: `incident_postgres_disk_full_recovery_mode.md`

--- a/docs/pipeline_inline_migration_plan.md
+++ b/docs/pipeline_inline_migration_plan.md
@@ -1,0 +1,112 @@
+# match_queue 제거 → inline 파이프라인 구현 계획
+
+> 작성일: 2026-06-05
+> 상태: 계획(Planned) — 착수 대기
+> 근거 결정: [ADR-008](./adr_remove_match_queue_inline_pipeline.md) / 요구사항: [pipeline_requirements.md](./pipeline_requirements.md)
+> 범위: **C-now (inline 순차)**. 병렬 executor·롤백 flag·poison 테이블 **없음**(확정).
+
+---
+
+## 0. 스코프 & 확정 사항
+
+- **대상**: Stage 2(Collect) → Stage 3(Ingest) 경계만. `match_queue` 제거 + inline 융합.
+- **안 건드림**: Aggregate cron, Archive, serving API(QR 표시는 별도 트랙).
+- **확정**: 실패 처리 = ADR-008 §6.5 옵션 A(1회 시도 + metric + skip). 롤백 flag 없음. 병렬 fan-out은 prod 키 때(ADR-008 §8).
+
+## 1. 전체 성공 기준 (verify 대상)
+
+제거 완료 후 다음이 **모두** 성립:
+1. 재시작/재배포 후 데이터 손실 0, 자동 재개 (NFR-5)
+2. dedup 유지 — 같은 매치 1회만 ingest (FR-4)
+3. patch 순도 유지 — cross-patch 오염 0 (FR-1)
+4. 관측 공백 0 — 큐 제거 전 emit 메트릭이 큐 지표와 parity (조건③)
+5. 빌드/테스트 green, `match_queue` 참조 0
+
+---
+
+## 2. Phase A — 관측 메트릭 emit (큐 살아있는 채로) — ✅ 코드 구현 완료
+
+> 조건③: 큐를 떼기 전에 새 관측 표면을 먼저 깔고 parity 검증.
+
+**설계 판단**: `PipelineMetrics`는 `pipeline` 컨텍스트이고 `pipeline → ingest`(`RegionalPipelineRunner`→`MatchIngestRunner`) 의존이 이미 있어, `ingest`에서 PipelineMetrics를 쓰면 **순환 의존**이 된다. → Phase A 메트릭은 **전부 pipeline 컨텍스트에서만** 배선(ingest 무수정).
+
+**변경 (구현됨)**
+- `PipelineMetrics`: `pipeline.ingest.success`/`pipeline.ingest.failure`(Counter), `pipeline.collect.pending_summoners`/`pipeline.heartbeat`(Gauge) 추가.
+- `RegionalPipelineRunner`: `loop`에서 `recordHeartbeat()`, Stage3 성공 시 `recordIngestOutcome(result.done(), result.error())` — 큐가 받던 done/error 카운트를 그대로 emit(parity).
+- `SummonerJpaRepository.countMatchIdsPendingSummoners()` + `PendingSummonersGaugeRegistrar`(gauge 등록).
+- 테스트: `PipelineMetricsTest`에 ingest outcome / heartbeat / pending gauge 검증 추가. (build + test green)
+
+**Phase B로 연기**: `ingest_failure{reason}` 분류(auth/5xx/timeout)·`ingest_latency`(Timer)·auth-halt → inline 에러 처리(옵션 A)와 함께. Phase A는 *parity 검증*이 목표라 success/failure 카운트면 충분(failures도 운영상 드묾).
+
+**verify (배포 후 — 미수행)**
+- Grafana에서 `pipeline_ingest_success` rate ≈ 기존 `IngestQueueStats.doneLast10m`, `pipeline_ingest_failure` ≈ 큐 ERROR 증가분, `pipeline_heartbeat`/`pipeline_collect_pending_summoners` 정상 노출.
+
+---
+
+## 3. Phase B — inline 경로 + 조건 ①② (핵심 변경)
+
+**변경 (surgical)**
+- `CollectMatchIdsRunner`:
+  - 의존성 교체: `MatchQueueEnqueuer` 제거 → `MatchJpaRepository`(existsById) + `IngestMatchDetail` 주입.
+  - `collectForSummoner`: `enqueueAllIdempotent(matchIds,…)` → matchIds 루프:
+    ```
+    for (id : matchIds)
+      if (matchRepo.existsById(id)) continue;        // dedup (ingest 앞 → API 콜 절약)
+      try   ingestMatchDetail.execute(id, tier, ctx.patch());  // 1 API 콜 + save
+      catch (RiotRateLimitedException e) throw e;      // 429 → 상위 backoff
+      catch (Exception e) metrics.recordIngestFailure(reason(e));  // 옵션 A: skip
+    ```
+  - **조건①**: `runBatch` 의 `ctx == null`(patch 미등록)이면 수집 skip — `findRecentMatchIds` 비결정 fallback(`CollectMatchIdsRunner:108`) 차단.
+  - **조건②**: `markMatchIdsCollected` 는 현 위치(`:86`, summoner 처리 후) 유지 — inline에선 ingest까지 끝난 뒤 표시되므로 자동 충족.
+- `RegionalPipelineRunner`:
+  - `executeTick` 의 Stage3 블록 + `runStage3WithTierRoundRobin` + `buildTierOrder` 제거.
+  - → `if (collectMatchIdsRunner.hasPending()) runBatch(); else sleep(pollingInterval);` 단일 단계.
+- `findMatchIdsPendingSummoners`: **tier 순 정렬** 추가(tier 우선순위 = summoner 선택 순서로 이전).
+
+**테스트** (한글 `@DisplayName`)
+- `CollectMatchIdsRunnerTest` / `RegionalPipelineRunnerTest` inline로 재작성.
+- 신규: **재시작 시나리오** — summoner의 매치 일부만 ingest 후 크래시 → 재수집 시 dedup으로 중복 0, 미수집분 ingest, 데이터 손실 0.
+- 신규: dedup(이미 match 테이블에 있는 id는 API 콜 안 함), 조건①(ctx==null이면 수집 skip).
+
+**verify**
+- 테스트 green.
+- 스테이징/프로드(큐와 병행): inline 경로로 수집→저장→집계 정상, Phase A 메트릭이 정상 진행 표시.
+- 재시작 mid-run → 손실/중복 0 확인.
+
+---
+
+## 4. Phase C — 큐 코드 제거 + 스키마 drop
+
+> Phase B가 프로드에서 안정 확인된 *후*.
+
+**제거 (main)**
+- `MatchQueue`, `QueueStatus`, `MatchQueueJpaRepository`, `MatchQueueDispatcher`, `MatchQueueEnqueuer`
+- `MatchIngestRunner`(큐 기반), `IngestQueueStats`, `MatchQueueGaugeRegistrar`, `AdminQueueController`(`/admin/queue/*`)
+- `IngestQueueStatsJpaRepository` 등 큐 전용 repo
+
+**제거 (test) — 9개**
+- `MatchQueueDispatcherTest`, `MatchQueueDispatcherPhase5Test`, `MatchIngestRunnerTest`, `MatchQueueEnqueuerTest`, `MatchQueueTest`, `MatchQueueJpaRepositoryTransactionalTest`
+- `CollectMatchIdsRunnerTest`, `RegionalPipelineRunnerTest`, `PipelineMetricsTest` — 큐 참조분 정리(Phase B에서 inline로 재작성된 것 확정)
+
+**마이그레이션**
+- `V7__drop_match_queue.sql` — `DROP TABLE match_queue;` (DONE 무한증가 문제도 동반 해소 — NFR-6)
+
+**verify**
+- `./gradlew build` green, `grep -r MatchQueue src/main` = 0.
+- Grafana: 큐 게이지(`MatchQueueGaugeRegistrar`) 제거 → Phase A emit 메트릭으로 대체 확인.
+- 프로드 디스크 추이(`bestduo_db_size_bytes`)에서 match_queue 증가분 소멸 확인.
+
+---
+
+## 5. 진행 순서 / 게이트
+
+```
+Phase A (메트릭) ──parity 검증(수일)──▶ Phase B (inline, 큐 병행) ──프로드 안정──▶ Phase C (제거 + V7 drop)
+```
+각 게이트 통과 전 다음 단계 착수 금지. 특히 **A→B 순서가 관측 공백 방지의 핵심**(조건③).
+
+## 6. 스코프 밖 (참고)
+
+- 병렬 executor fan-out → prod 키 시(ADR-008 §8)
+- QR 표시 라벨/임계 → serving 트랙(requirements §8)
+- poison skip-set → `ingest_failure_total` 가 필요를 보일 때만(reversible, ADR-008 §6.5)

--- a/docs/pipeline_requirements.md
+++ b/docs/pipeline_requirements.md
@@ -1,0 +1,122 @@
+# 데이터 파이프라인 요구사항 명세 (Requirements)
+
+> 작성일: 2026-06-05
+> 상태: 초안(Draft) — 일부 SLO 수치 `[확인 필요]`
+> 목적: 구현/마이그레이션(예: [ADR-008](./adr_remove_match_queue_inline_pipeline.md)) 이전에 **"이 파이프라인이 무엇을 보장해야 하는가"** 를 구조 비의존적으로 못박는다. 어떤 파이프라인 구조든 이 요구사항을 만족해야 한다.
+
+---
+
+## 1. 목적 & 범위
+
+BestDuo 데이터 파이프라인은 Riot 공식 API에서 **에메랄드+ 솔로 랭크 매치**를 수집·저장하고, **패치 단위로 ADC/서포터 듀오 조합의 승률·픽률·랭킹·매치업·카운터**를 집계해 REST로 제공한다.
+
+- **In scope**: Seed → Collect → Ingest → Aggregate → (Archive) 파이프라인, 그 산출물의 신선도·신뢰도·가용성 보장.
+- **Out of scope**: §7.
+
+---
+
+## 2. 제품 컨텍스트 — 파이프라인이 떠받치는 출력
+
+| API | 출력 단위 |
+|---|---|
+| `GET /bottom-duo/stats` | (tier, patch, ADC, SUP) 승률·픽률·랭킹·tier delta |
+| `GET /bottom-duo/matchups` | (tier, patch, 내 듀오 vs 상대 듀오) 매치업 |
+| `GET /bottom-duo/counters` | (tier, patch, 듀오) 최저 승률 카운터 |
+
+→ 분석의 최소 단위 = **셀(cell)**: stat = (tier × ADC × SUP), matchup = (tier × 내듀오 × 상대듀오). 품질 요구(§4)는 이 셀 단위로 정의된다.
+
+---
+
+## 3. 기능 요구 (FR)
+
+### FR-1. 데이터 출처 / 정합성
+- Riot `league-v4`(summoner) + `match-v5`(matchId, match 상세)에서만 수집. 순수 통계 목적.
+- **patch 순도(purity)**: 한 patch 통계에 다른 patch 매치가 섞이지 않는다. (입구 `startTime` 필터 + 출구 patch 검증.)
+
+### FR-2. 수집 범위 — tier별 분리 (핵심)
+- 대상 tier = **CHALLENGER / GRANDMASTER / MASTER / DIAMOND / EMERALD 5개, 각각 분리.** (Q4)
+- 수집과 집계 **둘 다 tier 단위**로 분리되어야 한다. (어떤 매치가 어느 tier 버킷에서 왔는지 복원 가능해야 함.)
+
+### FR-3. 수집 모델 — 현재 patch best-effort
+- **현재 patch**를 대상으로 **일일 rate-limit 예산이 닿는 만큼** 수집한다. (Q1)
+- tier별 차등(예: apex 더 깊게)을 허용한다.
+- 고정 "총 목표 매치 수"는 요구가 아니다. 품질은 §4의 셀 단위 기준으로 보장한다.
+
+### FR-4. 증분 · 멱등
+- 매일 증분 갱신. 이미 수집된 매치는 재수집하지 않는다(dedup).
+- 재시작/재실행이 데이터를 중복·손상시키지 않는다(idempotent). (→ NFR-5)
+
+### FR-5. 집계
+- (tier, patch)별로 듀오 조합의 wins/games/win_rate/pick_rate, 랭킹(rank_score), 매치업/카운터를 산출.
+- 집계 기준이 바뀌어도 **외부 호출 없이 재집계** 가능해야 한다 (현재 payload가 DB에 있는 patch 한정 — [ADR-006](./adr_aggregate_from_match_payload.md)).
+
+### FR-6. patch 전환
+- 새 patch 등장 시, 그 patch 기준 수집·집계로 전환된다. 전환 grace 처리를 포함한다.
+- 새 patch 통계가 노출되기까지의 신선도는 NFR-1.
+
+---
+
+## 4. 데이터 품질 요구 (QR) — *핵심*
+
+> "예산 best-effort 수집"은 셀의 **머리**(인기 조합/저tier)엔 충분하고 **꼬리**(희귀 조합/고tier/매치업)에만 약하다. 따라서 품질은 수집량이 아니라 **셀당 최소 표본**으로 보장한다.
+
+- **QR-1. 표시 정직성 (두 레버)**: 품질은 단일 임계가 아니라 ① **저표본 평활**(QR-2, prior 100)이 랭킹을 보호하고 ② **표본 수(games)를 항상 노출** + 표시 바닥 미만은 **"표본 부족" low-confidence 라벨**(숨기지 않음 — 고tier 데이터를 보여주려는 의도와 일치)로 정직성을 보장한다. 현재 값: 랭킹 바닥 `MIN_GAMES=4`(`ComputeBottomDuoRanking:20`) + 평활 prior 100. 표시 라벨 임계(제안 ~30)는 serving 결정 — §8.
+- **QR-2. 저표본 평활**: 랭킹/비교는 `adjusted_win_rate = (wins+50)/(games+100)` (Bayesian smoothing, 현행) 로 저표본 셀의 과대평가를 억제한다.
+- **QR-3. 고tier 한계 명시**: 챌린저 등 인구가 적은 tier는 구조적으로 표본이 작다. QR-1 가드가 가장 크게 작용하는 지점이며, "데이터 부족"을 사용자에게 정직하게 노출한다.
+- **QR-4. patch 순도**: FR-1 재확인 — 통계 신뢰의 전제.
+
+---
+
+## 5. 비기능 요구 (NFR) — production-like SLO (Q2)
+
+> 수집 *커버리지*는 예산 best-effort라 SLO를 안 걸지만, **신선도·가용성·신뢰도·운영 안전**엔 production-like SLO를 건다.
+
+| # | 요구 | SLO |
+|---|---|---|
+| NFR-1 | **신선도(freshness)** | 새 patch는 출시 후 **3일(`PATCH_GRACE_PERIOD_DAYS=3`) grace** 후 노출 — grace 중에는 직전 patch를 effective로 서빙(`PatchVersionService:20`, 초반 표본 부족 회피). effective patch는 **매일** 재집계(cron). |
+| NFR-2 | **읽기 가용성** | 공개 REST API uptime **≥ 99%**. 집계 지연 중에도 직전 patch 데이터는 계속 서빙. |
+| NFR-3 | **파이프라인 liveness** | 수집/집계가 진행 중임을 heartbeat로 관측. "진행 멈춤"(throughput=0 지속)을 알람. |
+| NFR-4 | **에러율 / rate-limit 준수** | 지속 429 = 0(예산 하한 90% 운영). 개별 ingest 실패는 1회 시도 후 skip + `ingest_failure_total{reason}` 기록(전용 재시도 머신 없음 — 재수집 + 10-참가자 redundancy가 자연 재시도). **시스템 실패(auth/대량 5xx)는 조용히 흡수 금지** — 실패율 급증 알람 + auth halt. |
+| NFR-5 | **재시작 안전** | 서버 재시작/재배포 후 데이터 손실 0, 자동 재개. 재시작 비용은 in-flight 작업 단위로 bounded(전체 부하와 무관). 크래시 중간 상태가 중복·누락을 만들지 않는다. |
+| NFR-6 | **디스크 제약 (바인딩)** | DB 크기 `< 임계`(현재 Hobby 5GB의 80% 룰, `bestduo_db_size_bytes/5e9 > 0.8` Grafana 알림). 무한 증가하는 테이블이 없어야 한다. |
+| NFR-7 | **보존(retention) — 적응적** | 고정 정책이 아니라 **디스크 여유를 보며 운영자가 조정**한다(Q3). stat은 최신 N patch, raw payload는 archive 후 삭제(최신 patch 보호)를 기본 가이드로 하되, NFR-6 임계를 1차 기준으로 유연 조정. |
+| NFR-8 | **관측성(observability)** | 처리율·에러분류·in-flight·pending·신선도·디스크를 Micrometer→Prometheus/Grafana로 노출. 상태-테이블 스캔이 아닌 event-emitted 메트릭을 지향(디스크 비용 회피). |
+
+---
+
+## 6. 제약 (Constraints)
+
+- **C-1. 단일 Riot API key**: 현재 dev 키. 처리량 천장이 키당 고정 → 멀티 워커 수평 확장은 예산을 늘리지 못함.
+  - 향후 prod 키: `500 req/10s`, `30,000 req/10min` = **50 req/s 지속**. 단일 프로세스 + 동시 10~25로 포화([ADR-008 §8](./adr_remove_match_queue_inline_pipeline.md)).
+- **C-2. 인프라**: Railway Hobby(디스크 5GB, 네이티브 볼륨 알림 미제공 → Grafana 임계 룰로 대체).
+- **C-3. Riot ToS / 공식 API only**: 비공식 수집·스크래핑 금지. rate limit 준수 필수.
+- **C-4. 단순성 원칙**: 지금 필요하지 않은 구조(추상화/큐/멀티프로세스)는 만들지 않는다. pressure가 real해질 때 도입.
+
+---
+
+## 7. 범위 외 (Out of scope)
+
+- 바텀 외 라인(탑/정글/미드) 통계.
+- 실시간(분 단위) 통계 — 일일 신선도로 충분.
+- 멀티 리전(현재 단일 regional host).
+- 멀티 머신/멀티 프로세스 수평 확장 — *키 추가로 예산이 실제 N배가 될 때까지* 보류([ADR-008 §9](./adr_remove_match_queue_inline_pipeline.md)).
+
+---
+
+## 8. 미해결 / 확인 필요 (Open questions)
+
+| 항목 | 필요 결정 |
+|---|---|
+| **QR-1 표시 라벨 임계** (serving) | "표본 부족" 라벨을 붙일 게임 수 (stat 셀 ~30 제안, matchup 셀 더 낮게). 파이프라인과 독립. |
+| **QR-4 시스템 실패 알람 임계** | `ingest_failure_total` 급증 알람 발화 기준(NFR-4). |
+
+> 해소됨: NFR-1 신선도(grace 3일+일일), NFR-2 uptime(99%), 저표본 노출 방식("숨김" 아님 → 표본 노출+라벨, QR-1), 실패 재시도(전용 머신 없음 — NFR-4).
+
+---
+
+## 9. 참고
+
+- [ADR-008](./adr_remove_match_queue_inline_pipeline.md) — 파이프라인 구조 결정(이 요구사항을 만족하는 구조 선택)
+- [ADR-006](./adr_aggregate_from_match_payload.md) — payload 기반 재집계(FR-5)
+- [pipeline_implementation_map.md](./pipeline_implementation_map.md) — 현재 구현 맵
+- [incident_postgres_disk_full_recovery_mode.md](./incident_postgres_disk_full_recovery_mode.md) — NFR-6 디스크 제약의 근거

--- a/src/main/java/com/bestduo_BE/common/infra/persistence/repository/SummonerJpaRepository.java
+++ b/src/main/java/com/bestduo_BE/common/infra/persistence/repository/SummonerJpaRepository.java
@@ -88,6 +88,15 @@ public interface SummonerJpaRepository extends JpaRepository<Summoner, String> {
       """, nativeQuery = true)
   List<Summoner> findMatchIdsPendingSummoners(@Param("limit") int limit);
 
+  /** matchIds 수집 대기 중인 summoner 수 (collect_pending_summoners gauge 용). */
+  @Query(value = """
+      SELECT count(*)
+      FROM summoner s
+      WHERE s.seeded_at IS NOT NULL
+        AND (s.match_ids_collected_at IS NULL OR s.match_ids_collected_at < s.seeded_at)
+      """, nativeQuery = true)
+  long countMatchIdsPendingSummoners();
+
   @Transactional
   @Modifying(clearAutomatically = true, flushAutomatically = true)
   @Query(value = """

--- a/src/main/java/com/bestduo_BE/pipeline/application/PendingSummonersGaugeRegistrar.java
+++ b/src/main/java/com/bestduo_BE/pipeline/application/PendingSummonersGaugeRegistrar.java
@@ -1,0 +1,29 @@
+package com.bestduo_BE.pipeline.application;
+
+import com.bestduo_BE.common.infra.persistence.repository.SummonerJpaRepository;
+import jakarta.annotation.PostConstruct;
+import org.springframework.stereotype.Component;
+
+/**
+ * {@code pipeline.collect.pending_summoners} gauge 등록.
+ * matchIds 수집 대기 중인 summoner 수를 노출해 "수집 백로그"를 관측한다
+ * (match_queue 제거 후 큐-깊이 지표를 대체).
+ */
+@Component
+public class PendingSummonersGaugeRegistrar {
+
+  private final PipelineMetrics pipelineMetrics;
+  private final SummonerJpaRepository summonerRepository;
+
+  public PendingSummonersGaugeRegistrar(
+      PipelineMetrics pipelineMetrics, SummonerJpaRepository summonerRepository) {
+    this.pipelineMetrics = pipelineMetrics;
+    this.summonerRepository = summonerRepository;
+  }
+
+  @PostConstruct
+  public void register() {
+    pipelineMetrics.registerPendingSummonersGauge(
+        summonerRepository::countMatchIdsPendingSummoners);
+  }
+}

--- a/src/main/java/com/bestduo_BE/pipeline/application/PipelineMetrics.java
+++ b/src/main/java/com/bestduo_BE/pipeline/application/PipelineMetrics.java
@@ -2,6 +2,8 @@ package com.bestduo_BE.pipeline.application;
 
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
+import java.time.Instant;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
 import org.springframework.stereotype.Component;
 
@@ -11,11 +13,19 @@ public class PipelineMetrics {
   private static final String STAGE_COMPLETED = "pipeline.stage.completed";
   private static final String MATCH_QUEUE_SIZE = "pipeline.match_queue.size";
   private static final String COLLECT_MATCHES_ENQUEUED = "pipeline.collect.matches_enqueued";
+  private static final String INGEST_SUCCESS = "pipeline.ingest.success";
+  private static final String INGEST_FAILURE = "pipeline.ingest.failure";
+  private static final String PENDING_SUMMONERS = "pipeline.collect.pending_summoners";
+  private static final String HEARTBEAT = "pipeline.heartbeat";
 
   private final MeterRegistry registry;
+  private final AtomicLong lastHeartbeatEpochSeconds = new AtomicLong(0L);
 
   public PipelineMetrics(MeterRegistry registry) {
     this.registry = registry;
+    Gauge.builder(HEARTBEAT, lastHeartbeatEpochSeconds, AtomicLong::doubleValue)
+        .strongReference(true)
+        .register(registry);
   }
 
   public void recordStageCompleted(int stage, String outcome) {
@@ -39,5 +49,29 @@ public class PipelineMetrics {
     Gauge.builder(MATCH_QUEUE_SIZE, sizeSupplier, s -> s.get().doubleValue())
         .strongReference(true)
         .register(registry);
+  }
+
+  /**
+   * Stage 3 한 배치의 ingest 결과(성공/실패 매치 수)를 기록한다.
+   * 큐 제거(ADR-008) 후 inline 경로에서도 동일 메트릭을 재사용해 parity 를 유지한다.
+   */
+  public void recordIngestOutcome(int success, int failure) {
+    if (success > 0) {
+      registry.counter(INGEST_SUCCESS).increment(success);
+    }
+    if (failure > 0) {
+      registry.counter(INGEST_FAILURE).increment(failure);
+    }
+  }
+
+  public void registerPendingSummonersGauge(Supplier<Number> countSupplier) {
+    Gauge.builder(PENDING_SUMMONERS, countSupplier, s -> s.get().doubleValue())
+        .strongReference(true)
+        .register(registry);
+  }
+
+  /** 파이프라인 루프가 살아있음을 표시한다. 알람: {@code time() - pipeline_heartbeat > 임계}. */
+  public void recordHeartbeat() {
+    lastHeartbeatEpochSeconds.set(Instant.now().getEpochSecond());
   }
 }

--- a/src/main/java/com/bestduo_BE/pipeline/application/RegionalPipelineRunner.java
+++ b/src/main/java/com/bestduo_BE/pipeline/application/RegionalPipelineRunner.java
@@ -73,6 +73,7 @@ public class RegionalPipelineRunner {
     log.info("RegionalPipelineRunner 시작 (가상 스레드)");
     while (!Thread.currentThread().isInterrupted()) {
       try {
+        pipelineMetrics.recordHeartbeat();
         executeTick();
       } catch (RiotRateLimitedException e) {
         log.warn("[regional] 429 Rate limited. {}ms 대기 후 재시도", RATE_LIMIT_SLEEP_MS);
@@ -115,6 +116,7 @@ public class RegionalPipelineRunner {
     try {
       result = runStage3WithTierRoundRobin(priorityTier, effectivePatch);
       pipelineMetrics.recordStageCompleted(3, "success");
+      pipelineMetrics.recordIngestOutcome(result.done(), result.error());
     } catch (RuntimeException e) {
       pipelineMetrics.recordStageCompleted(3, "error");
       throw e;

--- a/src/test/java/com/bestduo_BE/pipeline/application/PipelineMetricsTest.java
+++ b/src/test/java/com/bestduo_BE/pipeline/application/PipelineMetricsTest.java
@@ -110,4 +110,60 @@ class PipelineMetricsTest {
       attempts++;
     }
   }
+
+  @Test
+  @DisplayName("recordIngestOutcome는 success/failure 매치 수만큼 각 counter를 증가시킨다")
+  void recordIngestOutcome_incrementsSuccessAndFailureCounters() {
+    SimpleMeterRegistry registry = new SimpleMeterRegistry();
+    PipelineMetrics metrics = new PipelineMetrics(registry);
+
+    metrics.recordIngestOutcome(7, 2);
+
+    assertThat(registry.counter("pipeline.ingest.success").count()).isEqualTo(7.0);
+    assertThat(registry.counter("pipeline.ingest.failure").count()).isEqualTo(2.0);
+  }
+
+  @Test
+  @DisplayName("recordIngestOutcome에 0을 전달하면 해당 counter를 생성/증가시키지 않는다")
+  void recordIngestOutcome_zeroDoesNotIncrement() {
+    SimpleMeterRegistry registry = new SimpleMeterRegistry();
+    PipelineMetrics metrics = new PipelineMetrics(registry);
+
+    metrics.recordIngestOutcome(0, 0);
+
+    assertThat(registry.find("pipeline.ingest.success").counter()).isNull();
+    assertThat(registry.find("pipeline.ingest.failure").counter()).isNull();
+  }
+
+  @Test
+  @DisplayName("recordHeartbeat 호출 시 pipeline.heartbeat 게이지가 현재 epoch second로 갱신된다")
+  void recordHeartbeat_updatesHeartbeatGauge() {
+    SimpleMeterRegistry registry = new SimpleMeterRegistry();
+    PipelineMetrics metrics = new PipelineMetrics(registry);
+
+    Gauge gauge = registry.find("pipeline.heartbeat").gauge();
+    assertThat(gauge).isNotNull();
+    assertThat(gauge.value()).isEqualTo(0.0);
+
+    metrics.recordHeartbeat();
+
+    assertThat(gauge.value()).isGreaterThan(0.0);
+  }
+
+  @Test
+  @DisplayName("registerPendingSummonersGauge는 pipeline.collect.pending_summoners 게이지를 supplier 값으로 노출한다")
+  void registerPendingSummonersGauge_reflectsSupplierValue() {
+    SimpleMeterRegistry registry = new SimpleMeterRegistry();
+    PipelineMetrics metrics = new PipelineMetrics(registry);
+    AtomicLong pending = new AtomicLong(5L);
+
+    metrics.registerPendingSummonersGauge(pending::get);
+
+    Gauge gauge = registry.find("pipeline.collect.pending_summoners").gauge();
+    assertThat(gauge).isNotNull();
+    assertThat(gauge.value()).isEqualTo(5.0);
+
+    pending.set(12L);
+    assertThat(gauge.value()).isEqualTo(12.0);
+  }
 }


### PR DESCRIPTION
## 개요

`match_queue` 영속 큐 제거 → **inline 파이프라인 전환**의 첫 단계입니다. 이 PR은 **설계 문서**와 **Phase A(관측 메트릭 선이전)**만 포함하며, 큐 제거/inline 융합은 후속 PR(Phase B/C)에서 진행합니다.

## 왜 큐를 제거하나 (요약 — 상세는 ADR-008)

- prod 키 = `500/10s`·`30,000/10min` = **50 req/s 지속**. 단일 프로세스 + 동시 10~25로 포화 → **멀티 프로세스 불요**. rate limit은 키당 공유라 프로세스를 늘려도 throughput 불변.
- DB 큐의 유일한 명분(프로세스 간 분배)이 사라짐. dedup·재시작 영속·관측은 각각 `match` 테이블·`summoner` 플래그·emit 메트릭으로 대체.
- 유지 비용: `match_queue` DONE 행 무한 증가(디스크 제약과 충돌) + dead 컬럼.

## 변경 사항

### 📄 설계 문서 (`8520234`)
- `adr_remove_match_queue_inline_pipeline.md` (ADR-008): 큐 제거 결정 + 실패 처리 옵션 A + 파이프라인 구조 trade-off
- `pipeline_requirements.md`: 품질(셀당 표본)·SLO(uptime 99%/grace 3일)·제약
- `pipeline_inline_migration_plan.md`: Phase A/B/C 마이그레이션 계획
- `pipeline_implementation_map.md`: 현재 구현 맵

### 🔭 Phase A — 관측 메트릭 (`8f6b5a3`)
큐를 떼기 전에 관측 표면을 emit 메트릭으로 **선이전**(parity 검증용). 순환의존 회피를 위해 `pipeline` 컨텍스트에서만 배선(ingest 무수정).
- `pipeline.ingest.success` / `pipeline.ingest.failure` (Counter) — `RegionalPipelineRunner`가 `Result.done/error`로 emit
- `pipeline.heartbeat` (Gauge) — 루프 liveness
- `pipeline.collect.pending_summoners` (Gauge) — 수집 백로그(큐-깊이 대체)
- `reason` 분류·`latency`·auth-halt는 Phase B(inline 에러 처리)로 연기

## 테스트
- `PipelineMetricsTest`에 ingest outcome / heartbeat / pending gauge 검증 4개 추가
- `./gradlew compileJava test` + pipeline 전체 테스트 **green**

## 다음 단계 (게이트)
배포 후 Grafana에서 `pipeline_ingest_success` ≈ `IngestQueueStats.doneLast10m`, `pipeline_ingest_failure` ≈ 큐 ERROR 증가분 **parity 확인 → 통과 시 Phase B**(inline 전환 + 옵션 A) 착수.
