### PR TITLE
fix: Gradle wrapper 다운로드 타임아웃 10s→60s (빌드 이미지 실패 해결)

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,7 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-9.2.1-bin.zip
-networkTimeout=10000
+networkTimeout=60000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
## 문제

Railway 배포에서 **"Failed to build an image"** 로 빌드 실패. 원인은 코드가 아니라 **Gradle wrapper의 배포본 다운로드 타임아웃**:

> 클린 빌드 환경에서 `gradle-9.2.1-bin.zip` 을 `services.gradle.org` 에서 받는 도중 **10초 networkTimeout** 으로 실패.

- 로컬은 gradle 배포본이 캐시돼 있어 영향 없음 → `./gradlew build` 풀빌드는 통과(코드 무관 확정).
- **재발성**: 5/23에도 동일 실패. 빌드 환경 네트워크에 10초는 너무 빠듯함.

## 변경

`gradle/wrapper/gradle-wrapper.properties`:
```
- networkTimeout=10000
+ networkTimeout=60000
```

최소 수정(1줄). `validateDistributionUrl=true` 유지 — 60초 안에 다운로드되면 무결성 검증도 정상.

## 검증
- wrapper 정상 파싱 확인(`./gradlew --version` → Gradle 9.2.1)
- 머지 후 재배포 시 이미지 빌드 통과 기대
