### PR TITLE
refactor: Stage 2→3 inline 융합 — match_queue enqueue 제거 (Phase B)

### DIFF
--- a/docs/pipeline_inline_migration_plan.md
+++ b/docs/pipeline_inline_migration_plan.md
@@ -43,7 +43,15 @@
 
 ---
 
-## 3. Phase B — inline 경로 + 조건 ①② (핵심 변경)
+## 3. Phase B — inline 경로 + 조건 ①② (핵심 변경) — ✅ 코드 구현 완료
+
+> 구현 요약: `CollectMatchIdsRunner`가 `MatchQueueEnqueuer` 대신 `match.existsById` dedup 후 `IngestMatchDetail`로 inline ingest. 조건①(`hasPending`/`runBatch`에서 patch context 없으면 수집 안 함), 조건②(ingest 후 `markMatchIdsCollected`). 실패=옵션 A(`recordIngestFailure(reason)` + skip). `RegionalPipelineRunner`는 Stage 3/round-robin 제거 후 collect+ingest 단일 단계. tier 우선순위는 `findMatchIdsPendingSummoners` ORDER BY tier로 이전.
+> 메트릭: `recordIngestOutcome`(batch) → `recordIngestSuccess()`/`recordIngestFailure(reason)`(매치 단위). `pipeline.ingest.success` 시리즈 연속.
+> 테스트: CollectMatchIdsRunnerTest 15 · RegionalPipelineRunnerTest 3 · PipelineMetricsTest 9 green, 전체 `./gradlew build` green.
+> **남은 정리(Phase C)**: `MatchQueueEnqueuer`/큐 기반 `MatchIngestRunner`/dispatcher가 이제 dead(호출처 없음, IngestController만 MatchIngestRunner 잔존) → Phase C에서 제거. `stage3PriorityTier` config도 미사용.
+> **연기**: auth-halt 동작은 미구현 — `ingest_failure{reason=auth}` 메트릭으로 *탐지/알람*은 가능, 자동 halt는 실제 auth 에러 발생 시 별도 설계.
+
+**변경 (surgical)**
 
 **변경 (surgical)**
 - `CollectMatchIdsRunner`:

--- a/src/main/java/com/bestduo_BE/common/infra/persistence/repository/SummonerJpaRepository.java
+++ b/src/main/java/com/bestduo_BE/common/infra/persistence/repository/SummonerJpaRepository.java
@@ -83,7 +83,16 @@ public interface SummonerJpaRepository extends JpaRepository<Summoner, String> {
       FROM summoner s
       WHERE s.seeded_at IS NOT NULL
         AND (s.match_ids_collected_at IS NULL OR s.match_ids_collected_at < s.seeded_at)
-      ORDER BY s.seeded_at DESC
+      ORDER BY
+        CASE s.last_known_tier
+          WHEN 'CHALLENGER'  THEN 0
+          WHEN 'GRANDMASTER' THEN 1
+          WHEN 'MASTER'      THEN 2
+          WHEN 'DIAMOND'     THEN 3
+          WHEN 'EMERALD'     THEN 4
+          ELSE 5
+        END,
+        s.seeded_at DESC
       LIMIT :limit
       """, nativeQuery = true)
   List<Summoner> findMatchIdsPendingSummoners(@Param("limit") int limit);

--- a/src/main/java/com/bestduo_BE/pipeline/application/CollectMatchIdsRunner.java
+++ b/src/main/java/com/bestduo_BE/pipeline/application/CollectMatchIdsRunner.java
@@ -2,30 +2,39 @@ package com.bestduo_BE.pipeline.application;
 
 import com.bestduo_BE.common.application.PatchVersionService;
 import com.bestduo_BE.common.application.port.RiotApiPort;
-import com.bestduo_BE.common.infra.persistence.MatchQueueEnqueuer;
 import com.bestduo_BE.common.domain.model.EffectivePatchContext;
 import com.bestduo_BE.common.domain.model.Tier;
 import com.bestduo_BE.common.infra.persistence.entity.Summoner;
+import com.bestduo_BE.common.infra.persistence.repository.MatchJpaRepository;
 import com.bestduo_BE.common.infra.persistence.repository.SummonerJpaRepository;
 import com.bestduo_BE.common.infra.riot.budget.DailyBudgetTracker;
+import com.bestduo_BE.common.infra.riot.exception.RiotApiException;
 import com.bestduo_BE.common.infra.riot.exception.RiotRateLimitedException;
 import com.bestduo_BE.config.PipelineProperties;
+import com.bestduo_BE.ingest.application.IngestMatchDetail;
 import java.time.OffsetDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.HttpServerErrorException;
+import org.springframework.web.client.ResourceAccessException;
 
 /**
- * Stage 2 — summoner → match_queue.
+ * Stage 2 — summoner → match 상세를 inline 으로 수집·저장한다 (ADR-008).
  *
- * <p>seeded_at이 있고 match_ids_collected_at이 null이거나 seeded_at 이전인 summoner를
- * seeded_at 최신 순으로 조회해 matchIds를 수집하고 match_queue에 enqueue한다.
+ * <p>summoner 별로 matchIds 를 가져와 그 자리에서 {@link IngestMatchDetail} 로 ingest 한다.
+ * 별도 영속 큐(match_queue) 없이 {@code match} 테이블 {@code existsById} 로 dedup 한다.
  *
  * <ul>
  *   <li>CHALLENGER / GRANDMASTER / MASTER: {@code apexTiers} matchIds 수집</li>
  *   <li>그 외: {@code diamondEmerald} matchIds 수집</li>
  * </ul>
+ *
+ * <p>재시작 안전(ADR-008 §6): patch context 가 있을 때만 수집하고(조건①),
+ * summoner 의 모든 매치를 ingest 한 뒤 {@code markMatchIdsCollected} 한다(조건②).
+ * 개별 ingest 실패는 1회 시도 후 metric 기록 + skip 한다(옵션 A) — 재수집/참가자 redundancy 가 재시도를 대신한다.
  */
 @Component
 @RequiredArgsConstructor
@@ -34,7 +43,8 @@ public class CollectMatchIdsRunner {
 
   private final SummonerJpaRepository summonerRepository;
   private final RiotApiPort riotApiPort;
-  private final MatchQueueEnqueuer matchQueueEnqueuer;
+  private final MatchJpaRepository matchRepository;
+  private final IngestMatchDetail ingestMatchDetail;
   private final PatchVersionService patchVersionService;
   private final DailyBudgetTracker budgetTracker;
   private final PipelineProperties props;
@@ -43,19 +53,22 @@ public class CollectMatchIdsRunner {
   // ── public API ──────────────────────────────────────────────────────────
 
   /**
-   * matchIds 수집 대기 중인 summoner가 있으면 true.
-   * 예산 소진 시 항상 false.
+   * 수집 대기 중인 summoner 가 있으면 true.
+   * 예산 소진(canCollect=false) 또는 patch context 부재 시 항상 false(조건①).
    */
   public boolean hasPending() {
     if (!budgetTracker.canCollect()) {
+      return false;
+    }
+    if (patchVersionService.resolveEffectivePatchContext().isEmpty()) {
       return false;
     }
     return !summonerRepository.findMatchIdsPendingSummoners(1).isEmpty();
   }
 
   /**
-   * 한 배치를 처리한다.
-   * summoner를 {@code collectBatchSize}개 조회해 각각 matchIds를 수집하고 enqueue한다.
+   * 한 배치를 처리한다. summoner 를 {@code collectBatchSize} 개 조회해
+   * 각각 matchIds 를 수집하고 그 자리에서 inline ingest 한다.
    *
    * @return 배치 결과
    */
@@ -64,64 +77,78 @@ public class CollectMatchIdsRunner {
       return BatchResult.budgetExhausted();
     }
 
+    EffectivePatchContext ctx = patchVersionService.resolveEffectivePatchContext().orElse(null);
+    if (ctx == null) {
+      // 조건①: patch context 가 없으면 수집하지 않는다(재시작 시 재수집 재현성 보장).
+      return BatchResult.noPending();
+    }
+
     List<Summoner> summoners =
         summonerRepository.findMatchIdsPendingSummoners(props.getCollectBatchSize());
     if (summoners.isEmpty()) {
       return BatchResult.noPending();
     }
 
-    EffectivePatchContext ctx = patchVersionService.resolveEffectivePatchContext().orElse(null);
-
     int apiCalls = 0;
-    int matchIdsQueued = 0;
+    int matchIdsFound = 0;
 
     for (Summoner summoner : summoners) {
       if (!budgetTracker.canCollect()) {
         break;
       }
       try {
-        int queued = collectForSummoner(summoner, ctx);
-        matchIdsQueued += queued;
-        pipelineMetrics.recordMatchesEnqueued(queued);
+        int found = collectAndIngestForSummoner(summoner, ctx);
+        matchIdsFound += found;
+        pipelineMetrics.recordMatchesEnqueued(found);
+        // 조건②: 모든 매치 ingest 후 collected 표시 → 중간 크래시 시 통째 재처리.
         summonerRepository.markMatchIdsCollected(summoner.getPuuid(), OffsetDateTime.now());
         budgetTracker.recordCollectCall(1);
         apiCalls++;
       } catch (RiotRateLimitedException e) {
         throw e;
       } catch (Exception e) {
-        // 실패 시 예산 미차감 — summoner를 재시도 대상으로 남긴다.
+        // 수집(matchIds 조회) 실패 시 예산 미차감 — summoner 를 재시도 대상으로 남긴다.
         log.warn("matchIds 수집 실패, 예산 미차감 (재시도 예정): puuid={}", summoner.getPuuid(), e);
       }
     }
 
-    log.info("Stage2 배치 완료: summoners={} apiCalls={} matchIdsQueued={}",
-        summoners.size(), apiCalls, matchIdsQueued);
-    return new BatchResult(BatchResult.Type.OK, apiCalls, matchIdsQueued);
+    log.info("Stage2 배치 완료: summoners={} apiCalls={} matchIdsFound={}",
+        summoners.size(), apiCalls, matchIdsFound);
+    return new BatchResult(BatchResult.Type.OK, apiCalls, matchIdsFound);
   }
 
   // ── private helpers ─────────────────────────────────────────────────────
 
-  private int collectForSummoner(Summoner summoner, EffectivePatchContext ctx) {
+  private int collectAndIngestForSummoner(Summoner summoner, EffectivePatchContext ctx) {
     int matchCount = matchCountFor(summoner.getLastKnownTier());
 
-    List<String> matchIds;
-    if (ctx == null) {
-      matchIds = riotApiPort.findRecentMatchIds(summoner.getPuuid(), matchCount);
-    } else if (ctx.isInGracePeriod()) {
-      matchIds = riotApiPort.findMatchIdsBetween(
-          summoner.getPuuid(), ctx.startTimeEpochSeconds(), ctx.endTimeEpochSeconds(), matchCount);
-    } else {
-      matchIds = riotApiPort.findMatchIdsSince(
-          summoner.getPuuid(), ctx.startTimeEpochSeconds(), matchCount);
-    }
+    List<String> matchIds = ctx.isInGracePeriod()
+        ? riotApiPort.findMatchIdsBetween(
+            summoner.getPuuid(), ctx.startTimeEpochSeconds(), ctx.endTimeEpochSeconds(), matchCount)
+        : riotApiPort.findMatchIdsSince(
+            summoner.getPuuid(), ctx.startTimeEpochSeconds(), matchCount);
 
     if (matchIds == null || matchIds.isEmpty()) {
       return 0;
     }
 
-    String patch = ctx != null ? ctx.patch() : null;
     Tier tier = summoner.getLastKnownTier();
-    matchQueueEnqueuer.enqueueAllIdempotent(matchIds, tier, patch);
+    String patch = ctx.patch();
+    for (String matchId : matchIds) {
+      if (matchRepository.existsById(matchId)) {
+        continue; // dedup — 이미 수집된 매치는 API 호출 없이 skip
+      }
+      try {
+        ingestMatchDetail.execute(matchId, tier, patch);
+        pipelineMetrics.recordIngestSuccess();
+      } catch (RiotRateLimitedException e) {
+        throw e; // 429 → 상위 루프 backoff
+      } catch (Exception e) {
+        // 옵션 A: 1회 시도 후 metric + skip. 재수집/참가자 redundancy 가 재시도를 대신한다.
+        pipelineMetrics.recordIngestFailure(classifyIngestFailure(e));
+        log.error("ingest 실패 — skip (matchId={})", matchId, e);
+      }
+    }
     return matchIds.size();
   }
 
@@ -130,6 +157,28 @@ public class CollectMatchIdsRunner {
       return props.getTierMatchCount().getApexTiers();
     }
     return props.getTierMatchCount().getDiamondEmerald();
+  }
+
+  /** ingest 실패 예외를 저-cardinality reason 태그로 분류한다(NFR-4 alert: auth/server_5xx 식별). */
+  private static String classifyIngestFailure(Exception e) {
+    Throwable cause = (e instanceof RiotApiException && e.getCause() != null) ? e.getCause() : e;
+    if (cause instanceof HttpClientErrorException he) {
+      int status = he.getStatusCode().value();
+      if (status == 401 || status == 403) {
+        return "auth";
+      }
+      if (status == 404) {
+        return "not_found";
+      }
+      return "client_4xx";
+    }
+    if (cause instanceof HttpServerErrorException) {
+      return "server_5xx";
+    }
+    if (cause instanceof ResourceAccessException) {
+      return "timeout";
+    }
+    return "other";
   }
 
   // ── Result types ────────────────────────────────────────────────────────

--- a/src/main/java/com/bestduo_BE/pipeline/application/PipelineMetrics.java
+++ b/src/main/java/com/bestduo_BE/pipeline/application/PipelineMetrics.java
@@ -51,17 +51,17 @@ public class PipelineMetrics {
         .register(registry);
   }
 
+  /** 매치 1건 ingest 성공. (Phase A 의 batch counter 와 동일 {@code pipeline.ingest.success} 시리즈 — 연속성 유지.) */
+  public void recordIngestSuccess() {
+    registry.counter(INGEST_SUCCESS).increment();
+  }
+
   /**
-   * Stage 3 한 배치의 ingest 결과(성공/실패 매치 수)를 기록한다.
-   * 큐 제거(ADR-008) 후 inline 경로에서도 동일 메트릭을 재사용해 parity 를 유지한다.
+   * 매치 1건 ingest 실패. reason 은 저-cardinality 분류(auth/server_5xx/timeout/not_found/client_4xx/other).
+   * NFR-4: reason=auth/server_5xx 급증을 시스템 실패 알람으로 사용.
    */
-  public void recordIngestOutcome(int success, int failure) {
-    if (success > 0) {
-      registry.counter(INGEST_SUCCESS).increment(success);
-    }
-    if (failure > 0) {
-      registry.counter(INGEST_FAILURE).increment(failure);
-    }
+  public void recordIngestFailure(String reason) {
+    registry.counter(INGEST_FAILURE, "reason", reason).increment();
   }
 
   public void registerPendingSummonersGauge(Supplier<Number> countSupplier) {

--- a/src/main/java/com/bestduo_BE/pipeline/application/RegionalPipelineRunner.java
+++ b/src/main/java/com/bestduo_BE/pipeline/application/RegionalPipelineRunner.java
@@ -1,16 +1,9 @@
 package com.bestduo_BE.pipeline.application;
 
-import com.bestduo_BE.common.application.PatchVersionService;
-import com.bestduo_BE.common.domain.model.EffectivePatchContext;
-import com.bestduo_BE.common.domain.model.Tier;
 import com.bestduo_BE.common.infra.riot.exception.RiotRateLimitedException;
 import com.bestduo_BE.config.PipelineProperties;
-import com.bestduo_BE.ingest.application.MatchIngestRunner;
 import jakarta.annotation.PostConstruct;
 import jakarta.annotation.PreDestroy;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
@@ -19,16 +12,13 @@ import org.springframework.stereotype.Component;
 /**
  * Regional host(asia.api) 전담 파이프라인 루프.
  *
- * <p>Stage 우선순위:
- * <ol>
- *   <li>Stage 2 — {@link CollectMatchIdsRunner}: matchIds 수집 (일일 예산 내)</li>
- *   <li>Stage 3 — {@link MatchIngestRunner}: match 상세 수집 (상시, patch+tier 우선순위)</li>
- * </ol>
+ * <p>{@link CollectMatchIdsRunner} 가 summoner 별로 matchIds 를 수집하고 그 자리에서 inline ingest 한다
+ * (ADR-008 — match_queue 제거). 별도 Stage 3(큐 드레인)는 없다.
  *
  * <p>{@link PlatformPipelineRunner}와 독립된 가상 스레드에서 실행되며, ASIA limiter 의
  * 429 가 발생해도 platform 루프는 영향받지 않는다 (host 별 격리).
  *
- * <p>match_queue 가 비어있으면 {@code pollingIntervalMs} sleep.
+ * <p>수집 대기 summoner 가 없으면 {@code pollingIntervalMs} sleep.
  * 429 발생 시 {@link #RATE_LIMIT_SLEEP_MS} sleep 후 재시도.
  */
 @Component
@@ -38,11 +28,8 @@ import org.springframework.stereotype.Component;
 public class RegionalPipelineRunner {
 
   private static final long RATE_LIMIT_SLEEP_MS = 60_000L;
-  private static final Tier ROUND_ROBIN_LOWEST_TIER = Tier.EMERALD;
 
   private final CollectMatchIdsRunner collectMatchIdsRunner;
-  private final MatchIngestRunner matchIngestRunner;
-  private final PatchVersionService patchVersionService;
   private final PipelineProperties props;
   private final PipelineMetrics pipelineMetrics;
 
@@ -90,11 +77,10 @@ public class RegionalPipelineRunner {
     }
   }
 
-  /** Stage 2 → 3 우선순위 판단 후 한 단위를 실행한다. 테스트에서 직접 호출 가능하도록 package-private. */
+  /** collect+ingest 한 단위를 실행한다. 테스트에서 직접 호출 가능하도록 package-private. */
   void executeTick() throws InterruptedException {
-    // Stage 2: CollectMatchIds (일일 예산 내)
     if (collectMatchIdsRunner.hasPending()) {
-      log.debug("Stage 2 실행");
+      log.debug("Collect+Ingest 실행");
       try {
         collectMatchIdsRunner.runBatch();
         pipelineMetrics.recordStageCompleted(2, "success");
@@ -105,69 +91,8 @@ public class RegionalPipelineRunner {
       return;
     }
 
-    // Stage 3: Ingest (상시, patch+tier 우선순위)
-    // Stage 2가 유효 패치 기준으로 match ID를 수집하므로, Stage 3도 같은 기준을 사용해야 우선순위가 일치한다.
-    String effectivePatch = patchVersionService.resolveEffectivePatchContext()
-        .map(EffectivePatchContext::patch)
-        .orElse(null);
-    Tier priorityTier = props.getStage3PriorityTier();
-    log.debug("Stage 3 실행 (effectivePatch={}, priorityTier={})", effectivePatch, priorityTier);
-    MatchIngestRunner.Result result;
-    try {
-      result = runStage3WithTierRoundRobin(priorityTier, effectivePatch);
-      pipelineMetrics.recordStageCompleted(3, "success");
-      pipelineMetrics.recordIngestOutcome(result.done(), result.error());
-    } catch (RuntimeException e) {
-      pipelineMetrics.recordStageCompleted(3, "error");
-      throw e;
-    }
-
-    if (result.picked() == 0) {
-      log.debug("match_queue 비어있음. {}ms 대기", props.getPollingIntervalMs());
-      Thread.sleep(props.getPollingIntervalMs());
-    }
-  }
-
-  /**
-   * priorityTier가 지정되지 않으면(null/ALL_TIERS) tier 필터 없이 한 번 호출한다(레거시 동작).
-   * 지정되면 priority → 나머지 티어 순으로 순회하다가 picked > 0 시점에 멈춘다.
-   * 순회 범위는 CHALLENGER ~ {@link #ROUND_ROBIN_LOWEST_TIER}까지로 제한된다.
-   * 모든 티어가 비면 마지막 Result(picked=0)를 반환해 호출부가 sleep으로 진입하도록 한다.
-   */
-  private MatchIngestRunner.Result runStage3WithTierRoundRobin(
-      Tier priorityTier, String effectivePatch) {
-    int batchSize = props.getIngestBatchSize();
-    if (priorityTier == null || priorityTier == Tier.ALL_TIERS) {
-      return matchIngestRunner.executeWithPriority(batchSize, null, effectivePatch);
-    }
-
-    List<Tier> order = buildTierOrder(priorityTier);
-    MatchIngestRunner.Result result = null;
-    for (Tier t : order) {
-      result = matchIngestRunner.executeWithPriority(batchSize, t, effectivePatch);
-      if (result.picked() > 0) {
-        return result;
-      }
-      log.debug("Stage 3 tier={} 비어있음, 다음 tier로 순회", t);
-    }
-    return result;
-  }
-
-  private static List<Tier> buildTierOrder(Tier priority) {
-    List<Tier> allowed = Arrays.stream(Tier.values())
-        .filter(t -> t != Tier.ALL_TIERS)
-        .filter(t -> t.ordinal() <= ROUND_ROBIN_LOWEST_TIER.ordinal())
-        .toList();
-    List<Tier> ordered = new ArrayList<>(allowed.size() + 1);
-    if (allowed.contains(priority)) {
-      ordered.add(priority);
-    }
-    for (Tier t : allowed) {
-      if (t != priority) {
-        ordered.add(t);
-      }
-    }
-    return ordered;
+    log.debug("수집 대기 summoner 없음. {}ms 대기", props.getPollingIntervalMs());
+    Thread.sleep(props.getPollingIntervalMs());
   }
 
   private void sleep(long ms) {

--- a/src/test/java/com/bestduo_BE/pipeline/application/CollectMatchIdsRunnerTest.java
+++ b/src/test/java/com/bestduo_BE/pipeline/application/CollectMatchIdsRunnerTest.java
@@ -18,6 +18,7 @@ import com.bestduo_BE.common.infra.persistence.entity.Summoner;
 import com.bestduo_BE.common.infra.persistence.repository.MatchJpaRepository;
 import com.bestduo_BE.common.infra.persistence.repository.SummonerJpaRepository;
 import com.bestduo_BE.common.infra.riot.budget.DailyBudgetTracker;
+import com.bestduo_BE.common.infra.riot.exception.RiotApiException;
 import com.bestduo_BE.common.infra.riot.exception.RiotRateLimitedException;
 import com.bestduo_BE.config.PipelineProperties;
 import com.bestduo_BE.ingest.application.IngestMatchDetail;
@@ -29,8 +30,14 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.client.HttpClientErrorException;
+import org.springframework.web.client.HttpServerErrorException;
+import org.springframework.web.client.ResourceAccessException;
 
 @ExtendWith(MockitoExtension.class)
 class CollectMatchIdsRunnerTest {
@@ -284,6 +291,59 @@ class CollectMatchIdsRunnerTest {
 
     verify(ingestMatchDetail, never()).execute(any(), any(), any());
     verify(summonerRepository).markMatchIdsCollected(eq("p-empty"), any(OffsetDateTime.class));
+  }
+
+  // ── ingest 실패 분류 (classifyIngestFailure) ──────────────────────────────
+
+  @ParameterizedTest
+  @CsvSource({"401,auth", "403,auth", "404,not_found", "400,client_4xx"})
+  @DisplayName("HttpClientErrorException은 상태코드에 따라 auth/not_found/client_4xx로 분류된다")
+  void runBatch_ingestFailure_classifiesHttpClientError(int status, String expectedReason) {
+    runBatchWithIngestThrowing(new HttpClientErrorException(HttpStatus.valueOf(status)));
+
+    assertThat(registry.counter("pipeline.ingest.failure", "reason", expectedReason).count())
+        .isEqualTo(1.0);
+  }
+
+  @Test
+  @DisplayName("HttpServerErrorException(5xx)은 server_5xx로 분류된다")
+  void runBatch_ingestFailure_classifiesServerErrorAs5xx() {
+    runBatchWithIngestThrowing(new HttpServerErrorException(HttpStatus.INTERNAL_SERVER_ERROR));
+
+    assertThat(registry.counter("pipeline.ingest.failure", "reason", "server_5xx").count())
+        .isEqualTo(1.0);
+  }
+
+  @Test
+  @DisplayName("ResourceAccessException(timeout/IO)은 timeout으로 분류된다")
+  void runBatch_ingestFailure_classifiesResourceAccessAsTimeout() {
+    runBatchWithIngestThrowing(new ResourceAccessException("connection timed out"));
+
+    assertThat(registry.counter("pipeline.ingest.failure", "reason", "timeout").count())
+        .isEqualTo(1.0);
+  }
+
+  @Test
+  @DisplayName("RiotApiException은 원인(cause)을 풀어 분류한다 (401 wrap → auth)")
+  void runBatch_ingestFailure_unwrapsRiotApiExceptionCause() {
+    runBatchWithIngestThrowing(
+        new RiotApiException("load failed", new HttpClientErrorException(HttpStatus.UNAUTHORIZED)));
+
+    assertThat(registry.counter("pipeline.ingest.failure", "reason", "auth").count())
+        .isEqualTo(1.0);
+  }
+
+  /** 단일 summoner·단일 매치에서 ingest 가 주어진 예외를 던지도록 세팅 후 runBatch 실행. */
+  private void runBatchWithIngestThrowing(Throwable ingestException) {
+    Summoner summoner = summonerWithTier("p-dia", Tier.DIAMOND);
+    given(budgetTracker.canCollect()).willReturn(true);
+    given(patchVersionService.resolveEffectivePatchContext()).willReturn(Optional.of(normalCtx()));
+    given(summonerRepository.findMatchIdsPendingSummoners(props.getCollectBatchSize()))
+        .willReturn(List.of(summoner));
+    given(riotApiPort.findMatchIdsSince("p-dia", 1700000000L, 10)).willReturn(List.of("m1"));
+    given(ingestMatchDetail.execute("m1", Tier.DIAMOND, "15.23")).willThrow(ingestException);
+
+    runner.runBatch();
   }
 
   // ── helpers ─────────────────────────────────────────────────────────────

--- a/src/test/java/com/bestduo_BE/pipeline/application/CollectMatchIdsRunnerTest.java
+++ b/src/test/java/com/bestduo_BE/pipeline/application/CollectMatchIdsRunnerTest.java
@@ -12,14 +12,15 @@ import static org.mockito.Mockito.verify;
 
 import com.bestduo_BE.common.application.PatchVersionService;
 import com.bestduo_BE.common.application.port.RiotApiPort;
-import com.bestduo_BE.common.infra.persistence.MatchQueueEnqueuer;
 import com.bestduo_BE.common.domain.model.EffectivePatchContext;
 import com.bestduo_BE.common.domain.model.Tier;
 import com.bestduo_BE.common.infra.persistence.entity.Summoner;
+import com.bestduo_BE.common.infra.persistence.repository.MatchJpaRepository;
 import com.bestduo_BE.common.infra.persistence.repository.SummonerJpaRepository;
 import com.bestduo_BE.common.infra.riot.budget.DailyBudgetTracker;
 import com.bestduo_BE.common.infra.riot.exception.RiotRateLimitedException;
 import com.bestduo_BE.config.PipelineProperties;
+import com.bestduo_BE.ingest.application.IngestMatchDetail;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 import java.time.OffsetDateTime;
 import java.util.List;
@@ -34,22 +35,15 @@ import org.mockito.junit.jupiter.MockitoExtension;
 @ExtendWith(MockitoExtension.class)
 class CollectMatchIdsRunnerTest {
 
-  @Mock
-  private SummonerJpaRepository summonerRepository;
-
-  @Mock
-  private RiotApiPort riotApiPort;
-
-  @Mock
-  private MatchQueueEnqueuer matchQueueEnqueuer;
-
-  @Mock
-  private PatchVersionService patchVersionService;
-
-  @Mock
-  private DailyBudgetTracker budgetTracker;
+  @Mock private SummonerJpaRepository summonerRepository;
+  @Mock private RiotApiPort riotApiPort;
+  @Mock private MatchJpaRepository matchRepository;
+  @Mock private IngestMatchDetail ingestMatchDetail;
+  @Mock private PatchVersionService patchVersionService;
+  @Mock private DailyBudgetTracker budgetTracker;
 
   private PipelineProperties props;
+  private SimpleMeterRegistry registry;
   private CollectMatchIdsRunner runner;
 
   @BeforeEach
@@ -60,10 +54,14 @@ class CollectMatchIdsRunnerTest {
     tierMatchCount.setApexTiers(30);
     tierMatchCount.setDiamondEmerald(10);
     props.setTierMatchCount(tierMatchCount);
-    PipelineMetrics pipelineMetrics = new PipelineMetrics(new SimpleMeterRegistry());
+    registry = new SimpleMeterRegistry();
     runner = new CollectMatchIdsRunner(
-        summonerRepository, riotApiPort, matchQueueEnqueuer,
-        patchVersionService, budgetTracker, props, pipelineMetrics);
+        summonerRepository, riotApiPort, matchRepository, ingestMatchDetail,
+        patchVersionService, budgetTracker, props, new PipelineMetrics(registry));
+  }
+
+  private EffectivePatchContext normalCtx() {
+    return new EffectivePatchContext("15.23", 1700000000L, null);
   }
 
   // ── hasPending ──────────────────────────────────────────────────────────
@@ -77,18 +75,29 @@ class CollectMatchIdsRunnerTest {
   }
 
   @Test
+  @DisplayName("patch context가 없으면 hasPending는 false (조건①)")
+  void hasPending_whenNoPatchContext_returnsFalse() {
+    given(budgetTracker.canCollect()).willReturn(true);
+    given(patchVersionService.resolveEffectivePatchContext()).willReturn(Optional.empty());
+
+    assertThat(runner.hasPending()).isFalse();
+  }
+
+  @Test
   @DisplayName("대기 중인 summoner가 없으면 hasPending는 false")
   void hasPending_whenNoSummoners_returnsFalse() {
     given(budgetTracker.canCollect()).willReturn(true);
+    given(patchVersionService.resolveEffectivePatchContext()).willReturn(Optional.of(normalCtx()));
     given(summonerRepository.findMatchIdsPendingSummoners(1)).willReturn(List.of());
 
     assertThat(runner.hasPending()).isFalse();
   }
 
   @Test
-  @DisplayName("대기 중인 summoner가 있으면 hasPending는 true")
-  void hasPending_whenSummonersExist_returnsTrue() {
+  @DisplayName("예산·patch·대기 summoner 모두 있으면 hasPending는 true")
+  void hasPending_whenAllConditionsMet_returnsTrue() {
     given(budgetTracker.canCollect()).willReturn(true);
+    given(patchVersionService.resolveEffectivePatchContext()).willReturn(Optional.of(normalCtx()));
     given(summonerRepository.findMatchIdsPendingSummoners(1))
         .willReturn(List.of(summonerWithTier("p1", Tier.DIAMOND)));
 
@@ -109,9 +118,23 @@ class CollectMatchIdsRunnerTest {
   }
 
   @Test
+  @DisplayName("patch context가 없으면 runBatch는 수집하지 않고 NO_PENDING 반환 (조건①)")
+  void runBatch_whenNoPatchContext_returnsNoPending() {
+    given(budgetTracker.canCollect()).willReturn(true);
+    given(patchVersionService.resolveEffectivePatchContext()).willReturn(Optional.empty());
+
+    CollectMatchIdsRunner.BatchResult result = runner.runBatch();
+
+    assertThat(result.type()).isEqualTo(CollectMatchIdsRunner.BatchResult.Type.NO_PENDING);
+    verify(summonerRepository, never()).findMatchIdsPendingSummoners(anyInt());
+    verify(riotApiPort, never()).findRecentMatchIds(any(), anyInt());
+  }
+
+  @Test
   @DisplayName("대기 summoner 없으면 NO_PENDING 반환")
   void runBatch_whenNoPending_returnsNoPending() {
     given(budgetTracker.canCollect()).willReturn(true);
+    given(patchVersionService.resolveEffectivePatchContext()).willReturn(Optional.of(normalCtx()));
     given(summonerRepository.findMatchIdsPendingSummoners(props.getCollectBatchSize()))
         .willReturn(List.of());
 
@@ -121,35 +144,35 @@ class CollectMatchIdsRunnerTest {
   }
 
   @Test
-  @DisplayName("정상 패치(grace period 아님): DIAMOND tier summoner에게 findMatchIdsSince 호출")
-  void runBatch_normalPatch_usesCorrectMatchCountForDiamond() {
+  @DisplayName("정상 패치: 각 matchId를 inline ingest하고 collectedAt·예산을 갱신한다")
+  void runBatch_normalPatch_ingestsEachMatchAndMarksCollected() {
     Summoner summoner = summonerWithTier("p-dia", Tier.DIAMOND);
-    EffectivePatchContext ctx = new EffectivePatchContext("15.23", 1700000000L, null);
     given(budgetTracker.canCollect()).willReturn(true);
+    given(patchVersionService.resolveEffectivePatchContext()).willReturn(Optional.of(normalCtx()));
     given(summonerRepository.findMatchIdsPendingSummoners(props.getCollectBatchSize()))
         .willReturn(List.of(summoner));
-    given(patchVersionService.resolveEffectivePatchContext()).willReturn(Optional.of(ctx));
     given(riotApiPort.findMatchIdsSince("p-dia", 1700000000L, 10))
         .willReturn(List.of("m1", "m2"));
 
     CollectMatchIdsRunner.BatchResult result = runner.runBatch();
 
-    verify(riotApiPort).findMatchIdsSince("p-dia", 1700000000L, 10);
-    verify(riotApiPort, never()).findMatchIdsBetween(any(), anyLong(), anyLong(), anyInt());
+    verify(ingestMatchDetail).execute("m1", Tier.DIAMOND, "15.23");
+    verify(ingestMatchDetail).execute("m2", Tier.DIAMOND, "15.23");
+    verify(summonerRepository).markMatchIdsCollected(eq("p-dia"), any(OffsetDateTime.class));
+    verify(budgetTracker).recordCollectCall(1);
     assertThat(result.matchIdsQueued()).isEqualTo(2);
+    assertThat(registry.counter("pipeline.ingest.success").count()).isEqualTo(2.0);
   }
 
   @Test
-  @DisplayName("정상 패치(grace period 아님): CHALLENGER tier summoner에게 apexTiers matchCount 적용")
-  void runBatch_normalPatch_usesApexMatchCountForChallenger() {
+  @DisplayName("CHALLENGER tier는 apexTiers matchCount(30)를 사용한다")
+  void runBatch_apexTier_usesApexMatchCount() {
     Summoner summoner = summonerWithTier("p-chall", Tier.CHALLENGER);
-    EffectivePatchContext ctx = new EffectivePatchContext("15.23", 1700000000L, null);
     given(budgetTracker.canCollect()).willReturn(true);
+    given(patchVersionService.resolveEffectivePatchContext()).willReturn(Optional.of(normalCtx()));
     given(summonerRepository.findMatchIdsPendingSummoners(props.getCollectBatchSize()))
         .willReturn(List.of(summoner));
-    given(patchVersionService.resolveEffectivePatchContext()).willReturn(Optional.of(ctx));
-    given(riotApiPort.findMatchIdsSince("p-chall", 1700000000L, 30))
-        .willReturn(List.of("m1", "m2", "m3"));
+    given(riotApiPort.findMatchIdsSince("p-chall", 1700000000L, 30)).willReturn(List.of("m1"));
 
     runner.runBatch();
 
@@ -157,125 +180,89 @@ class CollectMatchIdsRunnerTest {
   }
 
   @Test
-  @DisplayName("grace period 중: findMatchIdsBetween이 endTime과 함께 호출된다")
-  void runBatch_inGracePeriod_callsFindMatchIdsBetweenWithEndTime() {
+  @DisplayName("grace period 중: findMatchIdsBetween으로 수집하고 이전 패치로 ingest한다")
+  void runBatch_inGracePeriod_usesFindMatchIdsBetween() {
     Summoner summoner = summonerWithTier("p-dia", Tier.DIAMOND);
     EffectivePatchContext ctx = new EffectivePatchContext("16.7", 1699000000L, 1700000000L);
     given(budgetTracker.canCollect()).willReturn(true);
+    given(patchVersionService.resolveEffectivePatchContext()).willReturn(Optional.of(ctx));
     given(summonerRepository.findMatchIdsPendingSummoners(props.getCollectBatchSize()))
         .willReturn(List.of(summoner));
-    given(patchVersionService.resolveEffectivePatchContext()).willReturn(Optional.of(ctx));
     given(riotApiPort.findMatchIdsBetween("p-dia", 1699000000L, 1700000000L, 10))
-        .willReturn(List.of("m1", "m2"));
+        .willReturn(List.of("m1"));
 
-    CollectMatchIdsRunner.BatchResult result = runner.runBatch();
+    runner.runBatch();
 
     verify(riotApiPort).findMatchIdsBetween("p-dia", 1699000000L, 1700000000L, 10);
     verify(riotApiPort, never()).findMatchIdsSince(any(), anyLong(), anyInt());
-    assertThat(result.matchIdsQueued()).isEqualTo(2);
+    verify(ingestMatchDetail).execute("m1", Tier.DIAMOND, "16.7");
   }
 
   @Test
-  @DisplayName("grace period 중: MatchQueue는 이전 패치(16.7)로 태깅된다")
-  void runBatch_inGracePeriod_enqueuedWithPreviousPatchTag() {
+  @DisplayName("이미 수집된 매치(existsById=true)는 ingest를 건너뛴다 (dedup)")
+  void runBatch_dedup_skipsAlreadyIngestedMatch() {
     Summoner summoner = summonerWithTier("p-dia", Tier.DIAMOND);
-    EffectivePatchContext ctx = new EffectivePatchContext("16.7", 1699000000L, 1700000000L);
     given(budgetTracker.canCollect()).willReturn(true);
+    given(patchVersionService.resolveEffectivePatchContext()).willReturn(Optional.of(normalCtx()));
     given(summonerRepository.findMatchIdsPendingSummoners(props.getCollectBatchSize()))
         .willReturn(List.of(summoner));
-    given(patchVersionService.resolveEffectivePatchContext()).willReturn(Optional.of(ctx));
-    given(riotApiPort.findMatchIdsBetween(any(), anyLong(), anyLong(), anyInt()))
-        .willReturn(List.of("m1"));
+    given(riotApiPort.findMatchIdsSince("p-dia", 1700000000L, 10))
+        .willReturn(List.of("m1", "m2"));
+    given(matchRepository.existsById("m1")).willReturn(true);
 
     runner.runBatch();
 
-    verify(matchQueueEnqueuer).enqueueAllIdempotent(any(), any(), eq("16.7"));
+    verify(ingestMatchDetail, never()).execute(eq("m1"), any(), any());
+    verify(ingestMatchDetail).execute("m2", Tier.DIAMOND, "15.23");
+    assertThat(registry.counter("pipeline.ingest.success").count()).isEqualTo(1.0);
   }
 
   @Test
-  @DisplayName("matchIds를 수집한 후 matchIdsCollectedAt을 갱신한다")
-  void runBatch_marksMatchIdsCollectedAfterCollection() {
-    Summoner summoner = summonerWithTier("p-1", Tier.EMERALD);
-    EffectivePatchContext ctx = new EffectivePatchContext("15.23", 1700000000L, null);
+  @DisplayName("개별 ingest 실패(옵션 A): metric 기록 후 skip하고 summoner는 collected 처리한다")
+  void runBatch_ingestFailure_skipsAndStillMarksCollected() {
+    Summoner summoner = summonerWithTier("p-dia", Tier.DIAMOND);
     given(budgetTracker.canCollect()).willReturn(true);
+    given(patchVersionService.resolveEffectivePatchContext()).willReturn(Optional.of(normalCtx()));
     given(summonerRepository.findMatchIdsPendingSummoners(props.getCollectBatchSize()))
         .willReturn(List.of(summoner));
-    given(patchVersionService.resolveEffectivePatchContext()).willReturn(Optional.of(ctx));
-    given(riotApiPort.findMatchIdsSince(eq("p-1"), anyLong(), anyInt()))
-        .willReturn(List.of("m1"));
+    given(riotApiPort.findMatchIdsSince("p-dia", 1700000000L, 10)).willReturn(List.of("m1"));
+    given(ingestMatchDetail.execute("m1", Tier.DIAMOND, "15.23"))
+        .willThrow(new RuntimeException("ingest boom"));
 
     runner.runBatch();
 
-    verify(summonerRepository).markMatchIdsCollected(eq("p-1"), any(OffsetDateTime.class));
-    verify(budgetTracker).recordCollectCall(1);
+    // 옵션 A: 실패해도 summoner는 collected 처리(재수집 시 dedup), failure metric 기록
+    verify(summonerRepository).markMatchIdsCollected(eq("p-dia"), any(OffsetDateTime.class));
+    assertThat(registry.counter("pipeline.ingest.failure", "reason", "other").count())
+        .isEqualTo(1.0);
+    assertThat(registry.counter("pipeline.ingest.success").count()).isEqualTo(0.0);
   }
 
   @Test
-  @DisplayName("패치 정보가 없으면 findRecentMatchIds를 사용")
-  void runBatch_whenNoPatchContext_usesRecentMatchIds() {
-    Summoner summoner = summonerWithTier("p-gold", Tier.GOLD);
+  @DisplayName("수집(matchIds 조회) 실패 시 summoner는 미수집·예산 미차감으로 남는다")
+  void runBatch_collectionError_doesNotMarkCollectedNorChargeBudget() {
+    Summoner summoner = summonerWithTier("p-bad", Tier.DIAMOND);
     given(budgetTracker.canCollect()).willReturn(true);
+    given(patchVersionService.resolveEffectivePatchContext()).willReturn(Optional.of(normalCtx()));
     given(summonerRepository.findMatchIdsPendingSummoners(props.getCollectBatchSize()))
         .willReturn(List.of(summoner));
-    given(patchVersionService.resolveEffectivePatchContext()).willReturn(Optional.empty());
-    given(riotApiPort.findRecentMatchIds("p-gold", 10)).willReturn(List.of("m1"));
-
-    runner.runBatch();
-
-    verify(riotApiPort).findRecentMatchIds("p-gold", 10);
-    verify(riotApiPort, never()).findMatchIdsSince(any(), anyLong(), anyInt());
-    verify(riotApiPort, never()).findMatchIdsBetween(any(), anyLong(), anyLong(), anyInt());
-  }
-
-  @Test
-  @DisplayName("matchIds 수집 중 개별 summoner 오류는 건너뛰고 계속 진행")
-  void runBatch_skipsSummonerOnIndividualError() {
-    Summoner bad = summonerWithTier("p-bad", Tier.GOLD);
-    Summoner good = summonerWithTier("p-good", Tier.GOLD);
-    EffectivePatchContext ctx = new EffectivePatchContext("15.23", 1700000000L, null);
-    given(budgetTracker.canCollect()).willReturn(true);
-    given(summonerRepository.findMatchIdsPendingSummoners(props.getCollectBatchSize()))
-        .willReturn(List.of(bad, good));
-    given(patchVersionService.resolveEffectivePatchContext()).willReturn(Optional.of(ctx));
     given(riotApiPort.findMatchIdsSince(eq("p-bad"), anyLong(), anyInt()))
-        .willThrow(new RuntimeException("API error"));
-    given(riotApiPort.findMatchIdsSince(eq("p-good"), anyLong(), anyInt()))
-        .willReturn(List.of("m1"));
+        .willThrow(new RuntimeException("collect error"));
 
-    CollectMatchIdsRunner.BatchResult result = runner.runBatch();
+    runner.runBatch();
 
-    verify(summonerRepository).markMatchIdsCollected(eq("p-good"), any());
     verify(summonerRepository, never()).markMatchIdsCollected(eq("p-bad"), any());
-    // 실패한 summoner는 apiCalls·예산 모두 미차감
-    assertThat(result.apiCalls()).isEqualTo(1);
-  }
-
-  @Test
-  @DisplayName("개별 summoner 수집 실패 시 예산을 차감하지 않는다")
-  void runBatch_onIndividualError_doesNotChargeBudget() {
-    Summoner bad = summonerWithTier("p-bad", Tier.GOLD);
-    EffectivePatchContext ctx = new EffectivePatchContext("15.23", 1700000000L, null);
-    given(budgetTracker.canCollect()).willReturn(true);
-    given(summonerRepository.findMatchIdsPendingSummoners(props.getCollectBatchSize()))
-        .willReturn(List.of(bad));
-    given(patchVersionService.resolveEffectivePatchContext()).willReturn(Optional.of(ctx));
-    given(riotApiPort.findMatchIdsSince(eq("p-bad"), anyLong(), anyInt()))
-        .willThrow(new RuntimeException("network error"));
-
-    runner.runBatch();
-
     verify(budgetTracker, never()).recordCollectCall(anyInt());
   }
 
   @Test
   @DisplayName("429 예외는 전파된다")
   void runBatch_propagatesRateLimitedException() {
-    Summoner summoner = summonerWithTier("p-1", Tier.GOLD);
-    EffectivePatchContext ctx = new EffectivePatchContext("15.23", 1700000000L, null);
+    Summoner summoner = summonerWithTier("p-1", Tier.DIAMOND);
     given(budgetTracker.canCollect()).willReturn(true);
+    given(patchVersionService.resolveEffectivePatchContext()).willReturn(Optional.of(normalCtx()));
     given(summonerRepository.findMatchIdsPendingSummoners(props.getCollectBatchSize()))
         .willReturn(List.of(summoner));
-    given(patchVersionService.resolveEffectivePatchContext()).willReturn(Optional.of(ctx));
     given(riotApiPort.findMatchIdsSince(any(), anyLong(), anyInt()))
         .willThrow(new RiotRateLimitedException("429"));
 
@@ -284,19 +271,18 @@ class CollectMatchIdsRunnerTest {
   }
 
   @Test
-  @DisplayName("matchIds가 비어있으면 enqueue 하지 않지만 collectedAt은 갱신")
-  void runBatch_whenNoMatchIds_doesNotEnqueueButMarksCollected() {
-    Summoner summoner = summonerWithTier("p-empty", Tier.GOLD);
-    EffectivePatchContext ctx = new EffectivePatchContext("15.23", 1700000000L, null);
+  @DisplayName("matchIds가 비어있으면 ingest하지 않지만 collectedAt은 갱신한다")
+  void runBatch_whenNoMatchIds_doesNotIngestButMarksCollected() {
+    Summoner summoner = summonerWithTier("p-empty", Tier.DIAMOND);
     given(budgetTracker.canCollect()).willReturn(true);
+    given(patchVersionService.resolveEffectivePatchContext()).willReturn(Optional.of(normalCtx()));
     given(summonerRepository.findMatchIdsPendingSummoners(props.getCollectBatchSize()))
         .willReturn(List.of(summoner));
-    given(patchVersionService.resolveEffectivePatchContext()).willReturn(Optional.of(ctx));
     given(riotApiPort.findMatchIdsSince(any(), anyLong(), anyInt())).willReturn(List.of());
 
     runner.runBatch();
 
-    verify(matchQueueEnqueuer, never()).enqueueAllIdempotent(any(), any(), any());
+    verify(ingestMatchDetail, never()).execute(any(), any(), any());
     verify(summonerRepository).markMatchIdsCollected(eq("p-empty"), any(OffsetDateTime.class));
   }
 

--- a/src/test/java/com/bestduo_BE/pipeline/application/PipelineMetricsTest.java
+++ b/src/test/java/com/bestduo_BE/pipeline/application/PipelineMetricsTest.java
@@ -112,27 +112,31 @@ class PipelineMetricsTest {
   }
 
   @Test
-  @DisplayName("recordIngestOutcome는 success/failure 매치 수만큼 각 counter를 증가시킨다")
-  void recordIngestOutcome_incrementsSuccessAndFailureCounters() {
+  @DisplayName("recordIngestSuccess 호출 시 pipeline.ingest.success counter가 증가한다")
+  void recordIngestSuccess_incrementsCounter() {
     SimpleMeterRegistry registry = new SimpleMeterRegistry();
     PipelineMetrics metrics = new PipelineMetrics(registry);
 
-    metrics.recordIngestOutcome(7, 2);
+    metrics.recordIngestSuccess();
+    metrics.recordIngestSuccess();
 
-    assertThat(registry.counter("pipeline.ingest.success").count()).isEqualTo(7.0);
-    assertThat(registry.counter("pipeline.ingest.failure").count()).isEqualTo(2.0);
+    assertThat(registry.counter("pipeline.ingest.success").count()).isEqualTo(2.0);
   }
 
   @Test
-  @DisplayName("recordIngestOutcome에 0을 전달하면 해당 counter를 생성/증가시키지 않는다")
-  void recordIngestOutcome_zeroDoesNotIncrement() {
+  @DisplayName("recordIngestFailure는 reason 태그와 함께 pipeline.ingest.failure counter를 증가시킨다")
+  void recordIngestFailure_incrementsCounterWithReasonTag() {
     SimpleMeterRegistry registry = new SimpleMeterRegistry();
     PipelineMetrics metrics = new PipelineMetrics(registry);
 
-    metrics.recordIngestOutcome(0, 0);
+    metrics.recordIngestFailure("timeout");
+    metrics.recordIngestFailure("timeout");
+    metrics.recordIngestFailure("auth");
 
-    assertThat(registry.find("pipeline.ingest.success").counter()).isNull();
-    assertThat(registry.find("pipeline.ingest.failure").counter()).isNull();
+    assertThat(registry.counter("pipeline.ingest.failure", "reason", "timeout").count())
+        .isEqualTo(2.0);
+    assertThat(registry.counter("pipeline.ingest.failure", "reason", "auth").count())
+        .isEqualTo(1.0);
   }
 
   @Test

--- a/src/test/java/com/bestduo_BE/pipeline/application/RegionalPipelineRunnerTest.java
+++ b/src/test/java/com/bestduo_BE/pipeline/application/RegionalPipelineRunnerTest.java
@@ -2,22 +2,12 @@ package com.bestduo_BE.pipeline.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
-import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
-import com.bestduo_BE.common.application.PatchVersionService;
-import com.bestduo_BE.common.domain.model.EffectivePatchContext;
-import com.bestduo_BE.common.domain.model.Tier;
 import com.bestduo_BE.common.infra.riot.exception.RiotRateLimitedException;
 import com.bestduo_BE.config.PipelineProperties;
-import com.bestduo_BE.ingest.application.MatchIngestRunner;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
-import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -29,8 +19,6 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class RegionalPipelineRunnerTest {
 
   @Mock private CollectMatchIdsRunner collectMatchIdsRunner;
-  @Mock private MatchIngestRunner matchIngestRunner;
-  @Mock private PatchVersionService patchVersionService;
 
   private PipelineProperties props;
   private RegionalPipelineRunner runner;
@@ -38,89 +26,25 @@ class RegionalPipelineRunnerTest {
   @BeforeEach
   void setUp() {
     props = new PipelineProperties();
-    props.setIngestBatchSize(10);
     props.setPollingIntervalMs(100);
     PipelineMetrics pipelineMetrics = new PipelineMetrics(new SimpleMeterRegistry());
-    runner = new RegionalPipelineRunner(collectMatchIdsRunner, matchIngestRunner,
-        patchVersionService, props, pipelineMetrics);
+    runner = new RegionalPipelineRunner(collectMatchIdsRunner, props, pipelineMetrics);
   }
 
   @Test
-  @DisplayName("Stage 2 대기 중이면 runBatch만 호출된다")
-  void executeTick_whenStage2HasPending_runsOnlyStage2() throws InterruptedException {
+  @DisplayName("수집 대기 summoner가 있으면 runBatch(collect+ingest)를 호출한다")
+  void executeTick_whenHasPending_runsBatch() throws InterruptedException {
     given(collectMatchIdsRunner.hasPending()).willReturn(true);
 
     runner.executeTick();
 
     verify(collectMatchIdsRunner).runBatch();
-    verify(matchIngestRunner, never()).executeWithPriority(anyInt(), any(), any());
   }
 
   @Test
-  @DisplayName("유예 기간이 아닐 때 Stage 3는 최신 패치(유효 패치 == 최신 패치)로 우선순위를 결정한다")
-  void executeTick_whenNotInGracePeriod_runsStage3WithCurrentPatch() throws InterruptedException {
+  @DisplayName("수집 대기 summoner가 없으면 폴링 간격만큼 대기한다")
+  void executeTick_whenNoPending_sleepsPollingInterval() throws InterruptedException {
     given(collectMatchIdsRunner.hasPending()).willReturn(false);
-    given(patchVersionService.resolveEffectivePatchContext())
-        .willReturn(Optional.of(new EffectivePatchContext("15.23", 1000L, null)));
-    given(matchIngestRunner.executeWithPriority(anyInt(), any(), any()))
-        .willReturn(ingestResult(1));
-
-    runner.executeTick();
-
-    verify(matchIngestRunner).executeWithPriority(props.getIngestBatchSize(), null, "15.23");
-  }
-
-  @Test
-  @DisplayName("유예 기간 중일 때 Stage 3는 직전 패치(유효 패치 == 직전 패치)로 우선순위를 결정한다")
-  void executeTick_whenInGracePeriod_runsStage3WithPreviousPatch() throws InterruptedException {
-    given(collectMatchIdsRunner.hasPending()).willReturn(false);
-    // 유예 기간: endTimeEpochSeconds != null → 유효 패치 = "15.22" (직전 패치)
-    given(patchVersionService.resolveEffectivePatchContext())
-        .willReturn(Optional.of(new EffectivePatchContext("15.22", 900L, 1000L)));
-    given(matchIngestRunner.executeWithPriority(anyInt(), any(), any()))
-        .willReturn(ingestResult(1));
-
-    runner.executeTick();
-
-    verify(matchIngestRunner).executeWithPriority(props.getIngestBatchSize(), null, "15.22");
-  }
-
-  @Test
-  @DisplayName("패치 정보가 없으면 null 패치로 Stage 3를 호출한다")
-  void executeTick_whenNoPatch_callsStage3WithNullPatch() throws InterruptedException {
-    given(collectMatchIdsRunner.hasPending()).willReturn(false);
-    given(patchVersionService.resolveEffectivePatchContext()).willReturn(Optional.empty());
-    given(matchIngestRunner.executeWithPriority(anyInt(), any(), any()))
-        .willReturn(ingestResult(1));
-
-    runner.executeTick();
-
-    verify(matchIngestRunner).executeWithPriority(props.getIngestBatchSize(), null, null);
-  }
-
-  @Test
-  @DisplayName("stage3PriorityTier가 EMERALD이면 EMERALD 티어로 Stage 3를 호출한다")
-  void executeTick_whenStage3PriorityTierIsEmerald_callsStage3WithEmeraldTier()
-      throws InterruptedException {
-    props.setStage3PriorityTier(Tier.EMERALD);
-    given(collectMatchIdsRunner.hasPending()).willReturn(false);
-    given(patchVersionService.resolveEffectivePatchContext())
-        .willReturn(Optional.of(new EffectivePatchContext("15.23", 1000L, null)));
-    given(matchIngestRunner.executeWithPriority(anyInt(), any(), any()))
-        .willReturn(ingestResult(1));
-
-    runner.executeTick();
-
-    verify(matchIngestRunner).executeWithPriority(props.getIngestBatchSize(), Tier.EMERALD, "15.23");
-  }
-
-  @Test
-  @DisplayName("Stage 3에서 처리된 항목이 없으면 폴링 간격만큼 대기한다")
-  void executeTick_whenNothingInQueue_sleepsPollingInterval() throws InterruptedException {
-    given(collectMatchIdsRunner.hasPending()).willReturn(false);
-    given(patchVersionService.resolveEffectivePatchContext()).willReturn(Optional.empty());
-    given(matchIngestRunner.executeWithPriority(anyInt(), any(), any()))
-        .willReturn(ingestResult(0));
 
     long start = System.currentTimeMillis();
     runner.executeTick();
@@ -131,96 +55,12 @@ class RegionalPipelineRunnerTest {
   }
 
   @Test
-  @DisplayName("Stage 3에서 429 발생 시 속도 제한 예외가 전파된다")
-  void executeTick_whenStage3Throws429_propagates() {
-    given(collectMatchIdsRunner.hasPending()).willReturn(false);
-    given(patchVersionService.resolveEffectivePatchContext()).willReturn(Optional.empty());
-    given(matchIngestRunner.executeWithPriority(anyInt(), any(), any()))
-        .willThrow(new RiotRateLimitedException("429"));
+  @DisplayName("runBatch에서 429 발생 시 속도 제한 예외가 전파된다")
+  void executeTick_whenRunBatchThrows429_propagates() {
+    given(collectMatchIdsRunner.hasPending()).willReturn(true);
+    given(collectMatchIdsRunner.runBatch()).willThrow(new RiotRateLimitedException("429"));
 
     assertThatThrownBy(() -> runner.executeTick())
         .isInstanceOf(RiotRateLimitedException.class);
-  }
-
-  @Test
-  @DisplayName("priority 티어가 비면 다음 티어로 순회하다가 잡힌 시점에 tick 종료")
-  void executeTick_whenPriorityTierEmpty_fallsBackToNextTier() throws InterruptedException {
-    props.setStage3PriorityTier(Tier.EMERALD);
-    given(collectMatchIdsRunner.hasPending()).willReturn(false);
-    given(patchVersionService.resolveEffectivePatchContext())
-        .willReturn(Optional.of(new EffectivePatchContext("15.23", 1000L, null)));
-    // EMERALD: 0건, CHALLENGER: 1건 — 그 뒤 티어는 호출되면 안 됨
-    given(matchIngestRunner.executeWithPriority(anyInt(), eq(Tier.EMERALD), any()))
-        .willReturn(ingestResult(0));
-    given(matchIngestRunner.executeWithPriority(anyInt(), eq(Tier.CHALLENGER), any()))
-        .willReturn(ingestResult(1));
-
-    runner.executeTick();
-
-    verify(matchIngestRunner).executeWithPriority(props.getIngestBatchSize(), Tier.EMERALD, "15.23");
-    verify(matchIngestRunner).executeWithPriority(props.getIngestBatchSize(), Tier.CHALLENGER, "15.23");
-    verify(matchIngestRunner, never())
-        .executeWithPriority(anyInt(), eq(Tier.GRANDMASTER), any());
-    verify(matchIngestRunner, never())
-        .executeWithPriority(anyInt(), eq(Tier.MASTER), any());
-  }
-
-  @Test
-  @DisplayName("priority 티어 지정 시 모든 티어가 비면 폴링 간격만큼 대기한다")
-  void executeTick_whenPriorityTierSetAndAllTiersEmpty_sleepsPollingInterval()
-      throws InterruptedException {
-    props.setStage3PriorityTier(Tier.EMERALD);
-    given(collectMatchIdsRunner.hasPending()).willReturn(false);
-    given(patchVersionService.resolveEffectivePatchContext()).willReturn(Optional.empty());
-    given(matchIngestRunner.executeWithPriority(anyInt(), any(), any()))
-        .willReturn(ingestResult(0));
-
-    long start = System.currentTimeMillis();
-    runner.executeTick();
-    long elapsed = System.currentTimeMillis() - start;
-
-    // CHALLENGER ~ EMERALD까지 5개 티어 시도 후 sleep
-    verify(matchIngestRunner, times(5)).executeWithPriority(anyInt(), any(Tier.class), any());
-    assertThat(elapsed).isGreaterThanOrEqualTo(80L);
-  }
-
-  @Test
-  @DisplayName("PLATINUM 이하 티어는 round-robin 순회에서 제외된다")
-  void executeTick_whenPriorityTierSetAndAllTiersEmpty_skipsPlatinumAndBelow()
-      throws InterruptedException {
-    props.setStage3PriorityTier(Tier.EMERALD);
-    given(collectMatchIdsRunner.hasPending()).willReturn(false);
-    given(patchVersionService.resolveEffectivePatchContext()).willReturn(Optional.empty());
-    given(matchIngestRunner.executeWithPriority(anyInt(), any(), any()))
-        .willReturn(ingestResult(0));
-
-    runner.executeTick();
-
-    verify(matchIngestRunner, never()).executeWithPriority(anyInt(), eq(Tier.PLATINUM), any());
-    verify(matchIngestRunner, never()).executeWithPriority(anyInt(), eq(Tier.GOLD), any());
-    verify(matchIngestRunner, never()).executeWithPriority(anyInt(), eq(Tier.SILVER), any());
-    verify(matchIngestRunner, never()).executeWithPriority(anyInt(), eq(Tier.BRONZE), any());
-    verify(matchIngestRunner, never()).executeWithPriority(anyInt(), eq(Tier.IRON), any());
-  }
-
-  @Test
-  @DisplayName("stage3PriorityTier가 ALL_TIERS이면 단일 호출(레거시)로 null tier를 사용한다")
-  void executeTick_whenStage3PriorityTierIsAllTiers_singleCallWithNull()
-      throws InterruptedException {
-    props.setStage3PriorityTier(Tier.ALL_TIERS);
-    given(collectMatchIdsRunner.hasPending()).willReturn(false);
-    given(patchVersionService.resolveEffectivePatchContext())
-        .willReturn(Optional.of(new EffectivePatchContext("15.23", 1000L, null)));
-    given(matchIngestRunner.executeWithPriority(anyInt(), any(), any()))
-        .willReturn(ingestResult(1));
-
-    runner.executeTick();
-
-    verify(matchIngestRunner, times(1))
-        .executeWithPriority(props.getIngestBatchSize(), null, "15.23");
-  }
-
-  private MatchIngestRunner.Result ingestResult(int picked) {
-    return new MatchIngestRunner.Result(0, picked, picked, picked, 0, 0);
   }
 }


### PR DESCRIPTION
## 개요

`match_queue` 영속 큐 제거 → **inline 파이프라인 전환의 Phase B** (핵심 실행 경로 변경). [ADR-008](https://github.com/NamMinwu/BestDuo_BE/blob/main/docs/adr_remove_match_queue_inline_pipeline.md) 기준.

Stage 2(수집)와 Stage 3(ingest)를 **summoner 단위로 융합** — matchIds를 가져와 `match.existsById` dedup 후 그 자리에서 `IngestMatchDetail`로 ingest. 영속 큐 enqueue 경로 제거.

## 왜

- 단일 키·단일 프로세스에선 큐의 작업 분배가 불필요(per-key 50req/s는 단일 프로세스로 포화). dedup·재시작·관측은 `match` 테이블·`summoner` 플래그·emit 메트릭으로 대체.
- Phase A 메트릭이 드러낸 **Stage 3 starvation**(collect 우선순위로 ingest가 버스티) 해소 → 연속 ingest.

## 변경 사항

### 핵심 (`7118cb0`)
- **`CollectMatchIdsRunner`**: `enqueue` → `existsById` dedup 후 inline `IngestMatchDetail.execute`
  - **조건①**: patch context 없으면 수집 skip (재시작 시 재수집 재현성)
  - **조건②**: 모든 매치 ingest 후 `markMatchIdsCollected` (중간 크래시 통째 재처리)
  - **실패 = 옵션 A**: `recordIngestFailure(reason)` + skip (재수집·10-참가자 redundancy가 재시도 대신). reason 분류(auth/server_5xx/timeout/not_found/client_4xx)
- **`RegionalPipelineRunner`**: Stage 3·tier round-robin 제거 → collect+ingest 단일 단계
- **`SummonerJpaRepository`**: `findMatchIdsPendingSummoners` tier 순 정렬(round-robin 우선순위 대체)
- **`PipelineMetrics`**: `recordIngestOutcome` → 매치 단위 `recordIngestSuccess()`/`recordIngestFailure(reason)`

### 코드리뷰 반영 (`a4aa02d`)
- `classifyIngestFailure` 분류 테스트 7개 추가(auth/5xx/timeout/not_found/client_4xx + RiotApiException unwrap) — NFR-4 auth 알람 검증 갭 해소

## 테스트
- CollectMatchIdsRunnerTest **22** · RegionalPipelineRunnerTest 3 · PipelineMetricsTest 9 — green
- `./gradlew build` (컴파일 + 전체 테스트 + bootJar) green

## 배포 후 검증 포인트
- `pipeline_ingest_success`가 **연속 증가**로 전환(Stage 3 starvation 해소)
- `pipeline_match_queue_size`가 **더는 증가 안 함**(enqueue 경로 제거)

## 후속 (이 PR 범위 밖)
- **Phase C**: dead 큐 클래스(`MatchQueueEnqueuer`/큐 기반 `MatchIngestRunner`/dispatcher) 제거 + `V7__drop_match_queue.sql`
- `stage3PriorityTier` config 정리, auth-halt 동작(현재는 metric 탐지만)
